### PR TITLE
Body of DELETE request should always be undefined

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/FileUploader.kt
@@ -229,7 +229,6 @@ fun <F : AbstractFileInfo> fileUploader() = FC<UploaderProps<F>> { props ->
             val response = delete(
                 props.getUrlForFileDeletion(fileToDelete),
                 jsonHeaders,
-                undefined,
                 loadingHandler = ::noopLoadingHandler,
             )
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
@@ -133,7 +133,6 @@ private fun manageUserRoleCardComponent() = FC<ManageUserRoleCardProps> { props 
         val response = delete(
             url = "$apiUrl/${props.groupType}s/${props.groupPath}/users/roles/${userToDelete.name}",
             headers = jsonHeaders,
-            body = Json.encodeToString(userToDelete),
             loadingHandler = ::loadingHandler,
         )
         if (!response.ok) {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/ManageGitCredentialsCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/ManageGitCredentialsCard.kt
@@ -224,7 +224,6 @@ private fun prepareDeleteGitCredential(
         val response = delete(
             url = "$apiUrl/organizations/$organizationName/delete-git?url=${gitCredentialToDelete.url}",
             headers = jsonHeaders,
-            body = undefined,
             loadingHandler = ::loadingHandler,
         )
         if (!response.ok) {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
@@ -99,8 +99,6 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
                 url = "$apiUrl/test-suites-sources/${key.organizationName}/${encodeURIComponent(key.testSuitesSourceName)}/delete-test-suites-and-snapshot?version=${key.version}",
                 headers = jsonHeaders,
                 loadingHandler = ::loadingHandler,
-                // TODO: body is forbidden in delete in some implementations, probably we should not support it
-                body = undefined
             )
             setTestSuitesSourceSnapshotKeyToDelete(null)
         }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectSettingsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectSettingsMenu.kt
@@ -97,7 +97,6 @@ private fun projectSettingsMenu() = FC<ProjectSettingsMenuProps> { props ->
         val responseFromDeleteProject = delete(
             "$apiUrl/projects/$projectPath/delete",
             jsonHeaders,
-            body = undefined,
             loadingHandler = ::noopLoadingHandler,
         )
         if (responseFromDeleteProject.ok) {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
@@ -744,7 +744,6 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
         val response = delete(
             url = "$apiUrl/projects/${project.organization.name}/${project.name}/delete",
             headers = jsonHeaders,
-            body = undefined,
             loadingHandler = ::noopLoadingHandler,
             errorHandler = ::noopResponseHandler,
         )

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/DeleteOrganizationButton.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/DeleteOrganizationButton.kt
@@ -34,7 +34,6 @@ val deleteOrganizationButton: FC<DeleteOrganizationButtonProps> = FC { props ->
                 delete(
                     "$apiUrl/organizations/${props.organizationName}/delete",
                     headers = jsonHeaders,
-                    body = undefined,
                     loadingHandler = ::noopLoadingHandler,
                     errorHandler = ::noopResponseHandler,
                 )

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/RequestUtils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/RequestUtils.kt
@@ -193,10 +193,9 @@ suspend fun ComponentWithScope<*, *>.post(
 suspend fun ComponentWithScope<*, *>.delete(
     url: String,
     headers: Headers,
-    body: dynamic,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-) = request(url, "DELETE", headers, body, loadingHandler = loadingHandler, responseHandler = responseHandler)
+) = request(url, "DELETE", headers, loadingHandler = loadingHandler, responseHandler = responseHandler)
 
 /**
  * Perform GET request from a functional component
@@ -231,8 +230,6 @@ suspend fun WithRequestStatusContext.post(
  * @param url the request URL.
  * @param headers the HTTP request headers.
  *   Use [jsonHeaders] for the standard `Accept` and `Content-Type` headers.
- * @param body the HTTP request body.
- *   Use [undefined] for an empty body.
  * @param loadingHandler use either [WithRequestStatusContext.loadingHandler],
  *   or [noopLoadingHandler].
  * @param errorHandler the response handler to be invoked.
@@ -254,10 +251,9 @@ suspend fun WithRequestStatusContext.post(
 suspend fun WithRequestStatusContext.delete(
     url: String,
     headers: Headers,
-    body: dynamic,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     errorHandler: (Response) -> Unit = this::withModalResponseHandler,
-) = request(url, "DELETE", headers, body, loadingHandler = loadingHandler, responseHandler = errorHandler)
+) = request(url, "DELETE", headers, loadingHandler = loadingHandler, responseHandler = errorHandler)
 
 /**
  * Handler that allows to show loading modal


### PR DESCRIPTION
As far as in some implementations `DELETE` method might have a body and is some it might not, it is not a good idea to support not-`undefined` body.

### What's done:
 * Forbade `DELETE` request method to have anything but `undefined` as its body