### PR TITLE
Minor fixes on frontend

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
@@ -114,7 +114,7 @@ class LnkContestProjectController(
         @PathVariable contestName: String,
         authentication: Authentication,
     ): Mono<List<String>> = Mono.fromCallable {
-        lnkUserProjectService.getAllProjectsByUserId((authentication.details as AuthenticationDetails).id).filter { it.public }
+        lnkUserProjectService.getCreatedProjectsByUserId((authentication.details as AuthenticationDetails).id).filter { it.public }
     }
         .map { userProjects ->
             userProjects to lnkContestProjectService.getProjectsFromListAndContest(contestName, userProjects).map { it.project }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
@@ -114,7 +114,7 @@ class LnkContestProjectController(
         @PathVariable contestName: String,
         authentication: Authentication,
     ): Mono<List<String>> = Mono.fromCallable {
-        lnkUserProjectService.getCreatedProjectsByUserId((authentication.details as AuthenticationDetails).id).filter { it.public }
+        lnkUserProjectService.getNonDeletedProjectsByUserId((authentication.details as AuthenticationDetails).id).filter { it.public }
     }
         .map { userProjects ->
             userProjects to lnkContestProjectService.getProjectsFromListAndContest(contestName, userProjects).map { it.project }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/LnkUserProjectRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/LnkUserProjectRepository.kt
@@ -2,6 +2,7 @@ package com.saveourtool.save.backend.repository
 
 import com.saveourtool.save.entities.LnkUserProject
 import com.saveourtool.save.entities.Project
+import com.saveourtool.save.entities.ProjectStatus
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -35,9 +36,10 @@ interface LnkUserProjectRepository : BaseEntityRepository<LnkUserProject> {
 
     /**
      * @param userId
+     * @param status
      * @return List of [LnkUserProject] where user with [userId] is a member
      */
-    fun findByUserId(userId: Long): List<LnkUserProject>
+    fun findByUserIdAndProjectStatus(userId: Long, status: ProjectStatus): List<LnkUserProject>
 
     /**
      * Save [LnkUserProject] using only ids and role string.

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserProjectService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserProjectService.kt
@@ -6,6 +6,7 @@ import com.saveourtool.save.backend.utils.AuthenticationDetails
 import com.saveourtool.save.domain.Role
 import com.saveourtool.save.entities.LnkUserProject
 import com.saveourtool.save.entities.Project
+import com.saveourtool.save.entities.ProjectStatus
 import com.saveourtool.save.entities.User
 import com.saveourtool.save.utils.getHighestRole
 import org.springframework.data.domain.PageRequest
@@ -117,7 +118,7 @@ class LnkUserProjectService(
      * @param userId
      * @return list of [Project]s that are connected to user with [userId]
      */
-    fun getAllProjectsByUserId(userId: Long): List<Project> = lnkUserProjectRepository.findByUserId(userId)
+    fun getCreatedProjectsByUserId(userId: Long): List<Project> = lnkUserProjectRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.CREATED)
         .mapNotNull { it.project }
 
     /**

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserProjectService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserProjectService.kt
@@ -118,7 +118,7 @@ class LnkUserProjectService(
      * @param userId
      * @return list of [Project]s that are connected to user with [userId]
      */
-    fun getCreatedProjectsByUserId(userId: Long): List<Project> = lnkUserProjectRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.CREATED)
+    fun getNonDeletedProjectsByUserId(userId: Long): List<Project> = lnkUserProjectRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.CREATED)
         .mapNotNull { it.project }
 
     /**

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/Project.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/Project.kt
@@ -37,7 +37,7 @@ data class Project(
         foreignKey = ForeignKey(),
         referencedColumnName = "",
         unique = false,
-        nullable = true,
+        nullable = false,
         insertable = true,
         updatable = true,
         columnDefinition = "",

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
@@ -6,6 +6,9 @@
 
 package com.saveourtool.save.frontend.components.basic
 
+import com.saveourtool.save.frontend.externals.fontawesome.faTimesCircle
+import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
+import com.saveourtool.save.frontend.externals.modal.loaderModalStyle
 import com.saveourtool.save.frontend.externals.modal.modal
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.utils.URL_PATH_DELIMITER
@@ -13,9 +16,11 @@ import com.saveourtool.save.utils.URL_PATH_DELIMITER
 import csstype.ClassName
 import org.w3c.fetch.Headers
 import react.*
+import react.dom.aria.ariaLabel
 import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.h5
 import react.dom.html.ReactHTML.option
 import react.dom.html.ReactHTML.select
 
@@ -76,7 +81,7 @@ external interface ContestEnrollerProps : Props {
  * @param onResponse callback invoked when enrollment response is received
  * @param onCloseButtonPressed callback invoked when close button was clicked
  */
-@Suppress("TOO_MANY_PARAMETERS", "LongParameterList")
+@Suppress("TOO_MANY_PARAMETERS", "LongParameterList", "TOO_LONG_FUNCTION")
 fun ChildrenBuilder.showContestEnrollerModal(
     isModalOpen: Boolean,
     selectedNameProps: NameProps,
@@ -85,19 +90,35 @@ fun ChildrenBuilder.showContestEnrollerModal(
 ) {
     modal { props ->
         props.isOpen = isModalOpen
-        contestEnrollerComponent {
-            nameProps = selectedNameProps
-            onResponseChanged = onResponse
-        }
+        props.style = loaderModalStyle
         div {
-            className = ClassName("d-sm-flex align-items-center justify-content-center mt-4")
-            button {
-                className = ClassName("btn btn-primary")
-                type = ButtonType.button
-                onClick = {
-                    onCloseButtonPressed()
+            className = ClassName("modal-dialog")
+            div {
+                className = ClassName("modal-content")
+                div {
+                    className = ClassName("modal-header")
+                    h5 {
+                        className = ClassName("modal-title")
+                        +"Enroll for a contest"
+                    }
+                    button {
+                        type = ButtonType.button
+                        className = ClassName("close")
+                        asDynamic()["data-dismiss"] = "modal"
+                        ariaLabel = "Close"
+                        fontAwesomeIcon(icon = faTimesCircle)
+                        onClick = {
+                            onCloseButtonPressed()
+                        }
+                    }
                 }
-                +"Cancel"
+                div {
+                    className = ClassName("modal-body")
+                    contestEnrollerComponent {
+                        nameProps = selectedNameProps
+                        onResponseChanged = onResponse
+                    }
+                }
             }
         }
     }
@@ -143,10 +164,7 @@ private fun contestEnrollerComponent() = FC<ContestEnrollerProps> { props ->
             } else {
                 "$apiUrl/contests/$contestName/eligible-projects"
             },
-            headers = Headers().also {
-                it.set("Accept", "application/json")
-                it.set("Content-Type", "application/json")
-            },
+            headers = jsonHeaders,
             loadingHandler = ::noopLoadingHandler,
         )
             .unsafeMap {
@@ -203,7 +221,7 @@ private fun contestEnrollerComponent() = FC<ContestEnrollerProps> { props ->
             }
         }
         div {
-            className = ClassName("d-flex justify-content-center")
+            className = ClassName("d-flex justify-content-center mt-3")
             button {
                 className = ClassName("btn btn-primary d-flex justify-content-center")
                 +"Participate"

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
@@ -8,8 +8,8 @@ package com.saveourtool.save.frontend.components.basic
 
 import com.saveourtool.save.frontend.externals.fontawesome.faTimesCircle
 import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
-import com.saveourtool.save.frontend.externals.modal.loaderModalStyle
 import com.saveourtool.save.frontend.externals.modal.modal
+import com.saveourtool.save.frontend.externals.modal.transparentModalStyle
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.utils.URL_PATH_DELIMITER
 
@@ -90,9 +90,9 @@ fun ChildrenBuilder.showContestEnrollerModal(
 ) {
     modal { props ->
         props.isOpen = isModalOpen
-        props.style = loaderModalStyle
+        props.style = transparentModalStyle
         div {
-            className = ClassName("modal-dialog")
+            className = ClassName("modal-dialog modal-dialog-centered")
             div {
                 className = ClassName("modal-content")
                 div {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelector.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelector.kt
@@ -7,9 +7,7 @@
 package com.saveourtool.save.frontend.components.basic.testsuiteselector
 
 import com.saveourtool.save.frontend.externals.fontawesome.*
-import com.saveourtool.save.frontend.externals.modal.CssProperties
-import com.saveourtool.save.frontend.externals.modal.Styles
-import com.saveourtool.save.frontend.externals.modal.modal
+import com.saveourtool.save.frontend.externals.modal.*
 
 import csstype.ClassName
 import react.*
@@ -18,8 +16,6 @@ import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h5
-
-import kotlin.js.json
 
 val testSuiteSelector = testSuiteSelector()
 
@@ -65,18 +61,9 @@ fun ChildrenBuilder.showTestSuiteSelectorModal(
 ) {
     modal { props ->
         props.isOpen = isOpen
-        props.style = Styles(
-            content = json(
-                "top" to "15%",
-                "left" to "30%",
-                "right" to "30%",
-                "bottom" to "5%",
-                "position" to "absolute",
-                "overflow" to "hide"
-            ).unsafeCast<CssProperties>()
-        )
+        props.style = transparentModalStyle
         div {
-            className = ClassName("modal-dialog modal-dialog-scrollable")
+            className = ClassName("modal-dialog modal-lg modal-dialog-scrollable")
             div {
                 className = ClassName("modal-content")
                 div {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/CreationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/CreationView.kt
@@ -181,10 +181,10 @@ class CreationView : AbstractView<Props, ProjectSaveViewState>(true) {
                                                     }
                                             }
                                             dataToString = { it }
+                                            selectedValue = state.projectCreationRequest.organizationName
                                             onChangeFun = { value ->
                                                 setState {
-                                                    projectCreationRequest =
-                                                            projectCreationRequest.copy(organizationName = value?.let { value } ?: "")
+                                                    projectCreationRequest = projectCreationRequest.copy(organizationName = value ?: "")
                                                 }
                                             }
                                         }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/modal/Modal.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/modal/Modal.kt
@@ -20,6 +20,18 @@ private val defaultModalStyle = Styles(
     ).unsafeCast<CssProperties>()
 )
 
+val transparentModalStyle = Styles(
+    content = json(
+        "top" to "5%",
+        "left" to "5%",
+        "right" to "5%",
+        "bottom" to "5%",
+        "overflow" to "hide",
+        "background-color" to "transparent",
+        "border" to "1px solid rgba(255, 255, 255, 0.01)"
+    ).unsafeCast<CssProperties>()
+)
+
 val loaderModalStyle = Styles(
     content = json(
         "top" to "25%",


### PR DESCRIPTION
This PR closes #1057

### What's done:
 - [x] Fixed a bug with select form in `CreationView` - props were not set correctly so that the form didn't work fine
 - [x] Fixed a bug with `500` when `eligible-projects` endpoint is called - `eligible-projects` endpoint used to fetch all the projects (even deleted) as well as we used to allow Organization to be nullable implicitly - now only created projects are fetched by the endpoint  and organization is defiantly non-nullable
 - [x] Improved styles of `ContestEnroller`
 - [x] Added new style for react modals in order to provide better compatibility with bootstrap modals
 
### How it looks:
![2022-08-18 в 12 51 47](https://user-images.githubusercontent.com/35039155/185367668-3093cce9-8447-40a6-b0e3-de2f70c5a88c.png)
![2022-08-18 в 12 52 18](https://user-images.githubusercontent.com/35039155/185367686-b944a50e-ceb2-4518-9660-0d50655afac5.png)

