### PR TITLE
[Helm] Discard custom prometheus config and use default one

### DIFF
--- a/save-cloud-charts/save-cloud/templates/_helpers.tpl
+++ b/save-cloud-charts/save-cloud/templates/_helpers.tpl
@@ -2,7 +2,6 @@
 io.kompose.service: {{ .service.name }}
 version: {{ or .service.dockerTag .Values.dockerTag }}
 env: {{ .Values.env }}
-prometheus-job: {{ .service.imageName }}
 {{- end }}
 
 {{- define "pod.common.labels" }}
@@ -11,6 +10,7 @@ version: {{ or .service.dockerTag .Values.dockerTag }}
 {{- end }}
 
 {{- define "pod.common.annotations" }}
+prometheus.io/scrape: 'true'
 prometheus.io/path: /actuator/prometheus
 {{- if (hasKey .service "managementPort") }}
 prometheus.io/port: {{ .service.managementPort | quote }}

--- a/save-cloud-charts/save-cloud/values.yaml
+++ b/save-cloud-charts/save-cloud/values.yaml
@@ -98,27 +98,6 @@ prometheus:
       type: Recreate
   pushgateway:
     enabled: false
-  serverFiles:
-    prometheus.yml:
-      scrape_configs:
-      - job_name: 'save-cloud-kubernetes'
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-            action: replace
-            regex: (.+?)(?::\d+)?;(\d+)
-            replacement: $1:$2
-            target_label: __address__
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__meta_kubernetes_pod_label_io_kompose_service]
-            regex: .+
-            action: keep
-          - source_labels: [__meta_kubernetes_pod_container_name]
-            target_label: job
 
 promtail:
   image:


### PR DESCRIPTION
Originally I've added a custom config that suppresses default configs. My intention was to extract service name through a pod label. However, default config is sufficient for this too with the only difference that it doesn't rename the label. Moreover, default configuration automatically configures scraping of all possible cluster targets, including kubelet. These metrics can be used to monitor save-agent pods (e.g. system resources consumption) without any changes in agents.