### PR TITLE
Add typeButton in Buttons

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ContestEnroller.kt
@@ -223,6 +223,7 @@ private fun contestEnrollerComponent() = FC<ContestEnrollerProps> { props ->
         div {
             className = ClassName("d-flex justify-content-center mt-3")
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-primary d-flex justify-content-center")
                 +"Participate"
                 onClick = {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FileUploader.kt
@@ -36,6 +36,7 @@ import kotlinx.browser.window
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import react.dom.html.ButtonType
 
 @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
 private val fileUploaderOverFileInfo = fileUploader<FileInfo>()
@@ -255,6 +256,7 @@ fun <F : AbstractFileInfo> fileUploader() = FC<UploaderProps<F>> { props ->
                     className = ClassName("list-group-item")
                     if (!props.isSandboxMode) {
                         button {
+                            type = ButtonType.button
                             className = ClassName("btn")
                             fontAwesomeIcon(icon = faTimesCircle)
                             onClick = {
@@ -265,6 +267,7 @@ fun <F : AbstractFileInfo> fileUploader() = FC<UploaderProps<F>> { props ->
                     }
                     a {
                         button {
+                            type = ButtonType.button
                             className = ClassName("btn")
                             fontAwesomeIcon(icon = faDownload)
                         }
@@ -272,6 +275,7 @@ fun <F : AbstractFileInfo> fileUploader() = FC<UploaderProps<F>> { props ->
                         href = props.getUrlForFileDownload(file)
                     }
                     button {
+                        type = ButtonType.button
                         className = ClassName("btn")
                         fontAwesomeIcon(icon = faTrash)
                         onClick = {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FiltersRow.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FiltersRow.kt
@@ -13,6 +13,7 @@ import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
 import csstype.ClassName
 import react.FC
 import react.Props
+import react.dom.html.ButtonType
 import react.dom.html.InputType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
@@ -176,6 +177,7 @@ private fun testExecutionFiltersRow(
                 }
             }
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-primary")
                 fontAwesomeIcon(icon = faSearch, classes = "trash-alt")
                 onClick = {
@@ -183,6 +185,7 @@ private fun testExecutionFiltersRow(
                 }
             }
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-primary")
                 fontAwesomeIcon(icon = faTrashAlt, classes = "trash-alt")
                 onClick = {
@@ -231,6 +234,7 @@ private fun nameFiltersRow(
                 }
             }
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-secondary mr-3")
                 fontAwesomeIcon(icon = faSearch, classes = "trash-alt")
                 onClick = {
@@ -238,6 +242,7 @@ private fun nameFiltersRow(
                 }
             }
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-secondary")
                 fontAwesomeIcon(icon = faTrashAlt, classes = "trash-alt")
                 onClick = {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
@@ -259,6 +259,7 @@ private fun manageUserRoleCardComponent() = FC<ManageUserRoleCardProps> { props 
                 div {
                     className = ClassName("col-5 align-self-right d-flex align-items-center justify-content-end")
                     button {
+                        type = ButtonType.button
                         className = ClassName("btn col-2 align-items-center mr-2")
                         fontAwesomeIcon(icon = faTimesCircle)
                         val canDelete = selfRole == Role.SUPER_ADMIN ||

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ProjectInfo.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ProjectInfo.kt
@@ -28,6 +28,7 @@ import react.useState
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import react.dom.html.ButtonType
 
 val projectInfo = projectInfo()
 
@@ -98,6 +99,7 @@ private fun projectInfo() = FC<ProjectInfoProps> { props ->
         div {
             className = ClassName("d-flex justify-content-center")
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-link text-xs text-muted text-left p-1 ml-2")
                 +"Edit  "
                 fontAwesomeIcon(icon = faEdit)
@@ -143,6 +145,7 @@ private fun projectInfo() = FC<ProjectInfoProps> { props ->
             className = ClassName("ml-3 mt-2 align-items-right float-right")
             button {
                 className = ClassName("btn")
+                type = ButtonType.button
                 fontAwesomeIcon(icon = faCheck)
                 hidden = isEditDisabled
                 onClick = {
@@ -153,6 +156,7 @@ private fun projectInfo() = FC<ProjectInfoProps> { props ->
 
             button {
                 className = ClassName("btn")
+                type = ButtonType.button
                 fontAwesomeIcon(icon = faTimesCircle)
                 hidden = isEditDisabled
                 onClick = {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestResourcesSelection.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestResourcesSelection.kt
@@ -17,6 +17,7 @@ import com.saveourtool.save.testsuite.TestSuiteDto
 
 import csstype.ClassName
 import react.*
+import react.dom.html.ButtonType
 import react.dom.html.InputType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
@@ -187,6 +188,7 @@ private fun ChildrenBuilder.renderForContestMode(
         div {
             className = ClassName("card-body d-flex justify-content-center")
             button {
+                type = ButtonType.button
                 className = ClassName("d-flex justify-content-center btn btn-primary")
                 +"Enroll for a contest"
                 onClick = contestEnrollerWindowOpenness.openWindowAction().withUnusedArg()

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/codeeditor/CodeEditorComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/codeeditor/CodeEditorComponent.kt
@@ -15,6 +15,7 @@ import csstype.ClassName
 import react.ChildrenBuilder
 import react.FC
 import react.Props
+import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h6
@@ -107,6 +108,7 @@ private fun ChildrenBuilder.displayEditorToolbar(
                 className = ClassName("input-group-prepend")
 
                 button {
+                    type = ButtonType.button
                     className = ClassName("btn btn-outline-primary")
                     onClick = onUploadChanges.withUnusedArg()
                     fontAwesomeIcon(icon = faUpload)
@@ -115,6 +117,7 @@ private fun ChildrenBuilder.displayEditorToolbar(
                     title = "Save changes on server"
                 }
                 button {
+                    type = ButtonType.button
                     className = ClassName("btn btn-outline-primary")
                     onClick = onReloadChanges.withUnusedArg()
                     fontAwesomeIcon(icon = faDownload)
@@ -153,6 +156,7 @@ private fun ChildrenBuilder.displayEditorToolbar(
                 className = ClassName("input-group-append")
 
                 button {
+                    type = ButtonType.button
                     className = ClassName("btn btn-outline-success")
                     onClick = onRunExecution.withUnusedArg()
                     fontAwesomeIcon(icon = faCaretSquareRight)

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/ManageGitCredentialsCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/ManageGitCredentialsCard.kt
@@ -145,6 +145,7 @@ fun manageGitCredentialsCardComponent() = FC<ManageGitCredentialsCardProps> { pr
                 div {
                     className = ClassName("col-5 align-self-right d-flex align-items-center justify-content-end")
                     button {
+                        type = ButtonType.button
                         className = ClassName("btn col-2 align-items-center mr-2")
                         fontAwesomeIcon(icon = faEdit)
                         id = "edit-git-credential-$index"
@@ -155,6 +156,7 @@ fun manageGitCredentialsCardComponent() = FC<ManageGitCredentialsCardProps> { pr
                         }
                     }
                     button {
+                        type = ButtonType.button
                         className = ClassName("btn col-2 align-items-center mr-2")
                         fontAwesomeIcon(icon = faTimesCircle)
                         id = "remove-git-credential-$index"

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectInfoMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectInfoMenu.kt
@@ -21,6 +21,7 @@ import react.dom.html.ReactHTML.li
 import react.dom.html.ReactHTML.ul
 
 import kotlinx.browser.window
+import react.dom.html.ButtonType
 
 private val infoCard = cardComponent(isBordered = true, hasBg = true)
 
@@ -148,6 +149,7 @@ private fun projectInfoMenu() = FC<ProjectInfoMenuProps> { props ->
                     fontAwesomeIcon(icon = faHistory)
 
                     button {
+                        type = ButtonType.button
                         className = ClassName("btn btn-link text-left")
                         +"Latest Execution"
                         disabled = props.latestExecutionId == null

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelectorBrowserMode.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelectorBrowserMode.kt
@@ -16,6 +16,7 @@ import csstype.ClassName
 import react.*
 import react.dom.aria.AriaRole
 import react.dom.aria.ariaLabel
+import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
@@ -264,6 +265,7 @@ private fun testSuiteSelectorBrowserMode() = FC<TestSuiteSelectorBrowserModeProp
                     ""
                 }
                 button {
+                    type = ButtonType.button
                     className = ClassName("btn btn-outline-secondary $active")
                     asDynamic()["data-toggle"] = "tooltip"
                     asDynamic()["data-placement"] = "bottom"

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuitessources/TestSuiteSourceUpsertComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuitessources/TestSuiteSourceUpsertComponent.kt
@@ -233,6 +233,7 @@ private fun testSuiteSourceUpsertComponent() = FC<TestSuiteSourceUpsertProps> { 
         div {
             className = ClassName("d-flex justify-content-center")
             button {
+                type = ButtonType.button
                 className = ClassName("btn btn-primary mt-2 mb-2")
                 disabled = !testSuiteSource.validate() || saveStatus != null
                 onClick = requestToUpsertEntity.withUnusedArg()

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
@@ -344,6 +344,7 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
                             }
                             if (state.selfRole.hasWritePermission() && state.isEditDisabled) {
                                 button {
+                                    type = ButtonType.button
                                     className = ClassName("btn btn-link text-xs text-muted text-left ml-auto")
                                     +"Edit  "
                                     fontAwesomeIcon(icon = faEdit)

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ProjectView.kt
@@ -534,6 +534,7 @@ class ProjectView : AbstractView<ProjectViewProps, ProjectViewState>(false) {
                         fontAwesomeIcon(icon = faHistory)
                         withNavigate { navigateContext ->
                             button {
+                                type = ButtonType.button
                                 className = ClassName("btn btn-link text-left")
                                 +"Latest Execution"
                                 disabled = state.latestExecutionId == null

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/DeleteOrganizationButton.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/DeleteOrganizationButton.kt
@@ -13,6 +13,7 @@ import csstype.ClassName
 import react.ChildrenBuilder
 import react.FC
 import react.Props
+import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.useState
@@ -49,6 +50,7 @@ val deleteOrganizationButton: FC<DeleteOrganizationButtonProps> = FC { props ->
 
     div {
         button {
+            type = ButtonType.button
             className = ClassName(props.classes)
             props.buttonStyleBuilder(this)
             id = "remove-organization-${props.organizationName}"

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/ChildrenBuilderUtils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/ChildrenBuilderUtils.kt
@@ -12,6 +12,7 @@ import org.w3c.dom.HTMLSelectElement
 import react.ChildrenBuilder
 import react.dom.events.ChangeEventHandler
 import react.dom.events.MouseEventHandler
+import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.option
 import react.dom.html.ReactHTML.select
@@ -49,6 +50,7 @@ fun ChildrenBuilder.buttonBuilder(
     onClickFun: MouseEventHandler<HTMLButtonElement>,
 ) {
     button {
+        type = ButtonType.button
         val outline = if (isOutline) {
             "outline-"
         } else {


### PR DESCRIPTION
## What added:
- Add field ```type = ButtonType.button``` in Buttons {} to change the default value (```submit```)

## Issue(#1272)

## Helps
@petertrr @sanyavertolet @Cheshiriks Please look at the changes made. Previously, these buttons did not have this field and had a default value (``submit``) (A button for sending form data to the server). It is she who breaks the logic by substituting ```"?"``` in the URL before ```"#"```