### PR TITLE
Import individual font-awesome icons to reduce bundle size

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
@@ -309,10 +309,6 @@ fun main() {
 
     kotlinext.js.require("../scss/save-frontend.scss")  // this is needed for webpack to include resource
     kotlinext.js.require("bootstrap")  // this is needed for webpack to include bootstrap
-    library.add(
-        fas, faUser, faCogs, faSignOutAlt, faAngleUp, faCheck, faExclamationTriangle, faTimesCircle, faQuestionCircle,
-        faUpload, faFile, faCheckCircle
-    )
     ReactModal.setAppElement(document.getElementById("wrapper") as HTMLElement)  // required for accessibility in react-modal
 
     render(document.getElementById("wrapper") as HTMLElement) {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/TopBar.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/TopBar.kt
@@ -44,8 +44,7 @@ external interface TopBarProps : PropsWithChildren {
 
 private fun RBuilder.dropdownEntry(faIcon: dynamic, text: String, handler: RDOMBuilder<BUTTON>.() -> Unit = { }) =
         button(type = ButtonType.button, classes = "btn btn-no-outline dropdown-item rounded-0 shadow-none") {
-            fontAwesomeIcon {
-                attrs.icon = faIcon
+            fontAwesomeIcon(icon = faIcon) {
                 attrs.className = "fas fa-sm fa-fw mr-2 text-gray-400"
             }
             +text
@@ -158,9 +157,7 @@ fun topBar() = fc<TopBarProps> { props ->
                         width = 6.rem
                     }.unsafeCast<Width>()
                     attrs.href = "https://github.com/saveourtool/save-cloud"
-                    i("fa fa-user opacity-6 text-dark me-1") {
-                        attrs["aria-hidden"] = "true"
-                    }
+                    fontAwesomeIcon(icon = faUser, classes = "fa opacity-6 text-dark me-1")
                     +"About"
                 }
             }
@@ -184,8 +181,7 @@ fun topBar() = fc<TopBarProps> { props ->
                             span("mr-2 d-none d-lg-inline text-gray-600") {
                                 +(props.userInfo?.name ?: "")
                             }
-                            fontAwesomeIcon {
-                                attrs.icon = "user"
+                            fontAwesomeIcon(icon = faUser) {
                                 attrs.className = "fas fa-lg fa-fw mr-2 text-gray-400"
                             }
                         }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/Card.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/Card.kt
@@ -6,6 +6,7 @@
 
 package com.saveourtool.save.frontend.components.basic
 
+import com.saveourtool.save.frontend.externals.fontawesome.FontAwesomeIconModule
 import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
 
 import react.PropsWithChildren
@@ -22,7 +23,7 @@ external interface CardProps : PropsWithChildren {
     /**
      * font-awesome class to be used as an icon
      */
-    var faIcon: String
+    var faIcon: FontAwesomeIconModule
 }
 
 /**

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FileUploader.kt
@@ -114,9 +114,7 @@ fun fileUploader(
                 props.files.map { fileInfo ->
                     li(classes = "list-group-item") {
                         button(classes = "btn") {
-                            fontAwesomeIcon {
-                                attrs.icon = faTimesCircle
-                            }
+                            fontAwesomeIcon(icon = faTimesCircle)
                             attrs.onClickFunction = {
                                 onFileRemove(fileInfo)
                             }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ScrollToTopButton.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ScrollToTopButton.kt
@@ -4,6 +4,7 @@
 
 package com.saveourtool.save.frontend.components.basic
 
+import com.saveourtool.save.frontend.externals.fontawesome.faAngleUp
 import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
 
 import org.w3c.dom.SMOOTH
@@ -39,7 +40,7 @@ fun scrollToTopButton() = fc<PropsWithChildren> {
             attrs.onClickFunction = {
                 window.scrollTo(ScrollToOptions(top = 0.0, behavior = ScrollBehavior.SMOOTH))
             }
-            fontAwesomeIcon(icon = "angle-up")
+            fontAwesomeIcon(icon = faAngleUp)
         }
     }
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettingsview/UserSettingsView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettingsview/UserSettingsView.kt
@@ -187,8 +187,7 @@ abstract class UserSettingsView : AbstractView<UserSettingsProps, UserSettingsVi
                                         div("menu") {
                                             div("mt-2") {
                                                 a(classes = "item", href = "#/${props.userName}/settings/profile") {
-                                                    fontAwesomeIcon {
-                                                        attrs.icon = faUser
+                                                    fontAwesomeIcon(icon = faUser) {
                                                         attrs.className = "fas fa-sm fa-fw mr-2 text-gray-600"
                                                     }
                                                     +"Profile"
@@ -196,8 +195,7 @@ abstract class UserSettingsView : AbstractView<UserSettingsProps, UserSettingsVi
                                             }
                                             div("mt-2") {
                                                 a(classes = "item", href = "#/${props.userName}/settings/email") {
-                                                    fontAwesomeIcon {
-                                                        attrs.icon = faEnvelope
+                                                    fontAwesomeIcon(icon = faEnvelope) {
                                                         attrs.className = "fas fa-sm fa-fw mr-2 text-gray-600"
                                                     }
                                                     +"Email management"
@@ -205,8 +203,7 @@ abstract class UserSettingsView : AbstractView<UserSettingsProps, UserSettingsVi
                                             }
                                             div("mt-2") {
                                                 a(classes = "item", href = "#/${props.userName}/settings/organizations") {
-                                                    fontAwesomeIcon {
-                                                        attrs.icon = faCity
+                                                    fontAwesomeIcon(icon = faCity) {
                                                         attrs.className = "fas fa-sm fa-fw mr-2 text-gray-600"
                                                     }
                                                     +"Organizations"
@@ -223,8 +220,7 @@ abstract class UserSettingsView : AbstractView<UserSettingsProps, UserSettingsVi
                                         div("menu") {
                                             div("mt-2") {
                                                 a(classes = "item", href = "#/${props.userName}/settings/token") {
-                                                    fontAwesomeIcon {
-                                                        attrs.icon = faKey
+                                                    fontAwesomeIcon(icon = faKey) {
                                                         attrs.className = "fas fa-sm fa-fw mr-2 text-gray-600"
                                                     }
                                                     +"Personal access tokens"

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/BrandIcons.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/BrandIcons.kt
@@ -6,4 +6,4 @@ package com.saveourtool.save.frontend.externals.fontawesome
 
 @JsModule("@fortawesome/free-brands-svg-icons/faGithub")
 @JsNonModule
-external val faGithub: dynamic
+external val faGithub: FontAwesomeIconModule

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/BrandIcons.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/BrandIcons.kt
@@ -2,9 +2,8 @@
  * External declarations of icons from fontawesome-solid
  */
 
-@file:JsModule("@fortawesome/free-brands-svg-icons")
-@file:JsNonModule
-
 package com.saveourtool.save.frontend.externals.fontawesome
 
+@JsModule("@fortawesome/free-brands-svg-icons/faGithub")
+@JsNonModule
 external val faGithub: dynamic

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/FontAwesomeIconBuilders.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/FontAwesomeIconBuilders.kt
@@ -1,8 +1,8 @@
-@file:Suppress("FILE_NAME_MATCH_CLASS")
-
 /**
  * kotlin-react builders for FontAwesomeIcon components
  */
+
+@file:Suppress("FILE_NAME_MATCH_CLASS")
 
 package com.saveourtool.save.frontend.externals.fontawesome
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/FontAwesomeIconBuilders.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/FontAwesomeIconBuilders.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
 /**
  * kotlin-react builders for FontAwesomeIcon components
  */
@@ -12,13 +14,25 @@ import react.react
 import kotlinx.js.jso
 
 /**
+ * A small wrapper for font awesome icons imported from individual modules.
+ * See [faUser.d.ts](https://unpkg.com/browse/@fortawesome/free-solid-svg-icons@5.11.2/faUser.d.ts) as an example.
+ * We only need [definition] field for using those icons, other fields could be added if needed.
+ */
+interface FontAwesomeIconModule {
+    /**
+     * Definition of FA icon ([IconDefinition] in terms of `@fortawesome/fontawesome-common-types`)
+     */
+    val definition: dynamic
+}
+
+/**
  * @param icon icon. Can be an object, string or array.
  * @param classes element's classes
  * @param handler handler to set up a component
  * @return ReactElement
  */
 fun RBuilder.fontAwesomeIcon(
-    icon: dynamic,
+    icon: FontAwesomeIconModule,
     classes: String = "",
     handler: RHandler<FontAwesomeIconProps> = {},
 ) = child(FontAwesomeIcon::class) {
@@ -35,7 +49,7 @@ fun RBuilder.fontAwesomeIcon(
  * @param handler
  */
 fun ChildrenBuilder.fontAwesomeIcon(
-    icon: dynamic,
+    icon: FontAwesomeIconModule,
     classes: String = "",
     handler: ChildrenBuilder.(props: FontAwesomeIconProps) -> Unit = {},
 ): Unit = child(FontAwesomeIcon::class.react, props = jso {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/FontAwesomeIconBuilders.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/FontAwesomeIconBuilders.kt
@@ -22,19 +22,9 @@ fun RBuilder.fontAwesomeIcon(
     classes: String = "",
     handler: RHandler<FontAwesomeIconProps> = {},
 ) = child(FontAwesomeIcon::class) {
-    attrs.icon = icon
+    attrs.icon = icon.definition
     attrs.className = classes
     handler(this)
-}
-
-/**
- * @param handler handler to set up a component
- * @return ReactElement
- */
-fun RBuilder.fontAwesomeIcon(
-    handler: RHandler<FontAwesomeIconProps>
-) = child(FontAwesomeIcon::class) {
-    handler.invoke(this)
 }
 
 /**
@@ -49,7 +39,7 @@ fun ChildrenBuilder.fontAwesomeIcon(
     classes: String = "",
     handler: ChildrenBuilder.(props: FontAwesomeIconProps) -> Unit = {},
 ): Unit = child(FontAwesomeIcon::class.react, props = jso {
-    this.icon = icon
+    this.icon = icon.definition
     this.className = classes
     handler(this)
 })

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/Icons.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/Icons.kt
@@ -6,129 +6,128 @@ package com.saveourtool.save.frontend.externals.fontawesome
 
 @JsModule("@fortawesome/free-solid-svg-icons/faUser")
 @JsNonModule
-external val faUser: dynamic
+external val faUser: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCogs")
 @JsNonModule
-external val faCogs: dynamic
+external val faCogs: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faSignOutAlt")
 @JsNonModule
-external val faSignOutAlt: dynamic
+external val faSignOutAlt: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faAngleUp")
 @JsNonModule
-external val faAngleUp: dynamic
+external val faAngleUp: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCheck")
 @JsNonModule
-external val faCheck: dynamic
+external val faCheck: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faExclamationTriangle")
 @JsNonModule
-external val faExclamationTriangle: dynamic
+external val faExclamationTriangle: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faTimesCircle")
 @JsNonModule
-external val faTimesCircle: dynamic
+external val faTimesCircle: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faQuestionCircle")
 @JsNonModule
-external val faQuestionCircle: dynamic
+external val faQuestionCircle: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faSpinner")
 @JsNonModule
-external val faSpinner: dynamic
+external val faSpinner: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faUpload")
 @JsNonModule
-external val faUpload: dynamic
+external val faUpload: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faFile")
 @JsNonModule
-external val faFile: dynamic
+external val faFile: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faHistory")
 @JsNonModule
-external val faHistory: dynamic
+external val faHistory: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCalendarAlt")
 @JsNonModule
-external val faCalendarAlt: dynamic
+external val faCalendarAlt: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faExternalLinkAlt")
 @JsNonModule
-external val faExternalLinkAlt: dynamic
+external val faExternalLinkAlt: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faTrashAlt")
 @JsNonModule
-external val faTrashAlt: dynamic
+external val faTrashAlt: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faEdit")
 @JsNonModule
-external val faEdit: dynamic
+external val faEdit: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faFilter")
 @JsNonModule
-external val faFilter: dynamic
+external val faFilter: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faSearch")
 @JsNonModule
-external val faSearch: dynamic
+external val faSearch: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faRedo")
 @JsNonModule
-external val faRedo: dynamic
+external val faRedo: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCopyright")
 @JsNonModule
-external val faCopyright: dynamic
+external val faCopyright: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faSignInAlt")
 @JsNonModule
-external val faSignInAlt: dynamic
+external val faSignInAlt: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCopy")
 @JsNonModule
-external val faCopy: dynamic
+external val faCopy: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faFolderOpen")
 @JsNonModule
-external val faFolderOpen: dynamic
+external val faFolderOpen: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCheckCircle")
 @JsNonModule
-external val faCheckCircle: dynamic
+external val faCheckCircle: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faPlus")
 @JsNonModule
-external val faPlus: dynamic
+external val faPlus: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faArrowRight")
 @JsNonModule
-external val faArrowRight: dynamic
+external val faArrowRight: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faLightbulb")
 @JsNonModule
-external val faLightbulb: dynamic
+external val faLightbulb: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCog")
 @JsNonModule
-external val faCog: dynamic
+external val faCog: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faHome")
 @JsNonModule
-external val faHome: dynamic
+external val faHome: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faEnvelope")
 @JsNonModule
-external val faEnvelope: dynamic
+external val faEnvelope: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faKey")
 @JsNonModule
-external val faKey: dynamic
+external val faKey: FontAwesomeIconModule
 
 @JsModule("@fortawesome/free-solid-svg-icons/faCity")
 @JsNonModule
-external val faCity: dynamic
-
+external val faCity: FontAwesomeIconModule

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/Icons.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/Icons.kt
@@ -2,41 +2,133 @@
  * External declarations of icons from fontawesome-solid
  */
 
-@file:JsModule("@fortawesome/free-solid-svg-icons")
-@file:JsNonModule
-
 package com.saveourtool.save.frontend.externals.fontawesome
 
-external val fas: dynamic
+@JsModule("@fortawesome/free-solid-svg-icons/faUser")
+@JsNonModule
 external val faUser: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCogs")
+@JsNonModule
 external val faCogs: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faSignOutAlt")
+@JsNonModule
 external val faSignOutAlt: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faAngleUp")
+@JsNonModule
 external val faAngleUp: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCheck")
+@JsNonModule
 external val faCheck: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faExclamationTriangle")
+@JsNonModule
 external val faExclamationTriangle: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faTimesCircle")
+@JsNonModule
 external val faTimesCircle: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faQuestionCircle")
+@JsNonModule
 external val faQuestionCircle: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faSpinner")
+@JsNonModule
 external val faSpinner: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faUpload")
+@JsNonModule
 external val faUpload: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faFile")
+@JsNonModule
 external val faFile: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faHistory")
+@JsNonModule
 external val faHistory: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCalendarAlt")
+@JsNonModule
 external val faCalendarAlt: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faExternalLinkAlt")
+@JsNonModule
 external val faExternalLinkAlt: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faTrashAlt")
+@JsNonModule
 external val faTrashAlt: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faEdit")
+@JsNonModule
 external val faEdit: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faFilter")
+@JsNonModule
 external val faFilter: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faSearch")
+@JsNonModule
 external val faSearch: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faRedo")
+@JsNonModule
 external val faRedo: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCopyright")
+@JsNonModule
 external val faCopyright: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faSignInAlt")
+@JsNonModule
 external val faSignInAlt: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCopy")
+@JsNonModule
 external val faCopy: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faFolderOpen")
+@JsNonModule
 external val faFolderOpen: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCheckCircle")
+@JsNonModule
 external val faCheckCircle: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faPlus")
+@JsNonModule
 external val faPlus: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faArrowRight")
+@JsNonModule
 external val faArrowRight: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faLightbulb")
+@JsNonModule
 external val faLightbulb: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCog")
+@JsNonModule
 external val faCog: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faHome")
+@JsNonModule
 external val faHome: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faEnvelope")
+@JsNonModule
 external val faEnvelope: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faKey")
+@JsNonModule
 external val faKey: dynamic
+
+@JsModule("@fortawesome/free-solid-svg-icons/faCity")
+@JsNonModule
 external val faCity: dynamic
+


### PR DESCRIPTION
Related discussion can be found at https://github.com/FortAwesome/react-fontawesome/issues/70.
We can't use babel to transform imports in existing code, because Kotlin (or Webpack?) hides them and provides already resolved modules to the entrypoint. So instead I'm using a marker interface for FA icons imported from individual modules.

This change leads to the following size reduction: 
- old: `save-frontend-vendors.js (1.79 MiB)`
- new `save-frontend-vendors.js (723 KiB)`

Related issue: #141 