### PR TITLE
Support the `onlyActive` parameter for the `/organizations/all` call to avoid client-side filtering

### DIFF
--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -5704,10 +5704,14 @@
         "operationId": "getAllOrganizations",
         "parameters": [
           {
-            "name": "organizationName",
-            "in": "path",
-            "description": "name of an organization",
-            "required": true
+            "name": "onlyActive",
+            "in": "query",
+            "description": "Whether deleted organizations should be excluded from the response. The default is false.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -8453,13 +8457,13 @@
               "DECEMBER"
             ]
           },
-          "monthNumber": {
-            "type": "integer",
-            "format": "int32"
-          },
           "value$kotlinx_datetime": {
             "type": "string",
             "format": "date"
+          },
+          "monthNumber": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
@@ -8545,6 +8549,10 @@
           "date": {
             "$ref": "#/components/schemas/LocalDate"
           },
+          "value$kotlinx_datetime": {
+            "type": "string",
+            "format": "date-time"
+          },
           "monthNumber": {
             "type": "integer",
             "format": "int32"
@@ -8552,10 +8560,6 @@
           "nanosecond": {
             "type": "integer",
             "format": "int32"
-          },
-          "value$kotlinx_datetime": {
-            "type": "string",
-            "format": "date-time"
           }
         }
       },
@@ -8584,12 +8588,12 @@
             "type": "integer",
             "format": "int32"
           },
+          "value$kotlinx_datetime": {
+            "$ref": "#/components/schemas/LocalTime"
+          },
           "nanosecond": {
             "type": "integer",
             "format": "int32"
-          },
-          "value$kotlinx_datetime": {
-            "$ref": "#/components/schemas/LocalTime"
           }
         }
       },

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -70,6 +70,12 @@ internal class OrganizationController(
 ) {
     private val webClientToPreprocessor = WebClient.create(config.preprocessorUrl)
 
+    /**
+     * @param includeDeleted whether deleted organizations should be included in
+     *   the response.
+     *   The default is `true`.
+     * @return the list of organizations.
+     */
     @GetMapping("/all")
     @PreAuthorize("permitAll()")
     @Operation(
@@ -77,12 +83,15 @@ internal class OrganizationController(
         summary = "Get all organizations",
         description = "Get organizations",
     )
-    @Parameters(
-        Parameter(name = "organizationName", `in` = ParameterIn.PATH, description = "name of an organization", required = true),
-    )
     @ApiResponse(responseCode = "200", description = "Successfully fetched all registered organizations")
-    fun getAllOrganizations() = Mono.fromCallable {
-        organizationService.findAll()
+    fun getAllOrganizations(
+        @RequestParam(required = false, defaultValue = "true") includeDeleted: Boolean
+    ): Mono<List<Organization>> = Mono.fromCallable {
+        when {
+            includeDeleted -> organizationService.findAll()
+
+            else -> organizationService.getFiltered(organizationFilters = OrganizationFilters.empty)
+        }
     }
 
     @PostMapping("/not-deleted")

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -70,18 +70,20 @@ internal class OrganizationController(
 ) {
     private val webClientToPreprocessor = WebClient.create(config.preprocessorUrl)
 
-    /**
-     * @param onlyActive whether deleted organizations should be excluded in
-     *   the response.
-     *   The default is `false`.
-     * @return the list of organizations.
-     */
     @GetMapping("/all")
     @PreAuthorize("permitAll()")
     @Operation(
         method = "GET",
         summary = "Get all organizations",
         description = "Get organizations",
+    )
+    @Parameters(
+        Parameter(
+            name = "onlyActive",
+            `in` = ParameterIn.QUERY,
+            description = "Whether deleted organizations should be excluded from the response. The default is false.",
+            required = false
+        ),
     )
     @ApiResponse(responseCode = "200", description = "Successfully fetched all registered organizations")
     fun getAllOrganizations(

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -71,9 +71,9 @@ internal class OrganizationController(
     private val webClientToPreprocessor = WebClient.create(config.preprocessorUrl)
 
     /**
-     * @param includeDeleted whether deleted organizations should be included in
+     * @param onlyActive whether deleted organizations should be excluded in
      *   the response.
-     *   The default is `true`.
+     *   The default is `false`.
      * @return the list of organizations.
      */
     @GetMapping("/all")
@@ -85,12 +85,12 @@ internal class OrganizationController(
     )
     @ApiResponse(responseCode = "200", description = "Successfully fetched all registered organizations")
     fun getAllOrganizations(
-        @RequestParam(required = false, defaultValue = "true") includeDeleted: Boolean
+        @RequestParam(required = false, defaultValue = "false") onlyActive: Boolean
     ): Mono<List<Organization>> = Mono.fromCallable {
         when {
-            includeDeleted -> organizationService.findAll()
+            onlyActive -> organizationService.getFiltered(organizationFilters = OrganizationFilters.empty)
 
-            else -> organizationService.getFiltered(organizationFilters = OrganizationFilters.empty)
+            else -> organizationService.findAll()
         }
     }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
@@ -3,7 +3,6 @@
 package com.saveourtool.save.frontend.components.views
 
 import com.saveourtool.save.entities.Organization
-import com.saveourtool.save.entities.OrganizationStatus.DELETED
 import com.saveourtool.save.frontend.components.modal.ModalDialogStrings
 import com.saveourtool.save.frontend.components.tables.TableProps
 import com.saveourtool.save.frontend.components.tables.tableComponent
@@ -153,18 +152,13 @@ internal class OrganizationAdminView : AbstractView<Props, OrganizationAdminStat
      */
     private suspend fun getOrganizations(): MutableList<Organization> {
         val response = get(
-            url = "$apiUrl/organizations/all",
+            url = "$apiUrl/organizations/all?includeDeleted=${false}",
             headers = jsonHeaders,
             loadingHandler = ::classLoadingHandler,
         )
 
         return when {
-            response.ok -> response.decodeFromJsonString<Array<Organization>>()
-                .asSequence()
-                .filter { organization ->
-                    organization.status != DELETED
-                }
-                .toMutableList()
+            response.ok -> response.decodeFromJsonString()
 
             else -> mutableListOf()
         }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
@@ -152,7 +152,7 @@ internal class OrganizationAdminView : AbstractView<Props, OrganizationAdminStat
      */
     private suspend fun getOrganizations(): MutableList<Organization> {
         val response = get(
-            url = "$apiUrl/organizations/all?includeDeleted=${false}",
+            url = "$apiUrl/organizations/all?onlyActive=${true}",
             headers = jsonHeaders,
             loadingHandler = ::classLoadingHandler,
         )


### PR DESCRIPTION
Closes #1365.