### PR TITLE
Agent: Rethrow exception on missing results file

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -224,9 +224,16 @@ class SaveAgent(internal val config: AgentConfiguration,
         ?.toLong()
         ?: 0L
 
-    private fun readExecutionReportFromFile(jsonFile: String) = reportFormat.decodeFromString<List<Report>>(
-        readFile(jsonFile).joinToString(separator = "")
-    )
+    private fun readExecutionReportFromFile(jsonFile: String): List<Report> {
+        val jsonFileContent = readFile(jsonFile).joinToString(separator = "")
+        return if (jsonFileContent.isEmpty()) {
+            throw IllegalStateException("Reading results file $jsonFile has returned empty")
+        } else {
+            reportFormat.decodeFromString(
+                jsonFileContent
+            )
+        }
+    }
 
     private fun CoroutineScope.launchLogSendingJob(executionLogs: ExecutionLogs) = launch {
         runCatching {


### PR DESCRIPTION
Currently exception is silently handled inside save-core and we get a new JsonDecodingException. By rethrowing we can handle it in a higher function