### PR TITLE
Inject `WebClientCustomizer`s as a collection

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,7 @@ spring-data-jpa = { module = "org.springframework.data:spring-data-jpa" }
 spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
 spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test" }
 spring-web = { module = "org.springframework:spring-web", version.ref = "spring" }
+spring-webflux = { module = "org.springframework:spring-webflux" }
 spring-jdbc-starter = { module = "org.springframework.boot:spring-boot-starter-data-jdbc" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
 

--- a/save-backend/build.gradle.kts
+++ b/save-backend/build.gradle.kts
@@ -24,7 +24,7 @@ openApi {
     waitTimeInSeconds.set(120)
 
     customBootRun {
-        jvmArgs.add("-Dbackend.fileStorage.location=\${HOME}/cnb/files")
+        jvmArgs.add("-Dbackend.fileStorage.location=\${user.home}/cnb/files")
     }
 }
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
@@ -21,9 +21,11 @@ import com.saveourtool.save.utils.switchIfEmptyToResponseException
 import com.saveourtool.save.v1
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.saveourtool.save.spring.utils.applyAll
 import generated.SAVE_CLOUD_VERSION
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.Logger
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -54,12 +56,14 @@ class RunExecutionController(
     private val meterRegistry: MeterRegistry,
     private val configProperties: ConfigProperties,
     objectMapper: ObjectMapper,
+    customizers: List<WebClientCustomizer>,
 ) {
     private val webClientOrchestrator = WebClient.builder()
         .baseUrl(configProperties.orchestratorUrl)
         .codecs {
             it.defaultCodecs().multipartCodecs().encoder(Jackson2JsonEncoder(objectMapper))
         }
+        .applyAll(customizers)
         .build()
     private val scheduler = Schedulers.boundedElastic()
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
@@ -13,6 +13,7 @@ import com.saveourtool.save.execution.ExecutionUpdateDto
 import com.saveourtool.save.execution.TestingType
 import com.saveourtool.save.permission.Permission
 import com.saveourtool.save.request.CreateExecutionRequest
+import com.saveourtool.save.spring.utils.applyAll
 import com.saveourtool.save.utils.blockingToMono
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.getLogger
@@ -21,7 +22,6 @@ import com.saveourtool.save.utils.switchIfEmptyToResponseException
 import com.saveourtool.save.v1
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.saveourtool.save.spring.utils.applyAll
 import generated.SAVE_CLOUD_VERSION
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.Logger

--- a/save-cloud-common/build.gradle.kts
+++ b/save-cloud-common/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             dependencies {
                 implementation(project.dependencies.platform(libs.spring.boot.dependencies))
                 implementation(libs.spring.web)
+                implementation(libs.spring.webflux)
                 implementation(libs.spring.boot)
                 implementation(libs.spring.data.jpa)
                 implementation(libs.jackson.module.kotlin)

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/spring/utils/WebClientUtils.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/spring/utils/WebClientUtils.kt
@@ -1,0 +1,25 @@
+/**
+ * Utilities for spring WebClient
+ */
+
+package com.saveourtool.save.spring.utils
+
+import com.saveourtool.save.utils.debug
+import org.slf4j.LoggerFactory
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
+import org.springframework.web.reactive.function.client.WebClient
+
+private val logger = LoggerFactory.getLogger("com.saveourtool.save.spring.utils.WebClientUtils")
+
+/**
+ * Applies all [WebClientCustomizer]s from [customizers] to [this] [WebClient.Builder].
+ *
+ * @param customizers [WebClientCustomizer]s to be applied
+ * @return the modified builder
+ */
+fun WebClient.Builder.applyAll(customizers: Iterable<WebClientCustomizer>): WebClient.Builder = apply { builder ->
+    customizers.forEach { customizer ->
+        logger.debug { "Applying a WebClientCustomizer of type ${customizer::class.qualifiedName}" }
+        customizer.customize(builder)
+    }
+}

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/BackendAgentRepository.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/BackendAgentRepository.kt
@@ -8,9 +8,11 @@ import com.saveourtool.save.entities.AgentStatusDto
 import com.saveourtool.save.entities.AgentStatusesForExecution
 import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.execution.ExecutionUpdateDto
+import com.saveourtool.save.spring.utils.applyAll
 import com.saveourtool.save.utils.*
 import org.slf4j.Logger
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 import org.springframework.http.ResponseEntity
 
 import org.springframework.stereotype.Component
@@ -26,8 +28,13 @@ internal typealias BodilessResponseEntity = ResponseEntity<Void>
 @Component
 class BackendAgentRepository(
     @Value("\${orchestrator.backend-url}") private val backendUrl: String,
+    customizers: List<WebClientCustomizer>,
 ) : AgentRepository {
-    private val webClientBackend = WebClient.create(backendUrl)
+    private val webClientBackend = WebClient.builder()
+        .baseUrl(backendUrl)
+        .applyAll(customizers)
+        .build()
+
     override fun getInitConfig(containerId: String): Mono<AgentInitConfig> = webClientBackend
         .get()
         .uri("/agents/get-init-config?containerId=$containerId")

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/AwesomeBenchmarksDownloadController.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/AwesomeBenchmarksDownloadController.kt
@@ -5,10 +5,11 @@ import com.saveourtool.save.entities.benchmarks.BenchmarkEntity
 import com.saveourtool.save.preprocessor.config.ConfigProperties
 import com.saveourtool.save.preprocessor.service.GitPreprocessorService
 import com.saveourtool.save.preprocessor.utils.*
+import com.saveourtool.save.spring.utils.applyAll
 
 import com.akuleshov7.ktoml.file.TomlFileReader
-import com.saveourtool.save.spring.utils.applyAll
 import org.slf4j.LoggerFactory
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,7 +26,6 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.div
 import kotlinx.serialization.serializer
-import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 
 /**
  * A Spring controller for git project downloading

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/AwesomeBenchmarksDownloadController.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/AwesomeBenchmarksDownloadController.kt
@@ -7,6 +7,7 @@ import com.saveourtool.save.preprocessor.service.GitPreprocessorService
 import com.saveourtool.save.preprocessor.utils.*
 
 import com.akuleshov7.ktoml.file.TomlFileReader
+import com.saveourtool.save.spring.utils.applyAll
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -24,6 +25,7 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.div
 import kotlinx.serialization.serializer
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 
 /**
  * A Spring controller for git project downloading
@@ -35,8 +37,12 @@ import kotlinx.serialization.serializer
 class AwesomeBenchmarksDownloadController(
     private val configProperties: ConfigProperties,
     private val gitPreprocessorService: GitPreprocessorService,
+    customizers: List<WebClientCustomizer>,
 ) {
-    private val webClientBackend = WebClient.create(configProperties.backend)
+    private val webClientBackend = WebClient.builder()
+        .baseUrl(configProperties.backend)
+        .applyAll(customizers)
+        .build()
 
     /**
      * Controller to download standard test suites


### PR DESCRIPTION
* Add extension function `WebClient.Builder.applyAll`
* Inject `WebClientCustomizer`s as an iterable
* Throw exception in preprocessor in case backend answers with non-ok code
* Change `${HOME}` to `${user.home}` to make `generateApiDocs` task platform-independent

This PR was originally a part of #1238. As far as IDEA shows, now there is only one customizer other than ours:  `MetricsWebClientCustomizer` which is configured by `HttpClientMetricsAutoConfiguration`.