### PR TITLE
base images: Install curl explicitly

### DIFF
--- a/save-deploy/base-images/Dockerfile
+++ b/save-deploy/base-images/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE_NAME
 ARG BASE_IMAGE_TAG
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
 
-RUN apt-get update && env DEBIAN_FRONTEND="noninteractive" apt-get install -y libcurl4-openssl-dev tzdata unzip
+RUN apt-get update && env DEBIAN_FRONTEND="noninteractive" apt-get install -y curl libcurl4-openssl-dev tzdata unzip
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Apparently, it's present in `jdk` and `python` images, but missing in `ubuntu:latest`