### PR TITLE
Fixes for agents shutdown logic

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -187,7 +187,7 @@ class SaveAgent(internal val config: AgentConfiguration,
             )
     }
 
-    @Suppress("TOO_MANY_LINES_IN_LAMBDA")
+    @Suppress("TOO_MANY_LINES_IN_LAMBDA", "TYPE_ALIAS")
     private fun readExecutionResults(jsonFile: String): Pair<List<TestResultDebugInfo>, List<TestExecutionDto>> {
         val currentTime = Clock.System.now()
         val reports: List<Report> = readExecutionReportFromFile(jsonFile)

--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -42,6 +42,7 @@ import kotlinx.serialization.modules.subclass
  * @property config
  * @property coroutineScope a [CoroutineScope] to launch other jobs
  */
+@Suppress("AVOID_NULL_CHECKS")
 class SaveAgent(internal val config: AgentConfiguration,
                 private val httpClient: HttpClient,
                 private val coroutineScope: CoroutineScope,

--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -7,7 +7,6 @@ import com.saveourtool.save.agent.utils.logErrorCustom
 import com.saveourtool.save.agent.utils.logInfoCustom
 import com.saveourtool.save.agent.utils.readFile
 import com.saveourtool.save.agent.utils.sendDataToBackend
-import com.saveourtool.save.core.config.OutputStreamType
 import com.saveourtool.save.core.logging.describe
 import com.saveourtool.save.core.plugin.Plugin
 import com.saveourtool.save.core.result.CountWarnings
@@ -179,7 +178,7 @@ class SaveAgent(internal val config: AgentConfiguration,
             append(" --report-type ${config.save.reportType.name.lowercase()}")
             append(" --result-output ${config.save.resultOutput.name.lowercase()}")
             append(" --report-dir ${config.save.reportDir}")
-            append(" --result-output ${OutputStreamType.FILE.name.lowercase()}")
+            append(" --result-output ${config.save.resultOutput.name.lowercase()}")
             append(" --log ${config.save.logType.name.lowercase()}")
         }
         return ProcessBuilder(true, FileSystem.SYSTEM)

--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -7,6 +7,7 @@ import com.saveourtool.save.agent.utils.logErrorCustom
 import com.saveourtool.save.agent.utils.logInfoCustom
 import com.saveourtool.save.agent.utils.readFile
 import com.saveourtool.save.agent.utils.sendDataToBackend
+import com.saveourtool.save.core.config.OutputStreamType
 import com.saveourtool.save.core.logging.describe
 import com.saveourtool.save.core.plugin.Plugin
 import com.saveourtool.save.core.result.CountWarnings
@@ -177,6 +178,7 @@ class SaveAgent(internal val config: AgentConfiguration,
             append(" $cliArgs")
             append(" --report-type ${config.save.reportType.name.lowercase()}")
             append(" --report-dir ${config.save.reportDir}")
+            append(" --result-output ${OutputStreamType.FILE.name.lowercase()}")
             append(" --log ${config.save.logType.name.lowercase()}")
         }
         return ProcessBuilder(true, FileSystem.SYSTEM)

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
@@ -94,10 +94,11 @@ class DockerAgentRunner(
         }
     }
 
-    override fun isAgentStopped(agentId: String): Boolean = dockerClient.listContainersCmd()
-        .withStatusFilter(listOf("running"))
+    override fun isAgentStopped(agentId: String): Boolean = dockerClient.inspectContainerCmd(agentId)
         .exec()
-        .none { container -> container.names.any { it.contains(agentId) } }
+        .state
+        .also { logger.debug("Container $agentId has state $it") }
+        .status != "running"
 
     override fun cleanup(executionId: Long) {
         val containersForExecution = dockerClient.listContainersCmd().withNameFilter(listOf("-$executionId-")).exec()

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 /**
  * Background inspector, which detect crashed agents
@@ -51,8 +52,13 @@ class HeartBeatInspector(
             }
         }
 
-        crashedAgents.removeIf {
-            !dockerService.isAgentRunning(it)
+        crashedAgents.removeIf { agentId ->
+            dockerService.isAgentStopped(agentId)
+        }
+        agentsLatestHeartBeatsMap.filterKeys { agentId ->
+            dockerService.isAgentStopped(agentId)
+        }.forEach { (agentId, _) ->
+            agentsLatestHeartBeatsMap.remove(agentId)
         }
     }
 

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
@@ -57,6 +57,7 @@ class HeartBeatInspector(
         agentsLatestHeartBeatsMap.filterKeys { agentId ->
             dockerService.isAgentStopped(agentId)
         }.forEach { (agentId, _) ->
+            logger.debug("Agent $agentId is already stopped, will stop watching it")
             agentsLatestHeartBeatsMap.remove(agentId)
         }
     }

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 /**
  * Background inspector, which detect crashed agents

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
@@ -50,6 +50,10 @@ class HeartBeatInspector(
                 crashedAgents.add(currentAgentId)
             }
         }
+
+        crashedAgents.removeIf {
+            !dockerService.isAgentRunning(it)
+        }
     }
 
     /**


### PR DESCRIPTION
* Agent: launch heartbeats in a nested coroutine scope, because top-level BlockingCoroutine shouldn't be cancelled
* Agent: don't update status while data is being sent to backend
* Orchestrator: Clean up already stopped agents in `HeartBeatInspector`
* Orchestrator: fix `DockerAgentRunner#isAgentStopped` method

Part of #862