### PR TITLE
Change `jvmArgs` for open api spec only on CI

### DIFF
--- a/.github/workflows/backend-api-spec-update.yml
+++ b/.github/workflows/backend-api-spec-update.yml
@@ -26,6 +26,7 @@ jobs:
           gradle-version: wrapper
           arguments: |
             :save-backend:generateOpenApiDocs
+            -PisExecutedOnCI=true
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
 

--- a/save-backend/build.gradle.kts
+++ b/save-backend/build.gradle.kts
@@ -19,8 +19,10 @@ openApi {
     outputFileName.set("backend-api-docs.json")
     waitTimeInSeconds.set(120)
 
-    tasks.named<BootRun>("bootRun") {
-        jvmArgs("-Dbackend.fileStorage.location=\${HOME}/cnb/files")
+    findProperty("isExecutedOnCI")?.let {
+        tasks.named<BootRun>("bootRun") {
+            jvmArgs("-Dbackend.fileStorage.location=\${HOME}/cnb/files")
+        }
     }
 }
 


### PR DESCRIPTION
### What's done:
* Change `jvmArgs` for open api spec only on CI