### PR TITLE
When creating a new project, pre-select the organization if possible

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
@@ -110,6 +110,11 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
             projectName = params["projectName"]!!
         }
     }
+    private val creationView: FC<Props> = withRouter { location, params ->
+        CreationView::class.react {
+            organizationName = params["owner"]
+        }
+    }
     private val organizationView: FC<Props> = withRouter { _, params ->
         OrganizationView::class.react {
             organizationName = params["owner"]!!
@@ -271,6 +276,11 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
                                 Route {
                                     path = "/${FrontendRoutes.CREATE_PROJECT.path}"
                                     element = CreationView::class.react.create()
+                                }
+
+                                Route {
+                                    path = "/${FrontendRoutes.CREATE_PROJECT.path}/:owner"
+                                    element = creationView.create()
                                 }
 
                                 Route {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/CreationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/CreationView.kt
@@ -50,8 +50,8 @@ import kotlinx.serialization.json.Json
  */
 external interface ProjectSaveViewProps : Props {
     /**
-     * The name of the currently selected organization (parent to the newly
-     * created project).
+     * The name of the parent organization, or `null` if the project is being
+     * created from scratch.
      */
     var organizationName: String?
 }
@@ -69,14 +69,6 @@ external interface ProjectSaveViewState : State {
      * Error message
      */
     var errorMessage: String
-
-    /**
-     * The name of the parent organization, or `null` if the project is being
-     * created from scratch.
-     *
-     * @see ProjectSaveViewProps.organizationName
-     */
-    var initialOrganizationName: String?
 
     /**
      * Draft [ProjectDto]
@@ -143,10 +135,9 @@ class CreationView : AbstractView<ProjectSaveViewProps, ProjectSaveViewState>(tr
          * Update the state if there's a parent organization available.
          */
         val organizationName = props.organizationName
-        scope.launch {
-            setState {
-                initialOrganizationName = organizationName
-                if (!organizationName.isNullOrEmpty()) {
+        if (!organizationName.isNullOrEmpty()) {
+            scope.launch {
+                setState {
                     projectCreationRequest = projectCreationRequest.copy(organizationName = organizationName)
                 }
             }
@@ -193,7 +184,7 @@ class CreationView : AbstractView<ProjectSaveViewProps, ProjectSaveViewState>(tr
                                     button {
                                         @Suppress("LOCAL_VARIABLE_EARLY_DECLARATION")
                                         val buttonText = "Add new organization"
-                                        val buttonEnabled = state.initialOrganizationName.isNullOrEmpty()
+                                        val buttonEnabled = props.organizationName.isNullOrEmpty()
 
                                         type = ButtonType.button
                                         className = ClassName("btn btn-primary mb-2")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
@@ -51,6 +51,7 @@ import react.dom.html.ReactHTML.nav
 import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.td
 import react.dom.html.ReactHTML.textarea
+import react.router.dom.Link
 import react.table.columns
 
 import kotlinx.browser.window
@@ -697,8 +698,8 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
                 }
 
                 if (state.selfRole.isHigherOrEqualThan(Role.ADMIN)) {
-                    a {
-                        href = "#/${FrontendRoutes.CREATE_PROJECT.path}/"
+                    Link {
+                        to = "/${FrontendRoutes.CREATE_PROJECT.path}/${this@OrganizationView.state.organization?.name}"
                         button {
                             type = ButtonType.button
                             className = ClassName("btn btn-outline-info")

--- a/save-frontend/src/test/kotlin/com/saveourtool/save/frontend/components/views/OrganizationViewTest.kt
+++ b/save-frontend/src/test/kotlin/com/saveourtool/save/frontend/components/views/OrganizationViewTest.kt
@@ -14,7 +14,7 @@ import com.saveourtool.save.utils.LocalDateTime
 
 import react.create
 import react.react
-import react.router.dom.HashRouter
+import react.router.MemoryRouter
 
 import kotlin.js.Promise
 import kotlin.test.*
@@ -114,7 +114,7 @@ class OrganizationViewTest {
     }
 
     private fun renderOrganizationView(userInfo: UserInfo = testUserInfo) = wrapper.create {
-        HashRouter {
+        MemoryRouter {
             OrganizationView::class.react {
                 organizationName = testOrganization.name
                 currentUserInfo = userInfo

--- a/save-frontend/src/test/kotlin/com/saveourtool/save/frontend/components/views/OrganizationViewTest.kt
+++ b/save-frontend/src/test/kotlin/com/saveourtool/save/frontend/components/views/OrganizationViewTest.kt
@@ -14,6 +14,7 @@ import com.saveourtool.save.utils.LocalDateTime
 
 import react.create
 import react.react
+import react.router.dom.HashRouter
 
 import kotlin.js.Promise
 import kotlin.test.*
@@ -113,9 +114,11 @@ class OrganizationViewTest {
     }
 
     private fun renderOrganizationView(userInfo: UserInfo = testUserInfo) = wrapper.create {
-        OrganizationView::class.react {
-            organizationName = testOrganization.name
-            currentUserInfo = userInfo
+        HashRouter {
+            OrganizationView::class.react {
+                organizationName = testOrganization.name
+                currentUserInfo = userInfo
+            }
         }
     }
         .let {


### PR DESCRIPTION
 - `a()` usages replaced with `Link()` (more router-friendly)
 - Fixes #754.