### PR TITLE
Hotfix: respect tags when saving Test Suites

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.7.10"
-save-core = "0.4.0-SNAPSHOT"
+save-core = "0.3.2"
 ktor = "2.0.3"
 okio = "3.2.0"
 serialization = "1.3.3"

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -50,7 +50,8 @@ class TestSuitesService(
                     dateAdded = null,
                     testRootPath = FilenameUtils.separatorsToUnix(it.testRootPath),
                     testSuiteRepoUrl = it.testSuiteRepoUrl,
-                    language = it.language
+                    language = it.language,
+                    tags = it.tags?.let(TestSuite::tagsFromList),
                 )
             }
             .map { testSuite ->

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
@@ -64,4 +64,8 @@ class TestSuite(
                 this.language,
                 this.tagsAsList(),
             )
+
+    companion object {
+        fun tagsFromList(tags: List<String>) = tags.joinToString(separator = ",")
+    }
 }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
@@ -70,6 +70,7 @@ class TestSuite(
          * Concatenates [tags] using same format as [TestSuite.tagsAsList]
          *
          * @param tags list of tags
+         * @return representation of [tags] as a single string understood by [TestSuite.tagsAsList]
          */
         fun tagsFromList(tags: List<String>) = tags.joinToString(separator = ",")
     }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
@@ -66,6 +66,11 @@ class TestSuite(
             )
 
     companion object {
+        /**
+         * Concatenates [tags] using same format as [TestSuite.tagsAsList]
+         *
+         * @param tags list of tags
+         */
         fun tagsFromList(tags: List<String>) = tags.joinToString(separator = ",")
     }
 }


### PR DESCRIPTION
Follow up for #925. We now send tags in `TestSuiteDto`s, but don't use them in `findOne` before saving tests. This leads to errors after data is initially saved and `findOne` starts to return more than one entry.

Also specifies save-core version to `0.3.2` unitl https://github.com/saveourtool/save-cli/issues/429 is implemented. Then it should be integrated in save-cloud (e.g. we should check how cliArgs in orhcestrator will be constructed)