### PR TITLE
Orchestrator: Proper handling for SAVE-cli issues reported by SAVE-agent #778

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -158,9 +158,7 @@ class SaveAgent(internal val config: AgentConfiguration,
                 state.value = AgentState.CLI_FAILED
             } else {
                 handleSuccessfulExit().invokeOnCompletion { cause ->
-                    if (cause == null) {
-                        state.value = AgentState.FINISHED
-                    }
+                    state.value = if (cause == null) AgentState.FINISHED else AgentState.CLI_FAILED
                 }
             }
             else -> {

--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -158,7 +158,7 @@ class SaveAgent(internal val config: AgentConfiguration,
                 state.value = AgentState.CLI_FAILED
             } else {
                 handleSuccessfulExit().invokeOnCompletion { cause ->
-                    state.value = if (cause == null) AgentState.FINISHED else AgentState.CLI_FAILED
+                    state.value = if (cause == null) AgentState.FINISHED else AgentState.CRASHED
                 }
             }
             else -> {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DownloadFilesController.kt
@@ -212,11 +212,11 @@ class DownloadFilesController(
         val agentContainerId = testExecutionDto.agentContainerId
             ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Request body should contain agentContainerId")
         val execution = agentRepository.findByContainerId(agentContainerId)?.execution
+        return execution?.id
             ?: throw ResponseStatusException(
                 HttpStatus.NOT_FOUND,
                 "Execution for agent $agentContainerId not found"
             )
-        return execution.id!!
     }
 
     /**

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DownloadFilesController.kt
@@ -22,7 +22,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.codec.multipart.FilePart
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
@@ -207,9 +206,9 @@ class DownloadFilesController(
         }
     }
 
-    private fun getExecutionId(testExecutionDto: TestExecutionDto): Long  {
-        if( testExecutionDto.executionId != null)
-            return testExecutionDto.executionId!!
+    private fun getExecutionId(testExecutionDto: TestExecutionDto): Long {
+        testExecutionDto.executionId?.let { return it }
+
         val agentContainerId = testExecutionDto.agentContainerId
             ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Request body should contain agentContainerId")
         val execution = agentRepository.findByContainerId(agentContainerId)?.execution

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DownloadFilesController.kt
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.codec.multipart.FilePart
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
@@ -229,10 +230,13 @@ class DownloadFilesController(
     fun getExecutionInfo(
         @RequestBody testExecutionDto: TestExecutionDto,
     ): String {
+        logger.debug("Processing getExecutionInfo : $testExecutionDto")
         val executionId = getExecutionId(testExecutionDto)
         val executionInfoFile = testDataFilesystemRepository.getExecutionInfoFile(executionId).file
         return if (executionInfoFile.exists()) {
-            executionInfoFile.readText()
+            val text = executionInfoFile.readText()
+            logger.debug("Sending $executionInfoFile : $text")
+            text
         } else {
             logger.debug("File ${executionInfoFile.absolutePath} not found")
             throw ResponseStatusException(HttpStatus.NOT_FOUND, "File not found")

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/TestDataFilesystemRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/TestDataFilesystemRepository.kt
@@ -4,22 +4,21 @@ import com.saveourtool.save.agent.TestExecutionDto
 import com.saveourtool.save.backend.configs.ConfigProperties
 import com.saveourtool.save.domain.TestResultDebugInfo
 import com.saveourtool.save.domain.TestResultLocation
+import com.saveourtool.save.execution.ExecutionUpdateDto
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.saveourtool.save.execution.ExecutionUpdateDto
 import okio.Path.Companion.toPath
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.FileSystemResource
 import org.springframework.stereotype.Repository
-import java.io.File
 
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
 import kotlin.io.path.createDirectories
 import kotlin.io.path.div
 import kotlin.io.path.exists
-import kotlin.io.path.name
 
 /**
  * A repository for storing additional data associated with test results
@@ -64,6 +63,13 @@ class TestDataFilesystemRepository(
     private fun TestResultLocation.toFsResource(executionId: Long) = FileSystemResource(
         getLocation(executionId, this)
     )
+
+    /**
+     * Get location of execution data for given [executionId]
+     *
+     * @param executionId
+     * @return path to file with execution info
+     */
     fun getExecutionInfoFile(executionId: Long) = FileSystemResource(
         root / executionId.toString() / "execution-info.json"
     )
@@ -98,6 +104,9 @@ class TestDataFilesystemRepository(
     private fun sanitizePathName(name: String): String =
             name.replace("[\\\\/:*?\"<>| ]".toRegex(), "")
 
+    /**
+     * @param executionInfo
+     */
     fun save(executionInfo: ExecutionUpdateDto) {
         val destination = getExecutionInfoFile(executionInfo.id).file
         if (destination.exists()) {
@@ -123,6 +132,10 @@ class TestDataFilesystemRepository(
         TODO("Not yet implemented")
     }
 
+    /**
+     * @param executionId
+     * @return
+     */
     fun getLocation(executionId: Long): Any {
         TODO("Not yet implemented")
     }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/TestDataFilesystemRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/TestDataFilesystemRepository.kt
@@ -26,7 +26,7 @@ import kotlin.io.path.exists
 @Repository
 class TestDataFilesystemRepository(
     configProperties: ConfigProperties,
-    private val objectMapper: ObjectMapper,
+    private val objectMapper: ObjectMapper
 ) {
     private val log = LoggerFactory.getLogger(TestDataFilesystemRepository::class.java)
 
@@ -84,8 +84,10 @@ class TestDataFilesystemRepository(
     @Suppress("UnsafeCallOnNullableType")
     fun getLocation(executionId: Long, testExecutionDto: TestExecutionDto): Path {
         val path = testExecutionDto.filePath.toPath()
-        val testResultLocation = TestResultLocation(testExecutionDto.testSuiteName!!, testExecutionDto.pluginName,
-            path.parent.toString(), path.name)
+        val testResultLocation = TestResultLocation(
+            testExecutionDto.testSuiteName!!, testExecutionDto.pluginName,
+            path.parent.toString(), path.name
+        )
         return getLocation(executionId, testResultLocation)
     }
 
@@ -111,9 +113,12 @@ class TestDataFilesystemRepository(
         val destination = getExecutionInfoFile(executionInfo.id).file
         if (destination.exists()) {
             val existingExecutionInfo = loadExecutionInfo(destination)
-            save(existingExecutionInfo.copy(
-                failReason = "${existingExecutionInfo.failReason}, ${executionInfo.failReason}"),
-                destination)
+            save(
+                existingExecutionInfo.copy(
+                    failReason = "${existingExecutionInfo.failReason}, ${executionInfo.failReason}"
+                ),
+                destination
+            )
         } else {
             destination.parentFile.mkdirs()
             save(executionInfo, destination)
@@ -128,15 +133,5 @@ class TestDataFilesystemRepository(
         )
     }
 
-    private fun loadExecutionInfo(destination: File): ExecutionUpdateDto {
-        TODO("Not yet implemented")
-    }
-
-    /**
-     * @param executionId
-     * @return
-     */
-    fun getLocation(executionId: Long): Any {
-        TODO("Not yet implemented")
-    }
+    private fun loadExecutionInfo(destination: File): ExecutionUpdateDto = objectMapper.readValue(destination, ExecutionUpdateDto::class.java)
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/agent/TestExecutionDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/agent/TestExecutionDto.kt
@@ -34,4 +34,5 @@ data class TestExecutionDto(
     val expected: Long?,
     val unexpected: Long?,
     val hasDebugInfo: Boolean? = null,
+    val executionId: Long? = null
 )

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/agent/TestExecutionDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/agent/TestExecutionDto.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.Serializable
  * @property expected number of all checks/validations in test (unmatched + matched)
  * @property unexpected number of matched,but not expected checks/validations in test (false positive results)
  * @property hasDebugInfo whether debug info data is available for this test execution
+ * @property executionId
  */
 @Serializable
 data class TestExecutionDto(

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/execution/ExecutionUpdateDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/execution/ExecutionUpdateDto.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.Serializable
  * @property status
  */
 @Serializable
-class ExecutionUpdateDto(
+data class ExecutionUpdateDto(
     val id: Long,
     val status: ExecutionStatus,
+    val failReason: String? = null
 )

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/execution/ExecutionUpdateDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/execution/ExecutionUpdateDto.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 /**
  * @property id
  * @property status
+ * @property failReason
  */
 @Serializable
 data class ExecutionUpdateDto(

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestExecution.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestExecution.kt
@@ -74,5 +74,6 @@ class TestExecution(
         expected,
         unexpected,
         null,
+        execution.id,
     )
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestStatusComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestStatusComponent.kt
@@ -78,3 +78,30 @@ fun <D : Any> testStatusComponent(testResultDebugInfo: TestResultDebugInfo, tabl
         }
     }
 }
+
+/**
+ * A function component that renders info about execution [failReason] into a table [tableInstance]
+ *
+ * @param failReason reason of execution fail
+ * @param tableInstance a table, into which this data is added
+ * @return a function component
+ */
+fun <D : Any> executionStatusComponent(
+    failReason: String,
+    tableInstance: TableInstance<D>
+) = fc<Props> {
+    tr {
+        td {
+            attrs.colSpan = "2"
+            +"Execution fail reason:"
+        }
+        td {
+            attrs.colSpan = "${tableInstance.columns.size - 2}"
+            small {
+                samp {
+                    +failReason
+                }
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -194,7 +194,7 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                                     val trei = getExecutionInfoFor(te)
                                     if (trei.ok) {
                                         cellProps.row.original.asDynamic().executionInfo =
-                                            trei.decodeFromJsonString<ExecutionUpdateDto>()
+                                                trei.decodeFromJsonString<ExecutionUpdateDto>()
                                     }
                                 }
                                 cellProps.row.toggleRowExpanded()
@@ -254,7 +254,7 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                     tr {
                         td {
                             attrs.colSpan = "${tableInstance.columns.size}"
-                            + "$reasonText"
+                            +reasonText
                         }
                     }
                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -250,7 +250,7 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
             }
                 ?: run {
                     val trei = row.original.asDynamic().executionInfo as ExecutionUpdateDto?
-                    val reasonText = trei?.let { it.failReason  } ?: "Debug info not available yet for this test execution"
+                    val reasonText = trei?.failReason ?: "Debug info not available yet for this test execution"
                     tr {
                         td {
                             attrs.colSpan = "${tableInstance.columns.size}"

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -9,6 +9,7 @@ import com.saveourtool.save.domain.TestResultDebugInfo
 import com.saveourtool.save.domain.TestResultStatus
 import com.saveourtool.save.execution.ExecutionDto
 import com.saveourtool.save.execution.ExecutionStatus
+import com.saveourtool.save.execution.ExecutionUpdateDto
 import com.saveourtool.save.frontend.components.RequestStatusContext
 import com.saveourtool.save.frontend.components.basic.SelectOption.Companion.ANY
 import com.saveourtool.save.frontend.components.basic.executionStatistics
@@ -21,6 +22,7 @@ import com.saveourtool.save.frontend.externals.fontawesome.faRedo
 import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
 import com.saveourtool.save.frontend.externals.table.useFilters
 import com.saveourtool.save.frontend.http.getDebugInfoFor
+import com.saveourtool.save.frontend.http.getExecutionInfoFor
 import com.saveourtool.save.frontend.themes.Colors
 import com.saveourtool.save.frontend.utils.*
 
@@ -188,6 +190,12 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                                 val trdi = getDebugInfoFor(te)
                                 if (trdi.ok) {
                                     cellProps.row.original.asDynamic().debugInfo = trdi.decodeFromJsonString<TestResultDebugInfo>()
+                                } else {
+                                    val trei = getExecutionInfoFor(te)
+                                    if (trei.ok) {
+                                        cellProps.row.original.asDynamic().executionInfo =
+                                            trdi.decodeFromJsonString<ExecutionUpdateDto>()
+                                    }
                                 }
                                 cellProps.row.toggleRowExpanded()
                             }
@@ -241,10 +249,12 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                 }
             }
                 ?: run {
+                    val trei = row.original.asDynamic().executionInfo as ExecutionUpdateDto?
+                    val reasonText = trei?.let { it.failReason  } ?: "Debug info not available yet for this test execution"
                     tr {
                         td {
                             attrs.colSpan = "${tableInstance.columns.size}"
-                            +"Debug info not available yet for this test execution"
+                            + "$reasonText"
                         }
                     }
                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -194,7 +194,7 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                                     val trei = getExecutionInfoFor(te)
                                     if (trei.ok) {
                                         cellProps.row.original.asDynamic().executionInfo =
-                                            trdi.decodeFromJsonString<ExecutionUpdateDto>()
+                                            trei.decodeFromJsonString<ExecutionUpdateDto>()
                                     }
                                 }
                                 cellProps.row.toggleRowExpanded()

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
@@ -107,12 +107,13 @@ private suspend fun getDebugInfoFor(
 @Suppress("TYPE_ALIAS")
 private suspend fun getExecutionInfoFor(
     testExecutionDto: TestExecutionDto,
-    post: suspend (String, Headers, dynamic, suspend (suspend () -> Response) -> Response) -> Response,
+    post: suspend (String, Headers, dynamic, suspend (suspend () -> Response) -> Response, (Response) -> Unit) -> Response,
 ) = post(
     "$apiUrl/files/get-execution-info",
     Headers().apply {
         set("Content-Type", "application/json")
     },
     Json.encodeToString(testExecutionDto),
-    ::noopLoadingHandler
+    ::noopLoadingHandler,
+    ::noopResponseHandler
 )

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
@@ -25,6 +25,12 @@ suspend fun ComponentWithScope<*, *>.getDebugInfoFor(testExecutionDto: TestExecu
 /**
  * @param testExecutionDto
  */
+suspend fun ComponentWithScope<*, *>.getExecutionInfoFor(testExecutionDto: TestExecutionDto) =
+    getExecutionInfoFor(testExecutionDto, this::post)
+
+/**
+ * @param testExecutionDto
+ */
 suspend fun WithRequestStatusContext.getDebugInfoFor(testExecutionDto: TestExecutionDto) =
         getDebugInfoFor(testExecutionDto, this::post)
 
@@ -88,4 +94,24 @@ private suspend fun getDebugInfoFor(
     },
     Json.encodeToString(testExecutionDto),
     ::noopLoadingHandler,
+)
+
+/**
+ * Fetch execution info for test execution
+ *
+ * @param testExecutionDto
+ * @param post
+ * @return Response
+ */
+@Suppress("TYPE_ALIAS")
+private suspend fun getExecutionInfoFor(
+    testExecutionDto: TestExecutionDto,
+    post: suspend (String, Headers, dynamic, suspend (suspend () -> Response) -> Response) -> Response,
+) = post(
+    "$apiUrl/files/get-execution-info?executionId=${testExecutionDto.executionId}",
+    Headers().apply {
+        set("Content-Type", "application/json")
+    },
+    Json.encodeToString(testExecutionDto),
+    ::noopLoadingHandler
 )

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
@@ -86,7 +86,7 @@ suspend fun ComponentWithScope<*, *>.getUser(name: String) = get(
 @Suppress("TYPE_ALIAS")
 private suspend fun getDebugInfoFor(
     testExecutionDto: TestExecutionDto,
-    post: suspend (String, Headers, dynamic, suspend (suspend () -> Response) -> Response) -> Response,
+    post: suspend (String, Headers, dynamic, suspend (suspend () -> Response) -> Response, (Response) -> Unit) -> Response,
 ) = post(
     "$apiUrl/files/get-debug-info",
     Headers().apply {
@@ -94,6 +94,7 @@ private suspend fun getDebugInfoFor(
     },
     Json.encodeToString(testExecutionDto),
     ::noopLoadingHandler,
+    ::noopResponseHandler
 )
 
 /**
@@ -108,7 +109,7 @@ private suspend fun getExecutionInfoFor(
     testExecutionDto: TestExecutionDto,
     post: suspend (String, Headers, dynamic, suspend (suspend () -> Response) -> Response) -> Response,
 ) = post(
-    "$apiUrl/files/get-execution-info?executionId=${testExecutionDto.executionId}",
+    "$apiUrl/files/get-execution-info",
     Headers().apply {
         set("Content-Type", "application/json")
     },

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
@@ -26,7 +26,7 @@ suspend fun ComponentWithScope<*, *>.getDebugInfoFor(testExecutionDto: TestExecu
  * @param testExecutionDto
  */
 suspend fun ComponentWithScope<*, *>.getExecutionInfoFor(testExecutionDto: TestExecutionDto) =
-    getExecutionInfoFor(testExecutionDto, this::post)
+        getExecutionInfoFor(testExecutionDto, this::post)
 
 /**
  * @param testExecutionDto

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
@@ -1,6 +1,5 @@
 package com.saveourtool.save.orchestrator.controller
 
-import com.github.dockerjava.api.exception.DockerClientException
 import com.saveourtool.save.agent.ExecutionLogs
 import com.saveourtool.save.entities.Agent
 import com.saveourtool.save.entities.Execution
@@ -11,6 +10,7 @@ import com.saveourtool.save.orchestrator.service.AgentService
 import com.saveourtool.save.orchestrator.service.DockerService
 import com.saveourtool.save.orchestrator.service.imageName
 
+import com.github.dockerjava.api.exception.DockerClientException
 import com.github.dockerjava.api.exception.DockerException
 import io.fabric8.kubernetes.client.KubernetesClientException
 import org.slf4j.LoggerFactory
@@ -62,7 +62,7 @@ class AgentsController(
                 // todo: pass SDK via request body
                 dockerService.buildBaseImage(execution)
             }
-                .onErrorResume({it is DockerException || it is DockerClientException}) { dex ->
+                .onErrorResume({ it is DockerException || it is DockerClientException }) { dex ->
                     reportExecutionError(execution, "Unable to build image and containers", dex)
                 }
                 .map { (baseImageId, agentRunCmd) ->

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
@@ -96,7 +96,9 @@ class AgentsController(
         ex: Throwable?
     ): Mono<T> {
         log.error("$failReason for executionId=${execution.id}, will mark it as ERROR", ex)
-        return agentService.updateExecution(execution.id!!, ExecutionStatus.ERROR, failReason).then(Mono.empty())
+        return execution.id?.let {
+            agentService.updateExecution(it, ExecutionStatus.ERROR, failReason).then(Mono.empty())
+        } ?: Mono.empty()
     }
 
     /**

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
@@ -202,6 +202,7 @@ class AgentService(
      *
      * @param executionId execution that should be updated
      * @param executionStatus new status for execution
+     * @param failReason to show to user in case of error status
      * @return a bodiless response entity
      */
     fun updateExecution(executionId: Long, executionStatus: ExecutionStatus, failReason: String? = null): Mono<BodilessResponseEntity> =

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/DownloadProjectController.kt
@@ -545,7 +545,7 @@ class DownloadProjectController(
     }
         .collectList()
 
-    private fun updateExecutionStatus(executionId: Long, executionStatus: ExecutionStatus, failReason:String? = null) =
+    private fun updateExecutionStatus(executionId: Long, executionStatus: ExecutionStatus, failReason: String? = null) =
             webClientBackend.makeRequest(
                 BodyInserters.fromValue(ExecutionUpdateDto(executionId, executionStatus, failReason)),
                 "/updateExecutionByDto"

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/DownloadProjectController.kt
@@ -305,7 +305,7 @@ class DownloadProjectController(
                     is InvalidRemoteException,
                     is TransportException,
                     is GitAPIException -> "Error with git API while cloning ${gitDto.url} repository"
-                    else -> "Cloning ${gitDto.url} repository failed"
+                    else -> "Cloning ${gitDto.url} repository failed. Reason: ${exception.message}"
                 }
                 log.error(failReason, exception)
                 updateExecutionStatus(executionRequest.executionId!!, ExecutionStatus.ERROR, failReason).flatMap {
@@ -365,7 +365,7 @@ class DownloadProjectController(
         .toBodilessEntity()
         .then(initializeAgents(this))
         .onErrorResume { ex ->
-            val failReason = "Error during preprocessing"
+            val failReason = "Error during preprocessing. Reason: ${ex.message}"
             log.error(
                 "$failReason, will mark execution.id=$id as failed; error: ",
                 ex


### PR DESCRIPTION
What's done:
* add new field failReason in ExecutionUpdateDto
* in case of failure ExecutionUpdateDto is saved in debugInfo folder in execution root
* new endpoint created for ui /get-execution-info
* in case of debug-info is unavailable for the test then in tries to extract and show execution-info