### PR TITLE
Test suite permissions improvements

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/TestSuitePermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/TestSuitePermissionEvaluator.kt
@@ -1,8 +1,6 @@
 package com.saveourtool.save.backend.security
 
 import com.saveourtool.save.backend.service.LnkOrganizationTestSuiteService
-import com.saveourtool.save.backend.utils.hasRole
-import com.saveourtool.save.domain.Role
 import com.saveourtool.save.entities.Organization
 import com.saveourtool.save.entities.TestSuite
 import com.saveourtool.save.permission.Permission
@@ -30,7 +28,7 @@ class TestSuitePermissionEvaluator(
         permission: Permission,
         authentication: Authentication?,
     ): Boolean = lnkOrganizationTestSuiteService.getDto(organization, testSuite).rights.let { currentRights ->
-        authentication?.hasRole(Role.SUPER_ADMIN) == true || when (permission) {
+        when (permission) {
             Permission.READ -> testSuite.isPublic || canAccessTestSuite(currentRights)
             Permission.WRITE, Permission.DELETE -> canMaintainTestSuite(currentRights)
         }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
@@ -17,7 +17,7 @@ const val URL_PATH_DELIMITER = "/"
 /**
  * Period in ms for debounce on frontend
  */
-const val DEFAULT_DEBOUNCE_PERIOD = 750
+const val DEFAULT_DEBOUNCE_PERIOD = 250
 
 /**
  * Period in ms for ace editor debouncing

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
@@ -149,7 +149,7 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
             setTestSuiteSourceWithIdToUpsert(null)
             testSuitesSourceUpsertWindowOpenness.openWindow()
         }
-        buttonBuilder("Manage permissions", "info", !props.selfRole.hasWritePermission(), classes = "btn-sm ml-2") {
+        buttonBuilder("Manage permissions", "info", !props.selfRole.hasWritePermission(), classes = "btn-sm mr-2 ml-2") {
             setManagePermissionsMode(PermissionManagerMode.TRANSFER)
         }
         buttonBuilder("Publish test suites", "info", !props.selfRole.hasWritePermission(), classes = "btn-sm ml-2") {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
@@ -8,6 +8,7 @@
 package com.saveourtool.save.frontend.components.basic.organizations
 
 import com.saveourtool.save.domain.Role
+import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.PermissionManagerMode
 import com.saveourtool.save.frontend.components.basic.organizations.testsuitespermissions.manageTestSuitePermissionsComponent
 import com.saveourtool.save.frontend.components.basic.testsuitessources.fetch.testSuitesSourceFetcher
 import com.saveourtool.save.frontend.components.basic.testsuitessources.showTestSuiteSourceUpsertModal
@@ -128,11 +129,12 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
         setTestSuitesSourceSnapshotKeys(testSuitesSourceSnapshotKeys.filterNot(it::equals))
     }
     val testSuitesSourceSnapshotKeysTable = prepareTestSuitesSourceSnapshotKeysTable(deleteHandler)
-    val testSuitePermissionModalOpener = useWindowOpenness()
+    val (managePermissionsMode, setManagePermissionsMode) = useState<PermissionManagerMode?>(null)
     manageTestSuitePermissionsComponent {
         organizationName = props.organizationName
-        isModalOpen = testSuitePermissionModalOpener.isOpen()
-        closeModal = testSuitePermissionModalOpener.closeWindowAction()
+        isModalOpen = managePermissionsMode != null
+        closeModal = { setManagePermissionsMode(null) }
+        mode = managePermissionsMode
     }
     showTestSuiteSourceUpsertModal(
         windowOpenness = testSuitesSourceUpsertWindowOpenness,
@@ -148,7 +150,10 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
             testSuitesSourceUpsertWindowOpenness.openWindow()
         }
         buttonBuilder("Manage permissions", "info", !props.selfRole.hasWritePermission(), classes = "btn-sm ml-2") {
-            testSuitePermissionModalOpener.openWindow()
+            setManagePermissionsMode(PermissionManagerMode.TRANSFER)
+        }
+        buttonBuilder("Publish test suites", "info", !props.selfRole.hasWritePermission(), classes = "btn-sm ml-2") {
+            setManagePermissionsMode(PermissionManagerMode.PUBLISH)
         }
     }
     div {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/PermissionManagerMode.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/PermissionManagerMode.kt
@@ -5,7 +5,7 @@ package com.saveourtool.save.frontend.components.basic.organizations.testsuitesp
  * @property title
  * @property purpose
  */
-internal enum class PermissionManagerMode(val title: String? = null, val purpose: String? = null) {
+enum class PermissionManagerMode(val title: String? = null, val purpose: String? = null) {
     /**
      * State when success (or error) message is shown.
      */


### PR DESCRIPTION
This PR closes #1350

### What's done:
 * Removed logic for super admins from `TestSuitePermissionEvaluator`
 * Split different modes of permission management (`PUBLISH` and `TRANSFER`)
 * Fixed unexpected null in modal title
 * Changed default debounce period (`750` -> `250`)
 * Changed placeholder for organization name input form