### PR TITLE
[WIP] Authenticated agent

### DIFF
--- a/save-cloud-charts/save-cloud/templates/save-agent-network-policy.yaml
+++ b/save-cloud-charts/save-cloud/templates/save-agent-network-policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: save-agent-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      io.kompose.service: save-agent
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              io.kompose.service: orchestrator
+    - to:
+        # https://stackoverflow.com/q/73049535
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            # Forbid private IP ranges effectively allowing only egress to the Internet
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: "kube-system"
+        - podSelector:
+            matchLabels:
+              k8s-app: "kube-dns"

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Agent.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Agent.kt
@@ -8,7 +8,8 @@ import javax.persistence.ManyToOne
 /**
  * @property containerId id of the container, inside which the agent is running
  * @property execution id of the execution, which the agent is serving
- * @property version
+ * @property version version of the agent binary
+ * @property isAuthenticated whether this agent has already received a token from orchestrator
  */
 @Entity
 class Agent(
@@ -19,4 +20,6 @@ class Agent(
     var execution: Execution,
 
     var version: String? = null,
+
+    var isAuthenticated: Boolean,
 ) : BaseEntity()

--- a/save-deploy/base-images/Dockerfile
+++ b/save-deploy/base-images/Dockerfile
@@ -14,9 +14,13 @@ RUN if [ "$BASE_IMAGE_NAME" = "python" ]; then \
     fi
 
 RUN groupadd --gid 1100 save-agent && \
+    groupadd --gid 1200 save-executor && \
     useradd --uid 1100 --gid 1100 --create-home --shell /bin/sh save-agent && \
+    useradd --uid 1200 --gid 1100 --create-home --shell /bin/sh save-agent && \
+    usermod -aG save-executor save-agent && \
     # `WORKDIR` directive creates the directory as `root` user unless the directory already exists
     mkdir /home/save-agent/save-execution && \
-    chown -R 1100:1100 /home/save-agent/save-execution
+    chown -R 1100:1100 /home/save-agent/save-execution && \
+    echo 'save-agent ALL = (save-executor) ALL' >> /etc/sudoers
 USER save-agent
 WORKDIR /home/save-agent/save-execution

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -74,6 +74,8 @@ class KubernetesManager(
                         }
                         // If agent fails, we should handle it manually (update statuses, attempt restart etc.)
                         restartPolicy = "Never"
+                        // save-agent pods shouldn't have access to valid cluster tokens
+                        automountServiceAccountToken = false
                         containers = listOf(
                             agentContainerSpec(baseImageTag, agentRunCmd, workingDir, configuration.env)
                         )


### PR DESCRIPTION
(partially TODO):
* Run tested tool as a dedicated user `save-executor`
* Authorize requests from save-agent using ServiceAccount token
* Create a NetworkPolicy that would restrict network access of save-agent pods only to orchestrator, kube-dns and the Internet

Closes #1049 