### PR TITLE
Enable `ignoreAnnotated` option in diktat

### DIFF
--- a/diktat-analysis.yml
+++ b/diktat-analysis.yml
@@ -110,3 +110,6 @@
   enabled: true
 - name: COMPLEX_EXPRESSION
   enabled: true
+- name: USE_DATA_CLASS
+  ignoreAnnotated:
+    - Entity

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/Organization.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/Organization.kt
@@ -16,7 +16,6 @@ import kotlinx.serialization.Serializable
  */
 @Entity
 @Serializable
-@Suppress("USE_DATA_CLASS")
 data class Organization(
     var name: String,
     @Enumerated(EnumType.STRING)

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Contest.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Contest.kt
@@ -12,8 +12,7 @@ import com.saveourtool.save.utils.LocalDateTime
  * @property testSuiteIds
  */
 @Entity
-@Suppress("USE_DATA_CLASS")
-data class Contest(
+class Contest(
     var name: String,
     @Enumerated(EnumType.STRING)
     var status: ContestStatus,

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Execution.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Execution.kt
@@ -38,7 +38,7 @@ import javax.persistence.ManyToOne
  * @property execCmd
  * @property batchSizeForAnalyzer
  */
-@Suppress("USE_DATA_CLASS", "LongParameterList")
+@Suppress("LongParameterList")
 @Entity
 class Execution(
 

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
@@ -20,7 +20,7 @@ import javax.persistence.ManyToOne
  * @property description description of the test suite
  * @property language
  */
-@Suppress("USE_DATA_CLASS", "LongParameterList")
+@Suppress("LongParameterList")
 @Entity
 class TestSuite(
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
* Ignore `@Entity` for `USE_DATA_CLASS` rule

Part of #820