### PR TITLE
Remove `test-resources.base-path` in orchestrator because it's no more used

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,6 @@ services:
       - "5100:5100"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - save:/home/cnb
       - /home/saveu/executionLogs:/home/cnb/executionLogs/
       - /home/saveu/configs/orchestrator:/home/cnb/config
       - save-tmp-resources:/tmp

--- a/save-cloud-charts/save-cloud/templates/orchestrator-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/orchestrator-deployment.yaml
@@ -44,8 +44,6 @@ spec:
                   fieldPath: spec.nodeName
           volumeMounts:
             - {{ include "spring-boot.config-volume-mount" . | indent 14 | trim }}
-            - name: repos-storage
-              mountPath: /home/cnb
             - name: execution-logs-storage
               mountPath: /home/cnb/executionLogs/
           {{- include "spring-boot.management" .Values.orchestrator | nindent 10 }}
@@ -56,9 +54,6 @@ spec:
               memory: 300M
       volumes:
         - {{ include "spring-boot.config-volume" (dict "service" .Values.orchestrator) | indent 10 | trim }}
-        - name: repos-storage
-          hostPath:
-            path: /tmp/save/repos
         - name: execution-logs-storage
           # FixMe: Do we still need logs storage? All logs should be stored in Loki.
           emptyDir: {}

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -46,7 +46,6 @@ data class ConfigProperties(
     val agentsStartCheckIntervalMillis: Long,
 ) {
     /**
-     * @property basePath path to the root directory, where all test resources are stored
      * @property tmpPath Path to the directory, where test resources can be copied into when creating volumes with test resources.
      * Because a new volume can't be mounted to the running container (in this case, save-orchestrator), and to be able to fill
      * the created volume with resources, we need to use an intermediate container, which will start with that new volume mounted.
@@ -54,7 +53,6 @@ data class ConfigProperties(
      * as a host location for this shared mount.
      */
     data class TestResources(
-        val basePath: String,
         val tmpPath: String,
     )
 

--- a/save-orchestrator/src/main/resources/application-mac.properties
+++ b/save-orchestrator/src/main/resources/application-mac.properties
@@ -1,3 +1,2 @@
 orchestrator.executionLogs=/Users/Shared/cnb/executionLogs/
-orchestrator.testResources.basePath=/Users/Shared/cnb/repositories
 orchestrator.adjustResourceOwner=false

--- a/save-orchestrator/src/main/resources/application.properties
+++ b/save-orchestrator/src/main/resources/application.properties
@@ -5,7 +5,6 @@ spring.jmx.enabled=false
 management.endpoints.web.exposure.include=health,info,prometheus
 orchestrator.backend-url=http://backend:5800/internal
 orchestrator.execution-logs=/home/cnb/executionLogs/
-orchestrator.test-resources.base-path=/home/cnb/repositories
 orchestrator.test-resources.tmp-path=/tmp
 orchestrator.shutdown.checks-interval-millis=5000
 orchestrator.shutdown.graceful-timeout-seconds=60

--- a/save-orchestrator/src/test/kotlin/com/saveourtool/save/orchestrator/service/DockerServiceTest.kt
+++ b/save-orchestrator/src/test/kotlin/com/saveourtool/save/orchestrator/service/DockerServiceTest.kt
@@ -159,11 +159,6 @@ class DockerServiceTest {
         @JvmStatic
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("orchestrator.testResources.basePath") {
-                val tmpDir = createTempDirectory("repository")
-                Path(tmpDir.pathString, "foo").createDirectory()
-                tmpDir.pathString
-            }
             registry.add("orchestrator.backendUrl") {
                 mockServer.start()
                 "http://localhost:${mockServer.port}"

--- a/save-orchestrator/src/test/resources/application-mac.properties
+++ b/save-orchestrator/src/test/resources/application-mac.properties
@@ -1,2 +1,1 @@
 orchestrator.executionLogs=/Users/Shared/cnb/executionLogs/
-orchestrator.testResources.basePath=/Users/Shared/cnb/repositories

--- a/save-orchestrator/src/test/resources/application.properties
+++ b/save-orchestrator/src/test/resources/application.properties
@@ -1,6 +1,5 @@
 orchestrator.backendUrl=http://backend:5800/internal
 orchestrator.executionLogs=${user.home}/.save-cloud/test/executionLogs/
-orchestrator.testResources.basePath=${user.home}/.save-cloud/test/repositories
 orchestrator.test-resources.tmp-path=${user.home}/.save-cloud/test/tmp
 orchestrator.shutdown.checksIntervalMillis=100
 orchestrator.shutdown.gracefulTimeoutSeconds=60


### PR DESCRIPTION
After #958 this property is no more used; orchestrator doesn't need a shared mount with preprocessor anymore

* Remove property
* Remove mount in Docker
* Remove mount in k8s; preprocessor and orchestrator probably can run on different nodes now!