### PR TITLE
Various improvements in orchestrator

### DIFF
--- a/save-cloud-charts/save-cloud/README.md
+++ b/save-cloud-charts/save-cloud/README.md
@@ -31,7 +31,7 @@ $ helm install save-cloud save-cloud-0.1.0.tgz --namespace save-cloud
 * Environment should be prepared:
   ```bash
   minikube ssh
-  docker@minikube:~$ for d in repos volumes resources; do sudo mkdir -p /tmp/save/$d && sudo chown -R 1000:100 /tmp/save/$d; done
+  docker@minikube:~$ for d in repos volumes resources; do sudo mkdir -p /tmp/save/$d && sudo chown -R 1000:1000 /tmp/save/$d; done
   ```
 * Install Helm chart using `values-minikube.yaml`: 
   ```bash

--- a/save-cloud-charts/save-cloud/templates/_helpers.tpl
+++ b/save-cloud-charts/save-cloud/templates/_helpers.tpl
@@ -51,7 +51,7 @@ lifecycle:
 
 {{/* Common configuration of deployment for spring-boot microservice */}}
 {{- define "spring-boot.common" -}}
-image: '{{ .Values.imageRegistry }}/{{ .service.imageName }}:{{ .Values.dockerTag }}'
+image: '{{ .Values.imageRegistry }}/{{ .service.imageName }}:{{ or .service.dockerTag .Values.dockerTag }}'
 imagePullPolicy: {{ .Values.pullPolicy }}
 ports:
   - name: http

--- a/save-cloud-charts/save-cloud/templates/_helpers.tpl
+++ b/save-cloud-charts/save-cloud/templates/_helpers.tpl
@@ -1,13 +1,13 @@
 {{- define "common.labels" -}}
 io.kompose.service: {{ .service.name }}
-version: {{ .Values.dockerTag }}
+version: {{ or .service.dockerTag .Values.dockerTag }}
 env: {{ .Values.env }}
 prometheus-job: {{ .service.imageName }}
 {{- end }}
 
 {{- define "pod.common.labels" }}
 io.kompose.service: {{ .service.name }}
-version: {{ .Values.dockerTag }}
+version: {{ or .service.dockerTag .Values.dockerTag }}
 {{- end }}
 
 {{- define "pod.common.annotations" }}

--- a/save-cloud-charts/save-cloud/templates/_helpers.tpl
+++ b/save-cloud-charts/save-cloud/templates/_helpers.tpl
@@ -7,6 +7,7 @@ prometheus-job: {{ .service.imageName }}
 
 {{- define "pod.common.labels" }}
 io.kompose.service: {{ .service.name }}
+version: {{ .Values.dockerTag }}
 {{- end }}
 
 {{- define "pod.common.annotations" }}

--- a/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
@@ -48,6 +48,8 @@ spec:
           args:
             - clone
             - --single-branch
+            - --branch
+            - {{ .Values.mysql.migrations.branch | default "master" }}
             - --
             - https://github.com/saveourtool/save-cloud.git
             - /data

--- a/save-cloud-charts/save-cloud/templates/gateway-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/gateway-deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: gateway
+  replicas: 1
   template:
     metadata:
       labels:

--- a/save-cloud-charts/save-cloud/templates/orchestrator-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/orchestrator-configmap.yaml
@@ -9,7 +9,6 @@ data:
     orchestrator.kubernetes.apiServerUrl=http://kubernetes.default.svc
     orchestrator.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
     orchestrator.kubernetes.namespace=${POD_NAMESPACE}
-    orchestrator.kubernetes.pvcMountPath=/home/save-agent/resources
 
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*

--- a/save-cloud-charts/save-cloud/templates/orchestrator-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/orchestrator-deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: orchestrator
+  replicas: 1
   template:
     metadata:
       labels:

--- a/save-cloud-charts/save-cloud/values-minikube.yaml
+++ b/save-cloud-charts/save-cloud/values-minikube.yaml
@@ -16,12 +16,6 @@ orchestrator:
     orchestrator.docker.host=tcp://localhost:2376
     logging.level.com.saveourtool=DEBUG
     orchestrator.kubernetes.useGvisor=false
-    orchestrator.kubernetes.pvcAnnotations=
-    orchestrator.kubernetes.pvcSize=5Gi
-    orchestrator.kubernetes.pvcStorageSpec=hostPath:\n\
-    \  path: /tmp/save/volumes\n\
-    \accessModes:\n\
-    \- ReadWriteMany
 mysql:
   external: false
   ip: nil

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -4,7 +4,6 @@
 
 package com.saveourtool.save.orchestrator.config
 
-import com.saveourtool.save.orchestrator.runner.EXECUTION_DIR
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 
@@ -81,6 +80,10 @@ data class ConfigProperties(
      * to authenticate orchestrator to the API server
      * @property namespace Kubernetes namespace, into which agents will be deployed.
      * @property useGvisor if true, will try to use gVisor's runsc runtime for starting agents
+     * @property agentCpuRequests configures `resources.requests.cpu` for agent pods
+     * @property agentCpuLimits configures `resources.limits.cpu` for agent pods
+     * @property agentMemoryRequests configures `resources.requests.memory` for agent pods
+     * @property agentMemoryLimits configures `resources.requests.memory` for agent pods
      */
     data class KubernetesSettings(
         val apiServerUrl: String,

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -81,20 +81,16 @@ data class ConfigProperties(
      * to authenticate orchestrator to the API server
      * @property namespace Kubernetes namespace, into which agents will be deployed.
      * @property useGvisor if true, will try to use gVisor's runsc runtime for starting agents
-     * @property pvcAnnotations Kubernetes annotations for each PVC that will be generated to store resources for an execution
-     * @property pvcSize requested size of the generated PVC
-     * @property pvcStorageSpec Additional YAML spec for PVC
-     * @property pvcMountPath mount point for the PV with test resources
      */
     data class KubernetesSettings(
         val apiServerUrl: String,
         val serviceAccount: String,
         val namespace: String,
         val useGvisor: Boolean,
-        val pvcAnnotations: String?,
-        val pvcSize: String,
-        val pvcStorageSpec: String,
-        val pvcMountPath: String = EXECUTION_DIR,
+        val agentCpuRequests: String = "100m",
+        val agentCpuLimits: String = "500m",
+        val agentMemoryRequests: String = "300m",
+        val agentMemoryLimits: String = "500m",
     )
 
     /**

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
@@ -13,6 +13,7 @@ import com.saveourtool.save.orchestrator.service.DockerService
 import com.saveourtool.save.orchestrator.service.HeartBeatInspector
 import com.saveourtool.save.orchestrator.service.areAgentsHaveStarted
 import com.saveourtool.save.utils.debug
+import com.saveourtool.save.utils.warn
 
 import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.PostMapping
@@ -155,7 +156,10 @@ class HeartbeatController(private val agentService: AgentService,
             .any { it }
             .doOnNext { successfullyStopped ->
                 if (!successfullyStopped) {
-                    logger.warn("Agent id=$agentId is not stopped in $shutdownTimeoutSeconds seconds after ${TerminateResponse::class.simpleName} signal, will add it to crashed list")
+                    logger.warn {
+                        "Agent id=$agentId is not stopped in $shutdownTimeoutSeconds seconds after ${TerminateResponse::class.simpleName} signal," +
+                                " will add it to crashed list"
+                    }
                     heartBeatInspector.watchCrashedAgent(agentId)
                 } else {
                     logger.debug { "Agent id=$agentId has stopped after ${TerminateResponse::class.simpleName} signal" }

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
@@ -143,9 +143,9 @@ class HeartbeatController(private val agentService: AgentService,
     }
 
     private fun ensureGracefulShutdown(agentId: String) {
-        val shutdownTimeout = configProperties.shutdown.gracefulTimeoutSeconds.seconds
+        val shutdownTimeoutSeconds = configProperties.shutdown.gracefulTimeoutSeconds.seconds
         val numChecks: Int = configProperties.shutdown.gracefulNumChecks
-        Flux.interval((shutdownTimeout / numChecks).toJavaDuration())
+        Flux.interval((shutdownTimeoutSeconds / numChecks).toJavaDuration())
             .take(numChecks.toLong())
             .map {
                 dockerService.isAgentStopped(agentId)
@@ -155,7 +155,7 @@ class HeartbeatController(private val agentService: AgentService,
             .any { it }
             .doOnNext { successfullyStopped ->
                 if (!successfullyStopped) {
-                    logger.warn("Agent id=$agentId is not stopped in 60 seconds after ${TerminateResponse::class.simpleName} signal, will add it to crashed list")
+                    logger.warn("Agent id=$agentId is not stopped in $shutdownTimeoutSeconds seconds after ${TerminateResponse::class.simpleName} signal, will add it to crashed list")
                     heartBeatInspector.watchCrashedAgent(agentId)
                 } else {
                     logger.debug { "Agent id=$agentId has stopped after ${TerminateResponse::class.simpleName} signal" }

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -22,8 +22,12 @@ import org.springframework.stereotype.Component
 @Profile("kubernetes")
 class KubernetesManager(
     private val kc: KubernetesClient,
-    private val configProperties: ConfigProperties,
+    configProperties: ConfigProperties,
 ) : AgentRunner {
+    private val kubernetesSettings = requireNotNull(configProperties.kubernetes) {
+        "orchestrator.kubernetes.* properties are required in this profile"
+    }
+
     @Suppress(
         "TOO_LONG_FUNCTION",
         "LongMethod",
@@ -38,7 +42,6 @@ class KubernetesManager(
         val baseImageTag = configuration.imageTag
         val agentRunCmd = configuration.runCmd
         val workingDir = configuration.workingDir
-        requireNotNull(configProperties.kubernetes)
         // fixme: pass image name instead of ID from the outside
 
         // Creating Kubernetes objects that will be responsible for lifecycle of save-agents.
@@ -54,7 +57,7 @@ class KubernetesManager(
                 backoffLimit = 0
                 template = PodTemplateSpec().apply {
                     spec = PodSpec().apply {
-                        if (configProperties.kubernetes.useGvisor) {
+                        if (kubernetesSettings.useGvisor) {
                             nodeSelector = mapOf(
                                 "gvisor" to "enabled"
                             )
@@ -64,7 +67,9 @@ class KubernetesManager(
                             labels = mapOf(
                                 "executionId" to executionId.toString(),
                                 // "baseImageName" to baseImageName
-                                "io.kompose.service" to "save-agent"
+                                "io.kompose.service" to "save-agent",
+                                // todo: should be set to version of agent that is stored in backend...
+//                                "version" to SAVE_CORE_VERSION
                             )
                         }
                         // If agent fails, we should handle it manually (update statuses, attempt restart etc.)
@@ -175,7 +180,7 @@ class KubernetesManager(
 
         this.workingDir = workingDir
 
-        resources = with(configProperties.kubernetes!!) {
+        resources = with(kubernetesSettings) {
             ResourceRequirements().apply {
                 requests = mapOf(
                     "cpu" to Quantity(agentCpuRequests),

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -174,6 +174,19 @@ class KubernetesManager(
         this.args = listOf(agentRunCmd.last())
 
         this.workingDir = workingDir
+
+        resources = with(configProperties.kubernetes!!) {
+            ResourceRequirements().apply {
+                requests = mapOf(
+                    "cpu" to Quantity(agentCpuRequests),
+                    "memory" to Quantity(agentMemoryRequests),
+                )
+                limits = mapOf(
+                    "cpu" to Quantity(agentCpuLimits),
+                    "memory" to Quantity(agentMemoryLimits),
+                )
+            }
+        }
     }
 
     private fun agentIdEnv(agentIdEnv: AgentEnvName) = EnvVar().apply {

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -69,7 +69,7 @@ class KubernetesManager(
                                 // "baseImageName" to baseImageName
                                 "io.kompose.service" to "save-agent",
                                 // todo: should be set to version of agent that is stored in backend...
-//                                "version" to SAVE_CORE_VERSION
+                                // "version" to SAVE_CORE_VERSION
                             )
                         }
                         // If agent fails, we should handle it manually (update statuses, attempt restart etc.)

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/DockerService.kt
@@ -21,7 +21,6 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Flux
 
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 import kotlin.io.path.*
@@ -125,14 +124,14 @@ class DockerService(
      */
     @Suppress("TOO_MANY_LINES_IN_LAMBDA", "FUNCTION_BOOLEAN_PREFIX")
     fun stopAgents(agentIds: Collection<String>) =
-        try {
-            agentIds.all { agentId ->
-                agentRunner.stopByAgentId(agentId)
+            try {
+                agentIds.all { agentId ->
+                    agentRunner.stopByAgentId(agentId)
+                }
+            } catch (e: AgentRunnerException) {
+                log.error("Error while stopping agents $agentIds", e)
+                false
             }
-        } catch (e: AgentRunnerException) {
-            log.error("Error while stopping agents $agentIds", e)
-            false
-        }
 
     /**
      * Check whether the agent agentId is stopped

--- a/save-orchestrator/src/test/kotlin/com/saveourtool/save/orchestrator/docker/KubernetesManagerTest.kt
+++ b/save-orchestrator/src/test/kotlin/com/saveourtool/save/orchestrator/docker/KubernetesManagerTest.kt
@@ -27,7 +27,7 @@ import java.net.HttpURLConnection
 @ExtendWith(SpringExtension::class, KubernetesMockServerExtension::class)
 @EnableConfigurationProperties(ConfigProperties::class)
 @EnableKubernetesMockClient
-@TestPropertySource("classpath:application.properties")
+@TestPropertySource("classpath:application.properties", "classpath:application-kubernetes.properties")
 class KubernetesManagerTest {
     @Autowired private lateinit var configProperties: ConfigProperties
     private lateinit var kubernetesManager: KubernetesManager

--- a/save-orchestrator/src/test/resources/application-kubernetes.properties
+++ b/save-orchestrator/src/test/resources/application-kubernetes.properties
@@ -1,0 +1,4 @@
+orchestrator.kubernetes.apiServerUrl=http://kubernetes.default.svc
+orchestrator.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
+orchestrator.kubernetes.namespace=${POD_NAMESPACE}
+orchestrator.kubernetes.useGvisor=false


### PR DESCRIPTION
* Remove properties for PVC
* Add properties for agent pod requests/limits (last part of and closes #783)
* Remove `isAgentsStopInProgress` completely (closes #154 as described in the comment there)
* Helm: Make gateway and orchestrator single-replica
* Helm: Add version to common pod labels
* Helm: Support different image versions per service
* Helm: Support running DB migrations from a different branch