### PR TITLE
Avoid java.nio.file.AccessDeniedException thrown on Windows

### DIFF
--- a/save-preprocessor/src/test/kotlin/com/saveourtool/save/preprocessor/utils/GitUtilKtTest.kt
+++ b/save-preprocessor/src/test/kotlin/com/saveourtool/save/preprocessor/utils/GitUtilKtTest.kt
@@ -1,21 +1,18 @@
 package com.saveourtool.save.preprocessor.utils
 
 import com.saveourtool.save.entities.GitDto
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.springframework.util.FileSystemUtils
-import kotlin.io.path.createTempDirectory
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.div
 
 internal class GitUtilKtTest {
     @Test
-    fun test() {
-        val tmpDir = createTempDirectory()
+    fun test(@TempDir tmpDir: Path) {
         val gitDto = GitDto("https://github.com/saveourtool/save-cli.git")
 
-        gitDto.cloneTagToDirectory("v0.3.4", tmpDir.resolve("tag"))
-        gitDto.cloneBranchToDirectory("infra/build-logic-includebuild", tmpDir.resolve("branch"))
-        gitDto.cloneCommitToDirectory("8a8f164", tmpDir.resolve("commit"))
-
-        FileSystemUtils.deleteRecursively(tmpDir)
+        gitDto.cloneTagToDirectory("v0.3.4", tmpDir / "tag")
+        gitDto.cloneBranchToDirectory("infra/build-logic-includebuild", tmpDir / "branch")
+        gitDto.cloneCommitToDirectory("8a8f164", tmpDir / "commit")
     }
 }


### PR DESCRIPTION
The test succeeds on Windows, because the temporary directory is now JUnit-managed.