### PR TITLE
Run executions on mac

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ You can enable hot reload by passing `--continuous` flag.
 ## Spring Intellij Idea Ultimate plugin
 In order to make Spring Intellij Idea Ultimate plugin work properly, you need to set these active profiles in service's configuration:  
 
-|         |  SaveApplication   | SaveGateway | SaveOrchestrator | SavePreprocessor | 
-|:-------:|:------------------:|:-----------:|:----------------:|:----------------:|
-|   Mac   | `mac, dev, secure` | `mac, dev`  |      `mac`       |      `mac`       |
-| Windows |   `dev, secure`    |    `dev`    |       `-`        |       `-`        |
-|  Linux  |   `dev, secure`    |    `dev`    |       `-`        |       `-`        |
+|         | SaveApplication  | SaveGateway |   SaveOrchestrator   | SavePreprocessor | 
+|:-------:|:----------------:|:-----------:|:--------------------:|:----------------:|
+|   Mac   | `mac,dev,secure` |  `mac,dev`  | `dev,mac,docker-tcp` |    `dev,mac`     |
+| Windows |   `dev,secure`   |    `dev`    | `dev,win,docker-tcp` |    `dev,win`     |
+|  Linux  |   `dev,secure`   |    `dev`    |         `-`          |       `-`        |
 
 ### Mac M1 contributors
 In file `save-cloud/build.gradle.kts` change languageVersion of `org.liquibase.gradle.LiquibaseTask` from 11 to 17
@@ -35,4 +35,7 @@ tasks.withType<org.liquibase.gradle.LiquibaseTask>().configureEach {
     })
 }
 ```
-
+In order to run `save-orchestrator` on Mac with M1 in order to make it run executions, in addition to `save-deploy/README.md` you need to 
+1. manually put all the files from `save-agent-*-distribution.jar` into `save-orchestrator/build/resources/main` as well as `save-*-linuxX64.kexe` (temporary workaround) 
+2. run `docker-mac-settings.sh` script (from `save-deploy` folder) in order to let docker be avaliable via TCP 
+Also check `save-deploy/README.md` for extra information

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ContestController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ContestController.kt
@@ -39,7 +39,7 @@ internal class ContestController(
 
     /**
      * @param contestName
-     * @return Organization
+     * @return contest with name [contestName]
      */
     @GetMapping("/{contestName}")
     @PreAuthorize("permitAll()")
@@ -49,7 +49,7 @@ internal class ContestController(
     /**
      * @param pageSize amount of contests that should be taken
      * @param authentication an [Authentication] representing an authenticated request
-     * @return list of organization by owner id
+     * @return list of active contests
      */
     @GetMapping("/active")
     @PreAuthorize("permitAll()")
@@ -63,7 +63,7 @@ internal class ContestController(
     /**
      * @param pageSize amount of contests that should be taken
      * @param authentication an [Authentication] representing an authenticated request
-     * @return list of organization by owner id
+     * @return list of finished contests
      */
     @GetMapping("/finished")
     @PreAuthorize("permitAll()")
@@ -76,7 +76,7 @@ internal class ContestController(
 
     /**
      * @param contestName
-     * @return Organization
+     * @return [TestFilesContent] filled with public test
      */
     @GetMapping("/{contestName}/public-test")
     @PreAuthorize("permitAll()")

--- a/save-deploy/README.md
+++ b/save-deploy/README.md
@@ -78,12 +78,17 @@ If you run on windows, dependency `save-agent` is omitted because of problems wi
 To run on windows you need to compile save-agent on wsl and put saveAgentDistroFilepath to %USERPROFILE%\.gradle\gradle.properties <br/>
 For example: <br/> 
 `saveAgentDistroFilepath=file:\\\\\\\\wsl$\\Ubuntu\\home\\username\\projects\\save-cloud\\save-agent\\build\\libs\\save-agent-0.3.0-alpha.0.48+1c1fd41-distribution.jar` <br/>
-If you need to test changes in save-cli also you can compile snapshot version of save-cli on wsl <br/> 
+If you need to test changes in save-cli also you can compile snapshot version of save-cli on wsl <br/>
 and set saveCliPath and saveCliVersion in %USERPROFILE%\.gradle\gradle.properties <br/>
 For example:<br/>
 `saveCliPath=file:\\\\\\\\wsl$\\Ubuntu\\home\\username\\projects\\save-cli\\save-cli\\build\\bin\\linuxX64\\releaseExecutable` <br/> 
 `saveCliVersion=0.4.0-alpha.0.42+78a24a8` <br/>
 the version corresponds to the file `save-0.4.0-alpha.0.42+78a24a8-linuxX64.kexe` <br/>
+
+#### Some workarounds:
+If setting `save-agnet`'s path in `gradle.properties` didn't help you (something doesn't work on Mac), you still can place all the files from `save-agent-*-distribution.jar` into `save-orchestrator/build/resources/main`.
+Moreover, if you use Mac with Apple Silicon, you should run `docker-mac-settings.sh` in order to let docker be avaliable via TCP.
+Do not forget to use `mac` profile.
 
 #### Note: 
 * This works only if snapshot version of save-core is set in lib.version.toml. 

--- a/save-deploy/README.md
+++ b/save-deploy/README.md
@@ -86,7 +86,7 @@ For example:<br/>
 the version corresponds to the file `save-0.4.0-alpha.0.42+78a24a8-linuxX64.kexe` <br/>
 
 #### Some workarounds:
-If setting `save-agnet`'s path in `gradle.properties` didn't help you (something doesn't work on Mac), you still can place all the files from `save-agent-*-distribution.jar` into `save-orchestrator/build/resources/main`.
+If setting `save-agent`'s path in `gradle.properties` didn't help you (something doesn't work on Mac), you still can place all the files from `save-agent-*-distribution.jar` into `save-orchestrator/build/resources/main`.
 Moreover, if you use Mac with Apple Silicon, you should run `docker-mac-settings.sh` in order to let docker be avaliable via TCP.
 Do not forget to use `mac` profile.
 

--- a/save-deploy/docker-mac-settings.sh
+++ b/save-deploy/docker-mac-settings.sh
@@ -1,0 +1,1 @@
+socat TCP-LISTEN:2375,range=127.0.0.1/32,reuseaddr,fork UNIX-CLIENT:/var/run/docker.sock

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
@@ -209,6 +209,7 @@ private fun contestEnrollerComponent() = FC<ContestEnrollerProps> { props ->
                 onClick = {
                     enrollRequest()
                 }
+                disabled = projectName.isNullOrBlank() || organizationName.isNullOrBlank() || contestName.isNullOrBlank()
             }
         }
     }

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -67,8 +67,8 @@ tasks.withType<Test> {
 dependencies {
     api(projects.saveCloudCommon)
     testImplementation(projects.testUtils)
-    if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
-        logger.warn("Dependency `save-agent` is omitted on Windows because of problems with linking in cross-compilation." +
+    if (!DefaultNativePlatform.getCurrentOperatingSystem().isLinux) {
+        logger.warn("Dependency `save-agent` is omitted on Windows and Mac because of problems with linking in cross-compilation." +
                 " Task `:save-agent:copyAgentDistribution` would fail without correct libcurl.so. If your changes are about " +
                 "save-agent, please test them on Linux " +
                 "or put the file with name like `save-agent-*-distribution.jar` built on Linux into libs subfolder."

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerContainerManager.kt
@@ -66,6 +66,7 @@ class DockerContainerManager(
         val buildImageResultCallback: BuildImageResultCallback = try {
             val buildCmd = dockerClient.buildImageCmd(dockerFile)
                 .withBaseDirectory(tmpDir)
+                .withPlatform("linux/amd64")
                 .withTags(setOf(imageName))
                 .withLabels(mapOf("save-id" to imageName))
                 // this is required to be able to access host, e.g. if proxy running on the host is required during image build process

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/DockerService.kt
@@ -47,10 +47,11 @@ import kotlin.io.path.ExperimentalPathApi
  */
 @Service
 @OptIn(ExperimentalPathApi::class)
-class DockerService(private val configProperties: ConfigProperties,
-                    private val dockerClient: DockerClient,
-                    internal val dockerContainerManager: DockerContainerManager,
-                    private val agentRunner: AgentRunner,
+class DockerService(
+    private val configProperties: ConfigProperties,
+    private val dockerClient: DockerClient,
+    internal val dockerContainerManager: DockerContainerManager,
+    private val agentRunner: AgentRunner,
 ) {
     private val executionDir = "/home/save-agent/save-execution"
 
@@ -86,9 +87,10 @@ class DockerService(private val configProperties: ConfigProperties,
      * @param agentRunCmd
      * @return list of IDs of created containers
      */
-    fun createContainers(executionId: Long,
-                         baseImageId: String,
-                         agentRunCmd: String,
+    fun createContainers(
+        executionId: Long,
+        baseImageId: String,
+        agentRunCmd: String,
     ) = agentRunner.create(
         executionId = executionId,
         baseImageId = baseImageId,

--- a/save-orchestrator/src/main/resources/application-mac.properties
+++ b/save-orchestrator/src/main/resources/application-mac.properties
@@ -1,2 +1,3 @@
 orchestrator.executionLogs=/Users/Shared/cnb/executionLogs/
 orchestrator.testResources.basePath=/Users/Shared/cnb/repositories
+orchestrator.adjustResourceOwner=false


### PR DESCRIPTION
### What's done:
 * Specified base agent docker image architecture to be `linux/amd64`
 * Updated `mac` profile for `save-orchestrator`
 * Updated check in dependencies from `save-orchestrator` (now it checks that current platform is NOT linux)
 * Improved `ContestEnroller` on frontend - now you cannot participate in stub contest
 * Updated `CONTRIBUTING.md` and `save-deploy/README.md`
 * Added shell script for docker tcp listening on Mac