### PR TITLE
[Helm] Set another port as a management port for all JVM services

### DIFF
--- a/save-cloud-charts/save-cloud/templates/backend-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-configmap.yaml
@@ -8,3 +8,6 @@ data:
     backend.orchestrator-url=http://orchestrator
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*
+    management.server.port={{ .Values.backend.managementPort }}
+    spring.datasource.url=${spring.datasource.backend-url}
+    logging.level.org.springframework.cloud=DEBUG

--- a/save-cloud-charts/save-cloud/templates/orchestrator-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/orchestrator-configmap.yaml
@@ -12,6 +12,7 @@ data:
 
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*
+    management.server.port={{ .Values.orchestrator.managementPort }}
     orchestrator.agent-settings.orchestrator-url=http://{{ .Values.orchestrator.name }}
     orchestrator.agent-settings.backend-url=http://{{ .Values.backend.name }}
     orchestrator.agent-settings.debug=true

--- a/save-cloud-charts/save-cloud/templates/preprocessor-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/preprocessor-configmap.yaml
@@ -8,3 +8,4 @@ data:
     save.orchestrator=http://orchestrator
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*
+    management.server.port={{ .Values.preprocessor.managementPort }}

--- a/save-cloud-charts/save-cloud/templates/sandbox-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/sandbox-configmap.yaml
@@ -12,6 +12,7 @@ data:
 
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*
+    management.server.port={{ .Values.sandbox.managementPort }}
     sandbox.agent-settings.orchestrator-url=http://{{ .Values.sandbox.name }}
     sandbox.agent-settings.backend-url=http://{{ .Values.sandbox.name }}
     sandbox.agent-settings.debug=true

--- a/save-cloud-charts/save-cloud/values.yaml
+++ b/save-cloud-charts/save-cloud/values.yaml
@@ -10,6 +10,7 @@ backend:
   profile: dev,secure,kubernetes
   imageName: save-backend
   containerPort: 5800
+  managementPort: 5801
   # Fixed ClusterIP can be assigned to make it easier to query backend from services outside Kubernetes.
   # Should be chosen depending on cluster's network configuration: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address.
   clusterIP: null
@@ -21,6 +22,7 @@ orchestrator:
   name: orchestrator
   imageName: save-orchestrator
   containerPort: 5100
+  managementPort: 5101
   # Fixed ClusterIP can be assigned to make it easier to query orchestrator from services outside Kubernetes
   clusterIP: null
   dockerHost: tcp://${HOST_IP}:2375
@@ -28,6 +30,7 @@ sandbox:
   name: sandbox
   imageName: save-sandbox
   containerPort: 5400
+  managementPort: 5401
   # Fixed ClusterIP can be assigned to make it easier to query orchestrator from services outside Kubernetes
   clusterIP: null
   dockerHost: tcp://${HOST_IP}:2375
@@ -35,6 +38,7 @@ preprocessor:
   name: preprocessor
   imageName: save-preprocessor
   containerPort: 5200
+  managementPort: 5201
   # Fixed ClusterIP can be assigned to make it easier to query preprocessor from services outside Kubernetes
   clusterIP: null
 gateway:


### PR DESCRIPTION
Extracted from #1238; part of #1049. This PR moves `/actuator` as well as `/swagger-ui.html` to a new port, that would be protected by a `NetworkPolicy` under #1247.