### PR TITLE
manageTestSuitePermissionsComponent fix

### DIFF
--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -6628,6 +6628,7 @@
             }
           },
           {
+            "description": "requested permission: READ, WRITE or DELETE",
             "in": "query",
             "name": "permission",
             "required": true,

--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -6628,18 +6628,22 @@
             }
           },
           {
-            "description": "is given request sent for browsing test suites for contest, default is false",
             "in": "query",
-            "name": "isContest",
-            "required": false,
+            "name": "permission",
+            "required": true,
             "schema": {
-              "type": "boolean",
-              "default": false
+              "type": "string",
+              "enum": [
+                "DELETE",
+                "READ",
+                "WRITE"
+              ]
             }
           },
           {
+            "description": "is given request sent for browsing test suites for contest, default is false",
             "in": "query",
-            "name": "onlyPrivate",
+            "name": "isContest",
             "required": false,
             "schema": {
               "type": "boolean",

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
@@ -76,6 +76,7 @@ class LnkOrganizationTestSuiteController(
     )
     @Parameters(
         Parameter(name = "organizationName", `in` = ParameterIn.PATH, description = "name of an organization", required = true),
+        Parameter(name = "permission", `in` = ParameterIn.QUERY, description = "requested permission: READ, WRITE or DELETE", required = true),
         Parameter(name = "isContest", `in` = ParameterIn.QUERY, description = "is given request sent for browsing test suites for contest, default is false", required = false),
     )
     @ApiResponse(responseCode = "200", description = "Successfully fetched test suites available for given organization.")

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkOrganizationTestSuiteController.kt
@@ -83,8 +83,8 @@ class LnkOrganizationTestSuiteController(
     @ApiResponse(responseCode = "404", description = "Organization with such name was not found.")
     fun getAvailableTestSuitesByOrganization(
         @PathVariable organizationName: String,
+        @RequestParam permission: Permission,
         @RequestParam(defaultValue = "false") isContest: Boolean,
-        @RequestParam(defaultValue = "false") onlyPrivate: Boolean,
         authentication: Authentication,
     ): Flux<TestSuiteDto> = getOrganizationIfParticipant(organizationName, authentication)
         .map { organization ->
@@ -96,11 +96,7 @@ class LnkOrganizationTestSuiteController(
                 testSuitePermissionEvaluator.hasPermission(
                     organization,
                     testSuite,
-                    if (onlyPrivate) {
-                        Permission.WRITE
-                    } else {
-                        Permission.READ
-                    },
+                    permission,
                     authentication,
                 )
             }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -8,6 +8,7 @@ import com.saveourtool.save.entities.TestSuite
 import com.saveourtool.save.entities.TestSuitesSource
 import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.filters.TestSuiteFilters
+import com.saveourtool.save.permission.Rights
 import com.saveourtool.save.testsuite.TestSuiteDto
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.orNotFound
@@ -35,6 +36,7 @@ class TestSuitesService(
     private val testExecutionRepository: TestExecutionRepository,
     private val testSuitesSourceService: TestSuitesSourceService,
     private val testSuitesSourceSnapshotStorage: TestSuitesSourceSnapshotStorage,
+    private val lnkOrganizationTestSuiteService: LnkOrganizationTestSuiteService,
     private val executionService: ExecutionService,
     private val agentStatusService: AgentStatusService,
     private val agentService: AgentService,
@@ -84,6 +86,7 @@ class TestSuitesService(
             }
         testSuiteRepository.save(testSuite)
         testSuitesSourceService.update(testSuiteSource)
+        lnkOrganizationTestSuiteService.setOrDeleteRights(testSuiteSource.organization, testSuite, Rights.MAINTAIN)
         return testSuite
     }
 

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeUnit
     MockBean(LnkUserProjectRepository::class),
     MockBean(OriginalLoginRepository::class),
     MockBean(LnkContestProjectService::class),
+    MockBean(LnkOrganizationTestSuiteService::class),
 )
 @AutoConfigureWebTestClient
 @Suppress("UnsafeCallOnNullableType")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/ManageTestSuitePermissionsCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/testsuitespermissions/ManageTestSuitePermissionsCard.kt
@@ -286,7 +286,10 @@ private fun manageTestSuitePermissionsComponent() = FC<ManageTestSuitePermission
         modalBuilder(
             title = "Test Suite Permission Manager${currentMode.title?.let { " - $it" }.orEmpty()}",
             classes = "modal-lg modal-dialog-scrollable",
-            onCloseButtonPressed = { props.closeModal() },
+            onCloseButtonPressed = {
+                props.closeModal()
+                clearFields()
+            },
             bodyBuilder = {
                 when (currentMode) {
                     TRANSFER -> displayPermissionManager(

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelectorBrowserMode.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelectorBrowserMode.kt
@@ -147,13 +147,20 @@ private fun ChildrenBuilder.showAvaliableOptions(
 ) {
     ul {
         className = ClassName("list-group")
-        options.forEach { option ->
+        if (options.isEmpty()) {
             li {
                 className = ClassName("list-group-item")
-                onClick = {
-                    onOptionClick(option)
+                +"There is no test suite that you can manage."
+            }
+        } else {
+            options.forEach { option ->
+                li {
+                    className = ClassName("list-group-item")
+                    onClick = {
+                        onOptionClick(option)
+                    }
+                    +option
                 }
-                +option
             }
         }
     }
@@ -174,9 +181,9 @@ private fun testSuiteSelectorBrowserMode() = FC<TestSuiteSelectorBrowserModeProp
     val (fetchedTestSuites, setFetchedTestSuites) = useState<List<TestSuiteDto>>(emptyList())
     useRequest {
         val options = when (props.selectorPurpose) {
-            TestSuiteSelectorPurpose.PUBLIC -> ""
-            TestSuiteSelectorPurpose.PRIVATE -> "?onlyPrivate=true"
-            TestSuiteSelectorPurpose.CONTEST -> "?isContest=true"
+            TestSuiteSelectorPurpose.PUBLIC -> "?permission=READ"
+            TestSuiteSelectorPurpose.PRIVATE -> "?permission=WRITE"
+            TestSuiteSelectorPurpose.CONTEST -> "?permission=READ&isContest=true"
         }
         val response = get(
             url = "$apiUrl/test-suites/${props.currentOrganizationName}/available$options",


### PR DESCRIPTION
This PR closes #1413

### What's done:
 * Fixed `testSuiteSelectorBrowserMode` to show if no test suites are found
 * Fixed endpoint `/test-suites/{organizationName}/available`
 * Added `LnkOrganizationTestSuite` creation when fetching source