### PR TITLE
Fix expanded row on ExecutionView.kt

### DIFF
--- a/save-backend/src/test/resources/files/debugInfo/1/WarnPlugin/test/src/test/suite1/testPath2-debug.json
+++ b/save-backend/src/test/resources/files/debugInfo/1/WarnPlugin/test/src/test/suite1/testPath2-debug.json
@@ -19,7 +19,7 @@
 	},
 	"testStatus": {
 		"type": "com.saveourtool.save.core.result.Pass",
-		"shortMessage": "Everything is awesome",
-		"message": "Everything is fine when you're part of the team"
+		"shortMessage": "Test passed normally",
+		"message": "Test passed normally"
 	}
 }

--- a/save-backend/src/test/resources/files/debugInfo/1/WarnPlugin/test/src/test/suite1/testPath2-debug.json
+++ b/save-backend/src/test/resources/files/debugInfo/1/WarnPlugin/test/src/test/suite1/testPath2-debug.json
@@ -1,0 +1,25 @@
+{
+	"testResultLocation": {
+		"testSuiteName": "test",
+		"pluginName": "WarnPlugin",
+		"testLocation": "src/test/suite1",
+		"testName": "testPath2"
+	},
+	"debugInfo": {
+		"execCmd": "python3 my-tool.py -i src/test/suite1/testPath2",
+		"stdout": "Processing file testPath2...",
+		"stderr": "",
+		"durationMillis": "200",
+		"countWarnings": {
+			"unmatched": "0",
+			"matched": "10",
+			"expected": "10",
+			"unexpected": "0"
+		}
+	},
+	"testStatus": {
+		"type": "com.saveourtool.save.core.result.Pass",
+		"shortMessage": "Everything is awesome",
+		"message": "Everything is fine when you're part of the team"
+	}
+}

--- a/save-backend/src/test/resources/files/debugInfo/1/WarnPlugin/test/src/test/suite2/testPath4-debug.json
+++ b/save-backend/src/test/resources/files/debugInfo/1/WarnPlugin/test/src/test/suite2/testPath4-debug.json
@@ -1,0 +1,25 @@
+{
+	"testResultLocation": {
+		"testSuiteName": "test",
+		"pluginName": "WarnPlugin",
+		"testLocation": "src/test/suite2",
+		"testName": "testPath4"
+	},
+	"debugInfo": {
+		"execCmd": "python3 my-tool.py -i src/test/suite2/testPath4",
+		"stdout": "",
+		"stderr": "python3: command not found",
+		"durationMillis": "20",
+		"countWarnings": {
+			"unmatched": "42",
+			"matched": "0",
+			"expected": "42",
+			"unexpected": "0"
+		}
+	},
+	"testStatus": {
+		"type": "com.saveourtool.save.core.result.Fail",
+		"shortReason": "We've got problems",
+		"reason": "There are 42 unexpected warnings."
+	}
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/domain/TestResultLocation.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/domain/TestResultLocation.kt
@@ -35,6 +35,6 @@ data class TestResultLocation(
 @Serializable
 data class TestResultDebugInfo(
     val testResultLocation: TestResultLocation,
-    val debugInfo: DebugInfo?,
+    val debugInfo: DebugInfo? = null,
     val testStatus: TestStatus,
 )


### PR DESCRIPTION
* Store additional information in a separate map instead of original object
* Add example debug info into backend's resources
* Make `TestResultDebugInfo.debugInfo` truly optional

Closes #942