### PR TITLE
Assign jobs for FINISHED agents immediately after FINISHED heartbeat, if data is already saved

### DIFF
--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
@@ -2,12 +2,14 @@ package org.cqfn.save.backend.controllers
 
 import org.cqfn.save.agent.TestExecutionDto
 import org.cqfn.save.backend.service.TestExecutionService
+import org.cqfn.save.domain.TestResultStatus
 import org.cqfn.save.test.TestDto
 import org.springframework.dao.DataAccessException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -35,6 +37,17 @@ class TestExecutionController(private val testExecutionService: TestExecutionSer
         return testExecutionService.getTestExecutions(executionId, page, size)
             .map { it.toDto() }
     }
+
+    /**
+     * @param agentContainerId id of agent's container
+     * @param status status for test executions
+     * @return a list of test executions
+     */
+    @GetMapping("/testExecutions/agent/{agentId}/{status}")
+    fun getTestExecutionsForAgentWithStatus(@PathVariable("agentId") agentContainerId: String,
+                                            @PathVariable status: TestResultStatus
+    ) = testExecutionService.getTestExecutions(agentContainerId, status)
+        .map { it.toDto() }
 
     /**
      * Returns number of TestExecutions with this [executionId]

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/TestExecutionRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/TestExecutionRepository.kt
@@ -37,6 +37,15 @@ interface TestExecutionRepository : BaseEntityRepository<TestExecution> {
     fun findByExecutionId(executionId: Long, pageable: Pageable): List<TestExecution>
 
     /**
+     * Returns test executions for agent [agentContainerId] and status [status]
+     *
+     * @param agentContainerId
+     * @param status
+     * @return a list of test executions
+     */
+    fun findByAgentContainerIdAndStatus(agentContainerId: String, status: TestResultStatus): List<TestExecution>
+
+    /**
      * Returns a TestExecution matched by a set of fields
      *
      * @param executionId if of execution

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
@@ -44,6 +44,16 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
         .findByExecutionId(executionId, PageRequest.of(page, pageSize))
 
     /**
+     * Get test executions by [agentContainerId] and [status]
+     *
+     * @param agentContainerId
+     * @param status
+     * @return a list of test executions
+     */
+    internal fun getTestExecutions(agentContainerId: String, status: TestResultStatus) = testExecutionRepository
+        .findByAgentContainerIdAndStatus(agentContainerId, status)
+
+    /**
      * Returns number of TestExecutions with this [executionId]
      *
      * @param executionId an ID of Execution to group TestExecutions

--- a/save-deploy/README.md
+++ b/save-deploy/README.md
@@ -75,4 +75,5 @@ manually placed in `save-orchestrator/build/resources/main` before build, and it
 # Server configuration
 ## Nginx
 Nginx is used as a reverse proxy, which allows access from external network to backend and some other services.
-File `save-deploy/reverse-proxy.conf` should be copied to `/etc/nginx/sites-available`.
+File `save-deploy/reverse-proxy.conf` should be copied to `/etc/nginx/sites-available`. Symlink should be created:
+`sudo ln -s /etc/nginx/sites-available/reverse-proxy.conf /etc/nginx/sites-enabled/` (or to `/etc/nginx/conf.d` on some distributions).

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -62,10 +62,11 @@ class HeartbeatController(private val agentService: AgentService,
                     AgentState.STARTING -> agentService.getNewTestsIds(heartbeat.agentId)
                     // if agent idles, we try to assign work, but also check if it should be terminated
                     AgentState.IDLE -> handleVacantAgent(heartbeat.agentId)
-                    AgentState.FINISHED -> agentService.checkSavedData().flatMap { isSavingSuccessful ->
+                    AgentState.FINISHED -> agentService.checkSavedData(heartbeat.agentId).flatMap { isSavingSuccessful ->
                         if (isSavingSuccessful) {
                             handleVacantAgent(heartbeat.agentId)
                         } else {
+                            // todo: if failure is repeated multiple times, re-assign missing tests once more
                             Mono.just(WaitResponse)
                         }
                     }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -3,7 +3,9 @@ package org.cqfn.save.orchestrator.service
 import org.cqfn.save.agent.AgentState
 import org.cqfn.save.agent.HeartbeatResponse
 import org.cqfn.save.agent.NewJobResponse
+import org.cqfn.save.agent.TestExecutionDto
 import org.cqfn.save.agent.WaitResponse
+import org.cqfn.save.domain.TestResultStatus
 import org.cqfn.save.entities.Agent
 import org.cqfn.save.entities.AgentStatus
 import org.cqfn.save.entities.AgentStatusDto
@@ -105,9 +107,16 @@ class AgentService {
                 .toBodilessEntity()
 
     /**
-     * @return nothing for now Fixme
+     * Check that no TestExecution for agent [agentId] have status READY
+     *
+     * @param agentId agent for which data is checked
+     * @return true if all executions have status other than `READY`
      */
-    fun checkSavedData() = Mono.just(true)
+    fun checkSavedData(agentId: String): Mono<Boolean> = webClientBackend.get()
+        .uri("/testExecutions/agent/$agentId/${TestResultStatus.READY}")
+        .retrieve()
+        .bodyToMono<List<TestExecutionDto>>()
+        .map { it.isEmpty() }
 
     /**
      * If an error occurs, should try to resend tests


### PR DESCRIPTION
### What's done:
* Check if TestExecutions for agent are updated
* Assign jobs for FINISHED agents immediately after FINISHED heartbeat
* Added notes on nginx deployment

Closes #309