### PR TITLE
Hotfix: Set correct path to save-cli in `deploy_images.yml`

### DIFF
--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -71,8 +71,6 @@ jobs:
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
       - name: Set environment variable with save-cli version
         run: |
-          mkdir -p save-cloud/save-orchestrator/build/resources/main
-          find save/save-cli/build/bin/linuxX64/releaseExecutable -name "save-*.kexe" -exec cp {} save-cloud/save-orchestrator/build/resources/main \;
           find save/save-cli/build/bin/linuxX64/releaseExecutable -name "save-*.kexe" -exec sh -c 'printf "$1" | sed -r "s/.*save-(.*)-linuxX64.kexe/\1/" | echo "SAVE_CLI_VERSION=$(cat)" >> $GITHUB_ENV' _ {} \;
       - uses: gradle/gradle-build-action@v2
         with:
@@ -87,6 +85,7 @@ jobs:
             -Porg.gradle.caching=true
             -Pdetekt.multiplatform.disabled=true
             -PsaveCliVersion=${{ env.SAVE_CLI_VERSION }}
+            -PsaveCliPath=../save/save-cli/build/bin/linuxX64/releaseExecutable
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
             ${{ env.ADDITIONAL_GRADLE_OPTS }}

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -85,7 +85,7 @@ jobs:
             -Porg.gradle.caching=true
             -Pdetekt.multiplatform.disabled=true
             -PsaveCliVersion=${{ env.SAVE_CLI_VERSION }}
-            -PsaveCliPath=file://${{ env.HOME }}/save/save-cli/build/bin/linuxX64/releaseExecutable
+            -PsaveCliPath=file:///home/runner/save/save-cli/build/bin/linuxX64/releaseExecutable
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
             ${{ env.ADDITIONAL_GRADLE_OPTS }}

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -85,7 +85,7 @@ jobs:
             -Porg.gradle.caching=true
             -Pdetekt.multiplatform.disabled=true
             -PsaveCliVersion=${{ env.SAVE_CLI_VERSION }}
-            -PsaveCliPath=file://${{ env.GITHUB_WORKSPACE }}/save/save-cli/build/bin/linuxX64/releaseExecutable
+            -PsaveCliPath=file://${{ github.workspace }}/save/save-cli/build/bin/linuxX64/releaseExecutable
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
             ${{ env.ADDITIONAL_GRADLE_OPTS }}

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -85,7 +85,7 @@ jobs:
             -Porg.gradle.caching=true
             -Pdetekt.multiplatform.disabled=true
             -PsaveCliVersion=${{ env.SAVE_CLI_VERSION }}
-            -PsaveCliPath=file:///home/runner/save/save-cli/build/bin/linuxX64/releaseExecutable
+            -PsaveCliPath=file://${{ env.GITHUB_WORKSPACE }}/save/save-cli/build/bin/linuxX64/releaseExecutable
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
             ${{ env.ADDITIONAL_GRADLE_OPTS }}

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -85,7 +85,7 @@ jobs:
             -Porg.gradle.caching=true
             -Pdetekt.multiplatform.disabled=true
             -PsaveCliVersion=${{ env.SAVE_CLI_VERSION }}
-            -PsaveCliPath=../save/save-cli/build/bin/linuxX64/releaseExecutable
+            -PsaveCliPath=file://${{ env.HOME }}/save/save-cli/build/bin/linuxX64/releaseExecutable
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
             ${{ env.ADDITIONAL_GRADLE_OPTS }}


### PR DESCRIPTION
Caused by changes in ded475278ee66d06787741c523777ce25baa84b9, where I've changed configuration for `Download` tasks for save-agent and save-cli. It now works better and doesn't rely on manual copying, like it used to be in this workflow.

Example run with these changes: https://github.com/saveourtool/save-cloud/runs/8017837622?check_suite_focus=true