### PR TITLE
[Gradle] Use custom save-cli distribution only with snapshot

### DIFF
--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/VersioningConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/VersioningConfiguration.kt
@@ -121,4 +121,4 @@ fun Project.getSaveCliPath(): String {
     return "$saveCliPath/save-$saveCliVersion-linuxX64.kexe"
 }
 
-fun String.isSnapshot() = endsWith("SNAPSHOT")
+private fun String.isSnapshot() = endsWith("SNAPSHOT")

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/VersioningConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/VersioningConfiguration.kt
@@ -84,7 +84,7 @@ fun Project.registerSaveCliVersionCheckTask() {
             (System.currentTimeMillis() - file.lastModified()) < Duration.ofMinutes(10).toMillis()
         }
         doFirst {
-            val version = if (saveCoreVersion.endsWith("SNAPSHOT")) {
+            val version = if (saveCoreVersion.isSnapshot()) {
                 // try to get the required version of cli
                 findProperty("saveCliVersion") as String? ?: run {
                     // as fallback, use latest release to allow the project to build successfully
@@ -117,5 +117,9 @@ fun Project.readSaveCliVersion(): String {
 fun Project.getSaveCliPath(): String {
     val saveCliVersion = readSaveCliVersion()
     val saveCliPath = findProperty("saveCliPath") as String? ?: "https://github.com/saveourtool/save-cli/releases/download/v$saveCliVersion"
+    val saveCliPath = findProperty("saveCliPath")?.takeIf { saveCliVersion.isSnapshot() } as String?
+        ?: "https://github.com/saveourtool/save-cli/releases/download/v$saveCliVersion"
     return "$saveCliPath/save-$saveCliVersion-linuxX64.kexe"
 }
+
+fun String.isSnapshot() = endsWith("SNAPSHOT")

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/VersioningConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/VersioningConfiguration.kt
@@ -116,7 +116,6 @@ fun Project.readSaveCliVersion(): String {
  */
 fun Project.getSaveCliPath(): String {
     val saveCliVersion = readSaveCliVersion()
-    val saveCliPath = findProperty("saveCliPath") as String? ?: "https://github.com/saveourtool/save-cli/releases/download/v$saveCliVersion"
     val saveCliPath = findProperty("saveCliPath")?.takeIf { saveCliVersion.isSnapshot() } as String?
         ?: "https://github.com/saveourtool/save-cli/releases/download/v$saveCliVersion"
     return "$saveCliPath/save-$saveCliVersion-linuxX64.kexe"


### PR DESCRIPTION
Respect values of `-PsaveCliPath` and `-PsaveCliVersion` only if save-core version in `libs.versions.toml` ends with `-SNAPSHOT`