### PR TITLE
Feature/agent in same docker network

### DIFF
--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DockerStackConfiguration.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DockerStackConfiguration.kt
@@ -164,6 +164,7 @@ fun Project.createStackDeployTask(profile: String) {
         require(componentName in allprojects.map { it.name }) { "Component name should be one of gradle subproject names" }
         val buildTask = project(componentName).tasks.named<BootBuildImage>("bootBuildImage")
         dependsOn(buildTask)
+        dependsOn("generateComposeFile")
         val serviceName = when (componentName) {
             "save-backend", "save-orchestrator", "save-preprocessor" -> "save_${componentName.substringAfter("save-")}"
             "api-gateway" -> "save_gateway"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,13 +16,6 @@ x-logging:
           level:
 
 services:
-  test:
-    image: alpine
-    environment:
-      - "DOCKER_NETWORK_NAME=${COMPOSE_PROJECT_NAME}"
-    entrypoint:
-      - /bin/echo
-      - $DOCKER_NETWORK_NAME
   orchestrator:
     image: ghcr.io/analysis-dev/save-orchestrator:${TAG}
     user: root  # to access host's docker socket

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,11 +16,19 @@ x-logging:
           level:
 
 services:
+  test:
+    image: alpine
+    environment:
+      - "DOCKER_NETWORK_NAME=${COMPOSE_PROJECT_NAME}"
+    entrypoint:
+      - /bin/echo
+      - $DOCKER_NETWORK_NAME
   orchestrator:
     image: ghcr.io/analysis-dev/save-orchestrator:${TAG}
     user: root  # to access host's docker socket
     environment:
       - "SPRING_PROFILES_ACTIVE=${PROFILE}"
+      - "DOCKER_NETWORK_NAME=${COMPOSE_PROJECT_NAME}"
     ports:
       - "5100:5100"
     volumes:

--- a/save-agent/src/linuxX64Main/resources/agent.properties
+++ b/save-agent/src/linuxX64Main/resources/agent.properties
@@ -1,6 +1,6 @@
 id=id-of-the-agent
-backend.url=http://host.docker.internal:5800
-orchestratorUrl=http://host.docker.internal:5100
+backend.url=http://backend:5800
+orchestratorUrl=http://orchestrator:5100
 heartbeat.intervalMillis=15000
 requestTimeoutMillis=60000
 retry.attempts=5

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     implementation(libs.commons.compress)
     implementation(libs.kotlinx.datetime)
     implementation(libs.zip4j)
+    implementation(libs.save.common)
 }
 
 // todo: this logic is duplicated between agent and frontend, can be moved to a shared plugin in buildSrc

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -19,6 +19,7 @@ import com.github.dockerjava.transport.DockerHttpClient
 import io.micrometer.core.instrument.MeterRegistry
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.cqfn.save.core.utils.runIf
 import org.slf4j.LoggerFactory
 
 import java.io.BufferedOutputStream
@@ -81,6 +82,9 @@ class ContainerManager(private val settings: DockerSettings,
             .withCmd(runCmd)
             .withName(containerName)
             .withHostConfig(HostConfig.newHostConfig()
+                .runIf({ System.getenv("DOCKER_NETWORK_NAME") != null }) {
+                    withNetworkMode(System.getenv("DOCKER_NETWORK_NAME"))
+                }
                 .withRuntime(settings.runtime)
                 // processes from inside the container will be able to access host's network using this hostname
                 .withExtraHosts("host.docker.internal:${getHostIp()}")


### PR DESCRIPTION
The idea of this change was to simplify setup of agents: now we are passing explicitly IP of host network so that agent can connect to backend's and orchestrator's exposed ports. If agents would be connected to the same docker network, this would be simplified as they could access upstream services by their DNS name. This change in its current state adds this option to docker compose.
Drawbacks:
* `COMPOSE_PROJECT_NAME` should be set explicitly - I couldn't find any reliable way to pass name of compose project to compose services (unlike Kubernetes, where a lot of useful info can be passed as environment variables)
* It works differently for Docker Swarm: there is a network which name defaults to swarm stack name.

So it would make sense to simply pass network name for agents as a property of save-orchestrator. It could be added into `~/configs/orchestrator/application.properties` and reference an existing network on a particular machine