### PR TITLE
Configure renovate.json to update Helm 3 charts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,9 +38,9 @@
       "groupSlug": "all-docker-images"
     },
     {
-      "managers": ["helm-requirements"],
-      "groupName": "all Helm requirements",
-      "groupSlug": "all-helm-requirements"
+      "managers": ["helmv3", "helm-values"],
+      "groupName": "Helm dependencies",
+      "groupSlug": "helm-dependencies"
     }
   ]
 }


### PR DESCRIPTION
After #867 renovate should be able to use two new managers: [`helmv3`](https://docs.renovatebot.com/modules/manager/helmv3/) and [`helm-values`](https://docs.renovatebot.com/modules/manager/helmv3/)