### PR TITLE
Make default docker swarm network `attachable`

### DIFF
--- a/.github/workflows/build-base-images.yaml
+++ b/.github/workflows/build-base-images.yaml
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare formatted tags
         run: |
-          echo FORMATTED_TAG=${{ matrix.base_image_tag }} | sed -e "s/$-focal$//" >> $GITHUB_ENV
+          echo FORMATTED_TAG=${{ matrix.base_image_tag }} | sed -e "s/-focal$//" >> $GITHUB_ENV
       - uses: docker/build-push-action@v3
         with:
           context: save-deploy/base-images

--- a/.github/workflows/build-base-images.yaml
+++ b/.github/workflows/build-base-images.yaml
@@ -21,11 +21,11 @@ jobs:
         # This should replicate list of SDKs from com.saveourtool.save.domain.Sdk
         include:
           - base_image_name: eclipse-temurin
-            base_image_tag: 8
+            base_image_tag: 8-focal
           - base_image_name: eclipse-temurin
-            base_image_tag: 11
+            base_image_tag: 11-focal
           - base_image_name: eclipse-temurin
-            base_image_tag: 17
+            base_image_tag: 17-focal
           - base_image_name: python
             base_image_tag: 2.7
           - base_image_name: python
@@ -47,7 +47,7 @@ jobs:
           - base_image_name: python
             base_image_tag: '3.10'
           - base_image_name: ubuntu
-            base_image_tag: latest
+            base_image_tag: '20.04'
     steps:
       - uses: actions/checkout@v3
       - if: github.event_name == 'workflow_dispatch'
@@ -60,6 +60,9 @@ jobs:
           registry: ghcr.io
           username: saveourtool
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare formatted tags
+        run: |
+          echo FORMATTED_TAG=${{ matrix.base_image_tag }} | sed -e "s/$-focal$//" >> $GITHUB_ENV
       - uses: docker/build-push-action@v3
         with:
           context: save-deploy/base-images
@@ -69,4 +72,4 @@ jobs:
           build-args: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
-          tags: ghcr.io/saveourtool/save-base:${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}
+          tags: ghcr.io/saveourtool/save-base:${{ matrix.base_image_name }}-${{ env.FORMATTED_TAG }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -150,6 +150,11 @@ services:
         constraints:
           - "node.role==manager"
 
+networks:
+  default:
+    driver: overlay
+    attachable: true
+
 volumes:
   save:
   save-fs-storage:

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
@@ -192,6 +192,9 @@ class DockerAgentRunner(
             )
             .withHostConfig(
                 HostConfig.newHostConfig()
+                    .run {
+                        System.getenv("DOCKER_NETWORK_NAME")?.let(::withNetworkMode) ?: this
+                    }
                     .withRuntime(settings.runtime)
                     // processes from inside the container will be able to access host's network using this hostname
                     .withExtraHosts("host.docker.internal:${getHostIp()}")
@@ -224,13 +227,6 @@ class DockerAgentRunner(
             envFileTargetPath.substringBeforeLast("/"),
             listOf(envFile.toFile())
         )
-
-        System.getenv("DOCKER_NETWORK_NAME")?.let { networkName ->
-            dockerClient.connectToNetworkCmd()
-                .withContainerId(containerId)
-                .withNetworkId(networkName)
-                .exec()
-        }
 
         return containerId
     }

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/docker/DockerAgentRunner.kt
@@ -192,9 +192,6 @@ class DockerAgentRunner(
             )
             .withHostConfig(
                 HostConfig.newHostConfig()
-                    .run {
-                        System.getenv("DOCKER_NETWORK_NAME")?.let(::withNetworkMode) ?: this
-                    }
                     .withRuntime(settings.runtime)
                     // processes from inside the container will be able to access host's network using this hostname
                     .withExtraHosts("host.docker.internal:${getHostIp()}")
@@ -227,6 +224,13 @@ class DockerAgentRunner(
             envFileTargetPath.substringBeforeLast("/"),
             listOf(envFile.toFile())
         )
+
+        System.getenv("DOCKER_NETWORK_NAME")?.let { networkName ->
+            dockerClient.connectToNetworkCmd()
+                .withContainerId(containerId)
+                .withNetworkId(networkName)
+                .exec()
+        }
 
         return containerId
     }


### PR DESCRIPTION
* Make default docker swarm network `attachable`. This is required to be able to attach agents to this network and use service name based DNS
* Change base images for save-base JDK to ubuntu-focal based images of eclipse-temurin. Containers based on Ubuntu 22 don't work normally (on Ubuntu 20? Or on an older version of Docker?)