### PR TITLE
Don't recalculate counters in Execution if value is `NOT_APPLICABLE`

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
@@ -167,6 +167,7 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
         "LongMethod",
         "MAGIC_NUMBER",
         "MagicNumber",
+        "PARAMETER_NAME_IN_OUTER_LAMBDA",
     )
     @Transactional
     fun saveTestResult(testExecutionsDtos: List<TestExecutionDto>): List<TestExecutionDto> {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
@@ -214,10 +214,10 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
                     it.unexpected = testExecDto.unexpected
 
                     with(counters) {
-                        unmatchedChecks += unmatchedChecks.increaseIfApplicable(testExecDto.unmatched)
-                        matchedChecks += matchedChecks.increaseIfApplicable(testExecDto.matched)
-                        expectedChecks += expectedChecks.increaseIfApplicable(testExecDto.expected)
-                        unexpectedChecks += unexpectedChecks.increaseIfApplicable(testExecDto.unexpected)
+                        unmatchedChecks += testExecDto.unmatched.orZeroIfNotApplicable()
+                        matchedChecks += testExecDto.matched.orZeroIfNotApplicable()
+                        expectedChecks += testExecDto.expected.orZeroIfNotApplicable()
+                        unexpectedChecks += testExecDto.unexpected.orZeroIfNotApplicable()
                     }
 
                     testExecutionRepository.save(it)
@@ -356,9 +356,7 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
         }
     }
 
-    private fun Long.increaseIfApplicable(delta: Long?) = takeUnless { CountWarnings.isNotApplicable(it.toInt()) }
-        ?.plus(delta ?: 0L)
-        ?: 0L
+    private fun Long?.orZeroIfNotApplicable() = this?.takeUnless { CountWarnings.isNotApplicable(it.toInt()) } ?: 0
 
     @Suppress(
         "KDOC_NO_CONSTRUCTOR_PROPERTY",

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
@@ -212,7 +212,7 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
                     it.expected = testExecDto.expected
                     it.unexpected = testExecDto.unexpected
 
-                    with (counters) {
+                    with(counters) {
                         unmatchedChecks += unmatchedChecks.increaseIfApplicable(testExecDto.unmatched)
                         matchedChecks += matchedChecks.increaseIfApplicable(testExecDto.matched)
                         expectedChecks += expectedChecks.increaseIfApplicable(testExecDto.expected)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestExecutionService.kt
@@ -14,6 +14,8 @@ import com.saveourtool.save.entities.Test
 import com.saveourtool.save.entities.TestExecution
 import com.saveourtool.save.execution.TestExecutionFilters
 import com.saveourtool.save.test.TestDto
+import com.saveourtool.save.utils.ScoreType
+import com.saveourtool.save.utils.calculateScore
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.getLogger
 
@@ -242,6 +244,8 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
                     matchedChecks += counters.matchedChecks
                     expectedChecks += counters.expectedChecks
                     unexpectedChecks += counters.unexpectedChecks
+
+                    score = toDto().calculateScore(scoreType = ScoreType.F_MEASURE)
                 }
                 executionRepository.save(execution)
             }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ExecutionLabels.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ExecutionLabels.kt
@@ -7,7 +7,6 @@
 
 package com.saveourtool.save.frontend.components.basic
 
-import com.saveourtool.save.core.result.CountWarnings
 import com.saveourtool.save.execution.ExecutionDto
 import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.frontend.externals.fontawesome.faRedo

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ExecutionLabels.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ExecutionLabels.kt
@@ -101,25 +101,25 @@ internal class ExecutionStatisticsValues(executionDto: ExecutionDto?) {
             ?: "0"
         this.precisionRate = executionDto
             ?.let {
-                if (isAllApplicable(it.matchedChecks, it.unexpectedChecks)) {
-                    "${it.getPrecisionRate()}"
-                } else {
+                if (isNoneApplicable(it.matchedChecks, it.unexpectedChecks)) {
                     "N/A"
+                } else {
+                    "${it.getPrecisionRate()}"
                 }
             }
             ?: "0"
         this.recallRate = executionDto
             ?.let {
-                if (isAllApplicable(it.matchedChecks, it.unmatchedChecks)) {
-                    "${it.getRecallRate()}"
-                } else {
+                if (isNoneApplicable(it.matchedChecks, it.unmatchedChecks)) {
                     "N/A"
+                } else {
+                    "${it.getRecallRate()}"
                 }
             }
             ?: "0"
     }
 
-    private fun isAllApplicable(vararg values: Long): Boolean = values.all { !CountWarnings.isNotApplicable(it.toInt()) }
+    private fun isNoneApplicable(vararg values: Long): Boolean = values.all { CountWarnings.isNotApplicable(it.toInt()) }
 }
 
 /**

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ExecutionLabels.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ExecutionLabels.kt
@@ -101,25 +101,15 @@ internal class ExecutionStatisticsValues(executionDto: ExecutionDto?) {
             ?: "0"
         this.precisionRate = executionDto
             ?.let {
-                if (isNoneApplicable(it.matchedChecks, it.unexpectedChecks)) {
-                    "N/A"
-                } else {
-                    "${it.getPrecisionRate()}"
-                }
+                "${it.getPrecisionRate()}"
             }
             ?: "0"
         this.recallRate = executionDto
             ?.let {
-                if (isNoneApplicable(it.matchedChecks, it.unmatchedChecks)) {
-                    "N/A"
-                } else {
-                    "${it.getRecallRate()}"
-                }
+                "${it.getRecallRate()}"
             }
             ?: "0"
     }
-
-    private fun isNoneApplicable(vararg values: Long): Boolean = values.all { CountWarnings.isNotApplicable(it.toInt()) }
 }
 
 /**


### PR DESCRIPTION
* Store aggregated metrics in Execution excluding `NOT_APPLICABLE` metrics from individual test executions (until we can calculate scores for other types of plugins too)
* Change logic of dispaly on frontend: don't calculate metrics only if all test executions under an execution are `NOT_APPLICABLE`; otherwise use filtered data from Execution

Related to #1115