### PR TITLE
Make test suites public/private again!

### DIFF
--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -581,11 +581,12 @@
         ],
         "summary": "Make given test suites public or private.",
         "description": "Make given test suites public or private.",
-        "operationId": "changeVisibilityBatch",
+        "operationId": "changeTestSuiteVisibilityBatch",
         "parameters": [
           {
             "name": "ownerOrganizationName",
             "in": "path",
+            "description": "name of an organization-maintainer",
             "required": true,
             "schema": {
               "type": "string"
@@ -593,7 +594,7 @@
           },
           {
             "name": "isPublic",
-            "in": "path",
+            "in": "query",
             "description": "flag to make test suite public or private",
             "required": true,
             "schema": {
@@ -623,17 +624,7 @@
         },
         "responses": {
           "403": {
-            "description": "Given organization has been forbidden to change given test suite rights",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Requested organization, test suite or organization-maintainer doesn\u0027t exist",
+            "description": "Given organization has been forbidden to change given test suite visibility",
             "content": {
               "*/*": {
                 "schema": {
@@ -643,7 +634,17 @@
             }
           },
           "200": {
-            "description": "Rights changed",
+            "description": "Visibility changed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Test suite or organization-maintainer doesn\u0027t exist",
             "content": {
               "*/*": {
                 "schema": {

--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -572,6 +572,104 @@
         ]
       }
     },
+    "/api/v1/test-suites/{ownerOrganizationName}/batch-change-visibility": {
+      "post": {
+        "tags": [
+          "rights",
+          "organizations",
+          "test-suites"
+        ],
+        "summary": "Make given test suites public or private.",
+        "description": "Make given test suites public or private.",
+        "operationId": "changeVisibilityBatch",
+        "parameters": [
+          {
+            "name": "ownerOrganizationName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "isPublic",
+            "in": "path",
+            "description": "flag to make test suite public or private",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "X-Authorization-Source",
+            "in": "header",
+            "required": true,
+            "example": "basic"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "403": {
+            "description": "Given organization has been forbidden to change given test suite rights",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Requested organization, test suite or organization-maintainer doesn\u0027t exist",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Rights changed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basic": []
+          }
+        ]
+      }
+    },
     "/api/v1/test-suites/{organizationName}/get-by-ids": {
       "post": {
         "tags": [

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
@@ -390,13 +390,13 @@ class LnkOrganizationTestSuiteController(
         description = "Make given test suites public or private.",
     )
     @Parameters(
-        Parameter(name = "isPublic", `in` = ParameterIn.PATH, description = "flag to make test suite public or private", required = true),
-        Parameter(name = "isPublic", `in` = ParameterIn.PATH, description = "flag to make test suite public or private", required = true),
+        Parameter(name = "ownerOrganizationName", `in` = ParameterIn.PATH, description = "name of an organization-maintainer", required = true),
+        Parameter(name = "isPublic", `in` = ParameterIn.QUERY, description = "flag to make test suite public or private", required = true),
     )
-    @ApiResponse(responseCode = "200", description = "Rights changed")
-    @ApiResponse(responseCode = "403", description = "Given organization has been forbidden to change given test suite rights")
-    @ApiResponse(responseCode = "404", description = "Requested organization, test suite or organization-maintainer doesn't exist")
-    fun changeVisibilityBatch(
+    @ApiResponse(responseCode = "200", description = "Visibility changed")
+    @ApiResponse(responseCode = "403", description = "Given organization has been forbidden to change given test suite visibility")
+    @ApiResponse(responseCode = "404", description = "Test suite or organization-maintainer doesn't exist")
+    fun changeTestSuiteVisibilityBatch(
         @PathVariable ownerOrganizationName: String,
         @RequestParam isPublic: Boolean,
         @RequestBody testSuiteIds: List<Long>,
@@ -420,19 +420,6 @@ class LnkOrganizationTestSuiteController(
                 .also {
                     testSuitesService.updateTestSuites(it)
                 }
-        }
-        .map {
-            val responseMessage: String = buildString {
-                append("Successfully made test suites ")
-                if (isPublic) {
-                    append("public.")
-                } else {
-                    append("private.")
-                }
-                // if (listOfFilteredOutTestSuiteIds.isNotEmpty()) {
-                // append("Test suites [${listOfFilteredOutTestSuiteIds.sorted().joinToString(", ")}] were skipped.")
-                // }
-            }
             ResponseEntity.ok(
                 "Successfully made test suites ${if (isPublic) "public." else "private."}"
             )

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
@@ -433,7 +433,9 @@ class LnkOrganizationTestSuiteController(
                 // append("Test suites [${listOfFilteredOutTestSuiteIds.sorted().joinToString(", ")}] were skipped.")
                 // }
             }
-            ResponseEntity.ok(responseMessage)
+            ResponseEntity.ok(
+                "Successfully made test suites ${if (isPublic) "public." else "private."}"
+            )
         }
 
     private fun getOrganizationIfParticipant(

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -256,6 +256,12 @@ class TestSuitesService(
         dto.version
     ).orNotFound { "TestSuite (name=${dto.name} in ${dto.source.name} with version ${dto.version}) not found" }
 
+    /**
+     * @param testSuites list of test suites to be updated
+     * @return saved [testSuites]
+     */
+    fun updateTestSuites(testSuites: List<TestSuite>): List<TestSuite> = testSuiteRepository.saveAll(testSuites)
+
     companion object {
         private val log = LoggerFactory.getLogger(TestSuitesService::class.java)
     }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/ManageTestSuitePermissionsCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/ManageTestSuitePermissionsCard.kt
@@ -6,11 +6,11 @@
 
 package com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions
 
-import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode.MANAGE
 import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode.MESSAGE
 import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode.PUBLISH
 import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode.SUITE_SELECTOR_FOR_PUBLISH
 import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode.SUITE_SELECTOR_FOR_RIGHTS
+import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode.TRANSFER
 import com.saveourtool.save.frontend.components.basic.testsuiteselector.TestSuiteSelectorPurpose
 import com.saveourtool.save.frontend.components.basic.testsuiteselector.testSuiteSelector
 import com.saveourtool.save.frontend.components.inputform.inputWithDebounceForString
@@ -59,7 +59,12 @@ external interface ManageTestSuitePermissionsComponentProps : Props {
     var closeModal: () -> Unit
 }
 
-@Suppress("TOO_MANY_PARAMETERS", "LongParameterList", "TOO_LONG_FUNCTION")
+@Suppress(
+    "TOO_MANY_PARAMETERS",
+    "LongParameterList",
+    "TOO_LONG_FUNCTION",
+    "LongMethod",
+)
 private fun ChildrenBuilder.displayPermissionManager(
     selectedTestSuites: List<TestSuiteDto>,
     organizationName: String,
@@ -69,6 +74,10 @@ private fun ChildrenBuilder.displayPermissionManager(
     setRequestedRights: (Rights) -> Unit,
 ) {
     div {
+        div {
+            className = ClassName("text-xs text-center font-weight-bold text-primary text-uppercase mb-3")
+            +TRANSFER.purpose.orEmpty()
+        }
         div {
             className = ClassName("row mb-2")
             label {
@@ -127,7 +136,12 @@ private fun ChildrenBuilder.displayPermissionManager(
     }
 }
 
-@Suppress("TOO_MANY_PARAMETERS", "LongParameterList", "TOO_LONG_FUNCTION", "LongMethod")
+@Suppress(
+    "TOO_MANY_PARAMETERS",
+    "LongParameterList",
+    "TOO_LONG_FUNCTION",
+    "LongMethod"
+)
 private fun ChildrenBuilder.displayMassPermissionManager(
     selectedTestSuites: List<TestSuiteDto>,
     isToBePublic: Boolean,
@@ -135,6 +149,10 @@ private fun ChildrenBuilder.displayMassPermissionManager(
     setIsToBePublic: (Boolean) -> Unit,
 ) {
     div {
+        div {
+            className = ClassName("text-xs text-center font-weight-bold text-primary text-uppercase mb-3")
+            +PUBLISH.purpose.orEmpty()
+        }
         div {
             className = ClassName("row mb-2")
             label {
@@ -209,7 +227,7 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
 
     val (isToBePublic, setIsToBePublic) = useState(true)
 
-    val (currentMode, setCurrentMode) = useState(MANAGE)
+    val (currentMode, setCurrentMode) = useState(TRANSFER)
     val (backendResponseMessage, setBackendResponseMessage) = useState("")
     val sendTransferRequest = useDeferredRequest {
         val response = post(
@@ -245,7 +263,7 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
 
     val clearFields = {
         setSelectedTestSuites(emptyList())
-        setCurrentMode(MANAGE)
+        setCurrentMode(TRANSFER)
         setBackendResponseMessage("")
         setRequiredRights(Rights.NONE)
         setOrganizationName("")
@@ -256,12 +274,12 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
         modalProps.isOpen = props.isModalOpen
         modalProps.style = largeTransparentModalStyle
         modalBuilder(
-            title = "Test Suite Permission Manager",
+            title = "Test Suite Permission Manager${currentMode.title?.let { " - $it" }}",
             classes = "modal-lg modal-dialog-scrollable",
             onCloseButtonPressed = { props.closeModal() },
             bodyBuilder = {
                 when (currentMode) {
-                    MANAGE -> displayPermissionManager(
+                    TRANSFER -> displayPermissionManager(
                         selectedTestSuites,
                         organizationName,
                         requiredRights,
@@ -286,7 +304,7 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
             }
         ) {
             when (currentMode) {
-                MANAGE -> {
+                TRANSFER -> {
                     buttonBuilder("Apply", isDisabled = selectedTestSuites.isEmpty()) {
                         sendTransferRequest()
                         setCurrentMode(MESSAGE)
@@ -296,7 +314,7 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
                     }
                 }
                 SUITE_SELECTOR_FOR_RIGHTS -> buttonBuilder("Apply", isDisabled = selectedTestSuites.isEmpty()) {
-                    setCurrentMode(MANAGE)
+                    setCurrentMode(TRANSFER)
                 }
                 SUITE_SELECTOR_FOR_PUBLISH -> buttonBuilder("Apply", isDisabled = selectedTestSuites.isEmpty()) {
                     setCurrentMode(PUBLISH)
@@ -307,20 +325,20 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
                         setCurrentMode(MESSAGE)
                     }
                     buttonBuilder("Transfers", style = "info") {
-                        setCurrentMode(MANAGE)
+                        setCurrentMode(TRANSFER)
                     }
                 }
                 else -> {}
             }
             buttonBuilder("Cancel", "secondary") {
                 when (currentMode) {
-                    MANAGE, PUBLISH, MESSAGE -> {
+                    TRANSFER, PUBLISH, MESSAGE -> {
                         clearFields()
                         props.closeModal()
                     }
                     SUITE_SELECTOR_FOR_RIGHTS -> {
                         setSelectedTestSuites(emptyList())
-                        setCurrentMode(MANAGE)
+                        setCurrentMode(TRANSFER)
                     }
                     SUITE_SELECTOR_FOR_PUBLISH -> {
                         setSelectedTestSuites(emptyList())

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/PermissionManagerMode.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/PermissionManagerMode.kt
@@ -1,0 +1,32 @@
+package com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions
+
+/**
+ * Enum class that defines current state of [manageTestSuitePermissionsComponent] (mostly state of the modal inside component)
+ */
+internal enum class PermissionManagerMode {
+    /**
+     * State when a modal with three input forms is shown: what, where and how to add.
+     */
+    MANAGE,
+
+    /**
+     * State when success (or error) message is shown.
+     */
+    MESSAGE,
+
+    /**
+     * Make test suites public or private
+     */
+    PUBLISH,
+
+    /**
+     * Select test suites that should be managed in case of visibility.
+     */
+    SUITE_SELECTOR_FOR_PUBLISH,
+
+    /**
+     * Select test suites that should be managed in case of rights.
+     */
+    SUITE_SELECTOR_FOR_RIGHTS,
+    ;
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/PermissionManagerMode.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/PermissionManagerMode.kt
@@ -2,13 +2,10 @@ package com.saveourtool.save.frontend.components.basic.organizations.testsuitesp
 
 /**
  * Enum class that defines current state of [manageTestSuitePermissionsComponent] (mostly state of the modal inside component)
+ * @property title
+ * @property purpose
  */
-internal enum class PermissionManagerMode {
-    /**
-     * State when a modal with three input forms is shown: what, where and how to add.
-     */
-    MANAGE,
-
+internal enum class PermissionManagerMode(val title: String? = null, val purpose: String? = null) {
     /**
      * State when success (or error) message is shown.
      */
@@ -17,7 +14,10 @@ internal enum class PermissionManagerMode {
     /**
      * Make test suites public or private
      */
-    PUBLISH,
+    PUBLISH(
+        title = "Visibility mode",
+        purpose = "Make test suites private or public",
+    ),
 
     /**
      * Select test suites that should be managed in case of visibility.
@@ -28,5 +28,13 @@ internal enum class PermissionManagerMode {
      * Select test suites that should be managed in case of rights.
      */
     SUITE_SELECTOR_FOR_RIGHTS,
+
+    /**
+     * State when a modal with three input forms is shown: what, where and how to add.
+     */
+    TRANSFER(
+        title = "Transfer mode",
+        purpose = "Share test suites with selected organization",
+    ),
     ;
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/ChildrenBuilderUtils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/ChildrenBuilderUtils.kt
@@ -38,6 +38,7 @@ enum class ConfirmationType {
  * @param isActive flag that defines whether button should be displayed as pressed or not
  * @param classes additional classes for button
  * @param onClickFun button click handler
+ * @param title title for tooltip
  */
 @Suppress("TOO_MANY_PARAMETERS", "LongParameterList")
 fun ChildrenBuilder.buttonBuilder(
@@ -47,6 +48,7 @@ fun ChildrenBuilder.buttonBuilder(
     isOutline: Boolean = false,
     isActive: Boolean = false,
     classes: String = "",
+    title: String? = null,
     onClickFun: MouseEventHandler<HTMLButtonElement>,
 ) {
     button {
@@ -64,6 +66,11 @@ fun ChildrenBuilder.buttonBuilder(
         className = ClassName("btn btn-$outline$style $active $classes")
         disabled = isDisabled
         onClick = onClickFun
+        title?.let {
+            asDynamic()["data-toggle"] = "tooltip"
+            asDynamic()["data-placement"] = "top"
+        }
+        this.title = title
         +label
     }
 }


### PR DESCRIPTION
This PR closes #1276

### What's done:
* Improved `manageTestSuitePermissionsComponent` to be able to manage test suite visibility
* Moved `PermissionManagerMode` to separate file
* Added endpoint to make a batch of test suites public/private

### How it looks now:
https://user-images.githubusercontent.com/35039155/196665399-e8f44921-5049-4426-991b-e8917f82c1fd.mov

