### PR TITLE
Use the `agentDistro/` directory rather than its children as a CLASSPATH entry

### DIFF
--- a/save-backend/build.gradle.kts
+++ b/save-backend/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
                 "save-agent, please test them on Linux " +
                 "or put the file with name like `save-agent-*-distribution.jar` built on Linux into libs subfolder."
         )
-        runtimeOnly(fileTree("$buildDir/agentDistro").apply {
+        runtimeOnly(files("$buildDir/agentDistro").apply {
             builtBy(downloadSaveAgentDistroTaskProvider)
         })
     } else {


### PR DESCRIPTION
If `save-agent.kexe` gets downloaded *before* Gradle (re-)configures the project, then `agentDistro/save-agent.kexe` rather than `agentDistro/` will become a CLASSSPATH entry, resulting in an HTTP 404 when accessing `/internal/files/download-save-agent` in local deployments.