### PR TITLE
Explicitly configure the back-end URL in production, too

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/configs/ConfigProperties.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/configs/ConfigProperties.kt
@@ -6,22 +6,22 @@ import org.springframework.boot.context.properties.ConstructorBinding
 /**
  * Class for properties
  *
- * @property url url of backend
  * @property preprocessorUrl url of preprocessor
  * @property initialBatchSize initial size of tests batch (for further scaling)
  * @property fileStorage configuration of file storage
  * @property orchestratorUrl url of save-orchestrator
  * @property scheduling configuration for scheduled tasks
+ * @property agentSettings overrides the defaults in `agent.properties`.
  */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "backend")
 data class ConfigProperties(
-    val url: String,
     val preprocessorUrl: String,
     val orchestratorUrl: String,
     val initialBatchSize: Int,
     val fileStorage: FileStorageConfig,
     val scheduling: Scheduling = Scheduling(),
+    val agentSettings: AgentSettings = AgentSettings(),
 ) {
     /**
      * @property location location of file storage
@@ -38,4 +38,16 @@ data class ConfigProperties(
         val standardSuitesUpdateCron: String = "0 0 */1 * * ?",
         val baseImagesBuildCron: String = "0 0 */1 * * ?",
     )
+
+    /**
+     * @property backendUrl the URL of save-backend that will be reported to
+     *   save-agents.
+     */
+    data class AgentSettings(
+        val backendUrl: String = DEFAULT_BACKEND_URL,
+    )
+
+    private companion object {
+        private const val DEFAULT_BACKEND_URL = "http://backend:5800"
+    }
 }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/internal/AgentsController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/internal/AgentsController.kt
@@ -57,13 +57,15 @@ class AgentsController(
             it.execution
         }
         .map { execution ->
+            val backendUrl = configProperties.agentSettings.backendUrl
+
             AgentInitConfig(
-                saveCliUrl = "${configProperties.url}/internal/files/download-save-cli?version=$SAVE_CORE_VERSION",
-                testSuitesSourceSnapshotUrl = "${configProperties.url}/internal/test-suites-sources/download-snapshot-by-execution-id?executionId=${execution.requiredId()}",
+                saveCliUrl = "$backendUrl/internal/files/download-save-cli?version=$SAVE_CORE_VERSION",
+                testSuitesSourceSnapshotUrl = "$backendUrl/internal/test-suites-sources/download-snapshot-by-execution-id?executionId=${execution.requiredId()}",
                 additionalFileNameToUrl = execution.getFileKeys()
                     .associate { fileKey ->
                         fileKey.name to buildString {
-                            append(configProperties.url)
+                            append(backendUrl)
                             append("/internal/files/download?")
                             mapOf(
                                 "organizationName" to fileKey.projectCoordinates.organizationName,

--- a/save-backend/src/main/resources/application-dev.properties
+++ b/save-backend/src/main/resources/application-dev.properties
@@ -1,7 +1,11 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/save_cloud
 spring.datasource.username=root
 spring.datasource.password=123
-backend.url=http://host.docker.internal:${server.port}
+# The back-end URL, as reported to agents.
+# For some reason, they seem unable to resolve the "backend" name.
+#
+# suppress inspection "HttpUrlsUsage"
+backend.agent-settings.backend-url=http://host.docker.internal:${server.port}
 backend.preprocessorUrl=http://localhost:5200
 backend.orchestratorUrl=http://localhost:5100
 backend.fileStorage.location=${user.home}/.save-cloud/cnb/files

--- a/save-backend/src/main/resources/application.properties
+++ b/save-backend/src/main/resources/application.properties
@@ -1,4 +1,8 @@
-backend.url=http://backend:${server.port}
+# The back-end URL, as reported to agents.
+# For some reason, they seem unable to resolve the "backend" name.
+#
+# suppress inspection "HttpUrlsUsage"
+backend.agent-settings.backend-url=http://host.docker.internal:${server.port}
 backend.preprocessorUrl=http://preprocessor:5200
 backend.orchestratorUrl=http://orchestrator:5100
 backend.initialBatchSize=100

--- a/save-backend/src/test/resources/application.properties
+++ b/save-backend/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 spring.profiles.default=test,secure
 server.port = 5800
-backend.url=stub
+backend.agent-settings.backend-url=stub
 backend.preprocessorUrl=stub
 backend.orchestratorUrl=stub
 backend.initialBatchSize=20


### PR DESCRIPTION
This change makes sure that the explicitly configured back-end URL (http://docker.host.internal:5800) is always reported by the back-end to agents.