### PR TITLE
Pull base image before creating container

### DIFF
--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
@@ -11,6 +11,7 @@ import com.saveourtool.save.orchestrator.runner.EXECUTION_DIR
 import com.saveourtool.save.orchestrator.runner.SAVE_AGENT_USER_HOME
 import com.saveourtool.save.orchestrator.service.DockerService
 import com.saveourtool.save.orchestrator.service.PersistentVolumeId
+import com.saveourtool.save.utils.debug
 
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd
@@ -18,7 +19,6 @@ import com.github.dockerjava.api.command.CreateContainerResponse
 import com.github.dockerjava.api.command.PullImageResultCallback
 import com.github.dockerjava.api.exception.DockerException
 import com.github.dockerjava.api.model.*
-import com.saveourtool.save.utils.debug
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
@@ -15,8 +15,10 @@ import com.saveourtool.save.orchestrator.service.PersistentVolumeId
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd
 import com.github.dockerjava.api.command.CreateContainerResponse
+import com.github.dockerjava.api.command.PullImageResultCallback
 import com.github.dockerjava.api.exception.DockerException
 import com.github.dockerjava.api.model.*
+import com.saveourtool.save.utils.debug
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
@@ -53,6 +55,13 @@ class DockerAgentRunner(
     ): List<String> {
         val (baseImageTag, agentRunCmd, pvId) = configuration
         require(pvId is DockerPvId) { "${DockerPersistentVolumeService::class.simpleName} can only operate with ${DockerPvId::class.simpleName}" }
+
+        logger.debug { "Pulling image ${configuration.imageTag}" }
+        dockerClient.pullImageCmd(configuration.imageTag)
+            .withRegistry("https://ghcr.io")
+            .exec(PullImageResultCallback())
+            .awaitCompletion()
+
         return (1..replicas).map { number ->
             logger.info("Creating a container #$number for execution.id=$executionId")
             createContainerFromImage(baseImageTag, pvId, workingDir, agentRunCmd, containerName("$executionId-$number")).also { agentId ->


### PR DESCRIPTION
Follow-up after #1030. Docker doesn't pull image when creating a container (these commands are combined only in `docker run`, which is part of docker CLI only, not API). If image is already preset, pull cmd is no-op.