### PR TITLE
[Gradle] Do not hardcode paths in `copyAgentDistribution` task configuration

### DIFF
--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/GitHookInstallation.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/GitHookInstallation.kt
@@ -17,9 +17,7 @@ fun Project.installGitHooks() {
         into(file("$rootDir/.git/hooks"))
     }
     // add git hooks installation to build by adding it as a dependency for some common task
-    subprojects.mapNotNull {
-        it.tasks.findByName("build")
+    tasks.named("build") {
+        dependsOn(installGitHooksTask)
     }
-        .firstOrNull()
-        ?.dependsOn(installGitHooksTask)
 }

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
         }
     }
 
+    @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
     val linkTask: TaskProvider<KotlinNativeLink> = tasks.named<KotlinNativeLink>("linkReleaseExecutableLinuxX64")
     val copyAgentDistribution by tasks.registering(Jar::class) {
         dependsOn(linkTask)

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.saveourtool.save.buildutils.configureSpotless
 import com.saveourtool.save.buildutils.pathToSaveCliVersion
 import com.saveourtool.save.buildutils.readSaveCliVersion
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
@@ -51,7 +52,7 @@ kotlin {
         }
     }
 
-    val linkTask = tasks.named<KotlinNativeLink>("linkReleaseExecutableLinuxX64")
+    val linkTask: TaskProvider<KotlinNativeLink> = tasks.named<KotlinNativeLink>("linkReleaseExecutableLinuxX64")
     val copyAgentDistribution by tasks.registering(Jar::class) {
         dependsOn(linkTask)
         archiveClassifier.set("distribution")

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -85,7 +85,9 @@ kotlin {
                 }
             }
         }
-        tasks.getByName("${hostTarget.name}Test").finalizedBy(createCoverageReportTask)
+        tasks.named("${hostTarget.name}Test") {
+            finalizedBy(createCoverageReportTask)
+        }
     }
 }
 

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -2,6 +2,7 @@ import com.saveourtool.save.buildutils.configureSpotless
 import com.saveourtool.save.buildutils.pathToSaveCliVersion
 import com.saveourtool.save.buildutils.readSaveCliVersion
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 plugins {
     kotlin("multiplatform")
@@ -50,16 +51,15 @@ kotlin {
         }
     }
 
-    val distribution by configurations.creating
+    val linkTask = tasks.named<KotlinNativeLink>("linkReleaseExecutableLinuxX64")
     val copyAgentDistribution by tasks.registering(Jar::class) {
-        dependsOn("linkReleaseExecutableLinuxX64")
+        dependsOn(linkTask)
         archiveClassifier.set("distribution")
-        from(file("$buildDir/bin/linuxX64/releaseExecutable")) {
-            include("*")
-        }
+        from(linkTask.flatMap { it.outputFile })
         from(file("$projectDir/src/linuxX64Main/resources/agent.properties"))
     }
-    artifacts.add(distribution.name, file("$buildDir/libs/${project.name}-${project.version}-distribution.jar")) {
+    val distribution by configurations.creating
+    artifacts.add(distribution.name, copyAgentDistribution.flatMap { it.archiveFile }) {
         builtBy(copyAgentDistribution)
     }
 

--- a/save-backend/build.gradle.kts
+++ b/save-backend/build.gradle.kts
@@ -32,7 +32,9 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-tasks.getByName("processTestResources").dependsOn("copyLiquibase")
+tasks.named("processTestResources") {
+    dependsOn("copyLiquibase")
+}
 
 tasks.register<Copy>("copyLiquibase") {
     from("$rootDir/db")


### PR DESCRIPTION
* Do not hardcode paths in `copyAgentDistribution` task configuration
* Change some eager task configurations to lazy