### PR TITLE
[docker-compose] Support different image tags for services in docker-compose.yaml

### DIFF
--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DockerStackConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DockerStackConfiguration.kt
@@ -88,10 +88,17 @@ fun Project.createStackDeployTask(profile: String) {
         }
 
         doLast {
+            val defaultVersionOrProperty: (propertyName: String) -> String = { propertyName ->
+                findProperty(propertyName) as String?
+                    ?: versionForDockerImages()
+            }
             // https://docs.docker.com/compose/environment-variables/#the-env-file
             file(envFile).writeText(
                 """
-                    TAG=${versionForDockerImages()}
+                    BACKEND_TAG=${defaultVersionOrProperty("backendTag")}
+                    GATEWAY_TAG=${defaultVersionOrProperty("gatewayTag")}
+                    ORCHESTRATOR_TAG=${defaultVersionOrProperty("orchestratorTag")}
+                    PREPROCESSOR_TAG=${defaultVersionOrProperty("preprocessorTag")}
                     PROFILE=$profile
                 """.trimIndent()
             )

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DockerStackConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DockerStackConfiguration.kt
@@ -95,10 +95,10 @@ fun Project.createStackDeployTask(profile: String) {
             // https://docs.docker.com/compose/environment-variables/#the-env-file
             file(envFile).writeText(
                 """
-                    BACKEND_TAG=${defaultVersionOrProperty("backendTag")}
-                    GATEWAY_TAG=${defaultVersionOrProperty("gatewayTag")}
-                    ORCHESTRATOR_TAG=${defaultVersionOrProperty("orchestratorTag")}
-                    PREPROCESSOR_TAG=${defaultVersionOrProperty("preprocessorTag")}
+                    BACKEND_TAG=${defaultVersionOrProperty("backend.dockerTag")}
+                    GATEWAY_TAG=${defaultVersionOrProperty("gateway.dockerTag")}
+                    ORCHESTRATOR_TAG=${defaultVersionOrProperty("orchestrator.dockerTag")}
+                    PREPROCESSOR_TAG=${defaultVersionOrProperty("preprocessor.dockerTag")}
                     PROFILE=$profile
                 """.trimIndent()
             )

--- a/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DockerStackConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/saveourtool/save/buildutils/DockerStackConfiguration.kt
@@ -89,7 +89,11 @@ fun Project.createStackDeployTask(profile: String) {
 
         doLast {
             val defaultVersionOrProperty: (propertyName: String) -> String = { propertyName ->
+                // Image tag can be specified explicitly for a particular service,
+                // or specified explicitly for the whole app,
+                // or be inferred based on the project.version
                 findProperty(propertyName) as String?
+                    ?: findProperty("dockerTag") as String?
                     ?: versionForDockerImages()
             }
             // https://docs.docker.com/compose/environment-variables/#the-env-file

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ x-logging:
 
 services:
   orchestrator:
-    image: ghcr.io/saveourtool/save-orchestrator:${TAG}
+    image: ghcr.io/saveourtool/save-orchestrator:${ORCHESTRATOR_TAG}
     user: root  # to access host's docker socket
     environment:
       - "SPRING_PROFILES_ACTIVE=${PROFILE}"
@@ -35,7 +35,7 @@ services:
         - "prometheus-job=save-orchestrator"
     logging: *loki-logging-jvm
   backend:
-    image: ghcr.io/saveourtool/save-backend:${TAG}
+    image: ghcr.io/saveourtool/save-backend:${BACKEND_TAG}
     environment:
       - "SPRING_PROFILES_ACTIVE=${PROFILE},secure,docker-secrets"
       - "MYSQL_USER=/run/secrets/db_username"
@@ -54,7 +54,7 @@ services:
         - "prometheus-job=save-backend"
     logging: *loki-logging-jvm
   preprocessor:
-    image: ghcr.io/saveourtool/save-preprocessor:${TAG}
+    image: ghcr.io/saveourtool/save-preprocessor:${PREPROCESSOR_TAG}
     environment:
       - "SPRING_PROFILES_ACTIVE=${PROFILE}"
     volumes:
@@ -72,7 +72,7 @@ services:
         max_attempts: 3
     logging: *loki-logging-jvm
   gateway:
-    image: ghcr.io/saveourtool/api-gateway:${TAG}
+    image: ghcr.io/saveourtool/api-gateway:${GATEWAY_TAG}
     environment:
       - "SPRING_PROFILES_ACTIVE=${PROFILE}"
     ports:


### PR DESCRIPTION
Now the whole application is always deployed from the same image tag. This change allows overriding some of the tags, for example to avoid recreating services that are not affected by a particular change to be deployed.