### PR TITLE
Add delete, recover and banned Organization logic in backend

### DIFF
--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -2774,6 +2774,16 @@
             },
             "description": "Successfully change status an organization."
           },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid new status of the organization."
+          },
           "401": {
             "content": {
               "*/*": {

--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -2728,6 +2728,103 @@
         ]
       }
     },
+    "/api/v1/organizations/{organizationName}/change-status": {
+      "post": {
+        "description": "Change status existing organization by its name.",
+        "operationId": "deleteOrganization",
+        "parameters": [
+          {
+            "description": "name of an organization",
+            "in": "path",
+            "name": "organizationName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "BANNED",
+                "CREATED",
+                "DELETED"
+              ]
+            }
+          },
+          {
+            "example": "basic",
+            "in": "header",
+            "name": "X-Authorization-Source",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successfully change status an organization."
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not enough permission for this action on organization."
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Could not find an organization with such name."
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "There are projects connected to organization. Please delete all of them and try again."
+          }
+        },
+        "security": [
+          {
+            "basic": []
+          }
+        ],
+        "summary": "Change status existing organization.",
+        "tags": [
+          "organizations"
+        ]
+      }
+    },
     "/api/v1/organizations/{organizationName}/create-git": {
       "post": {
         "description": "Create git in organization.",
@@ -2817,90 +2914,6 @@
           }
         ],
         "summary": "Create git in organization.",
-        "tags": [
-          "organizations"
-        ]
-      }
-    },
-    "/api/v1/organizations/{organizationName}/delete": {
-      "delete": {
-        "description": "Delete existing organization by its name.",
-        "operationId": "deleteOrganization",
-        "parameters": [
-          {
-            "description": "name of an organization",
-            "in": "path",
-            "name": "organizationName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "example": "basic",
-            "in": "header",
-            "name": "X-Authorization-Source",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Successfully deleted an organization."
-          },
-          "401": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Not enough permission for deleting this organization."
-          },
-          "404": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Could not find an organization with such name."
-          },
-          "409": {
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "There are projects connected to organization. Please delete all of them and try again."
-          }
-        },
-        "security": [
-          {
-            "basic": []
-          }
-        ],
-        "summary": "Delete existing organization.",
         "tags": [
           "organizations"
         ]
@@ -6635,6 +6648,7 @@
             "schema": {
               "type": "string",
               "enum": [
+                "BAN",
                 "DELETE",
                 "READ",
                 "WRITE"
@@ -8492,6 +8506,7 @@
           "status": {
             "type": "string",
             "enum": [
+              "BANNED",
               "CREATED",
               "DELETED"
             ]
@@ -8555,6 +8570,7 @@
           "status": {
             "type": "string",
             "enum": [
+              "BANNED",
               "CREATED",
               "DELETED"
             ]
@@ -8605,6 +8621,7 @@
           "status": {
             "type": "string",
             "enum": [
+              "BANNED",
               "CREATED",
               "DELETED"
             ]

--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -2743,6 +2743,7 @@
             }
           },
           {
+            "description": "type of status being set",
             "in": "query",
             "name": "status",
             "required": true,

--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -2731,7 +2731,7 @@
     "/api/v1/organizations/{organizationName}/change-status": {
       "post": {
         "description": "Change status existing organization by its name.",
-        "operationId": "deleteOrganization",
+        "operationId": "changeOrganizationStatus",
         "parameters": [
           {
             "description": "name of an organization",

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -328,6 +328,7 @@ internal class OrganizationController(
         Parameter(name = "status", `in` = ParameterIn.QUERY, description = "type of status being set", required = true),
     )
     @ApiResponse(responseCode = "200", description = "Successfully change status an organization.")
+    @ApiResponse(responseCode = "400", description = "Invalid new status of the organization.")
     @ApiResponse(responseCode = "403", description = "Not enough permission for this action on organization.")
     @ApiResponse(responseCode = "404", description = "Could not find an organization with such name.")
     @ApiResponse(responseCode = "409", description = "There are projects connected to organization. Please delete all of them and try again.")
@@ -341,6 +342,10 @@ internal class OrganizationController(
         }
         .switchIfEmptyToNotFound {
             "Could not find an organization with name $organizationName."
+        }.filter {
+            it.status != status
+        }.switchIfEmptyToResponseException(HttpStatus.BAD_REQUEST) {
+            "Invalid new status of the organization $organizationName"
         }
         .filter {
             organizationPermissionEvaluator.hasPermissionToChangeStatus(authentication, it, status)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -342,9 +342,11 @@ internal class OrganizationController(
         }
         .switchIfEmptyToNotFound {
             "Could not find an organization with name $organizationName."
-        }.filter {
+        }
+        .filter {
             it.status != status
-        }.switchIfEmptyToResponseException(HttpStatus.BAD_REQUEST) {
+        }
+        .switchIfEmptyToResponseException(HttpStatus.BAD_REQUEST) {
             "Invalid new status of the organization $organizationName"
         }
         .filter {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -330,7 +330,7 @@ internal class OrganizationController(
     @ApiResponse(responseCode = "403", description = "Not enough permission for this action on organization.")
     @ApiResponse(responseCode = "404", description = "Could not find an organization with such name.")
     @ApiResponse(responseCode = "409", description = "There are projects connected to organization. Please delete all of them and try again.")
-    fun deleteOrganization(
+    fun changeOrganizationStatus(
         @PathVariable organizationName: String,
         @RequestParam status: OrganizationStatus,
         authentication: Authentication,

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -345,10 +345,10 @@ internal class OrganizationController(
             organizationPermissionEvaluator.hasPermissionToChangeStatus(authentication, it, status)
         }
         .switchIfEmptyToResponseException(HttpStatus.FORBIDDEN) {
-            "Not enough permission for this action with organization of organization $organizationName."
+            "Not enough permission for this action with organization $organizationName."
         }
         .filter {
-            status == OrganizationStatus.DELETED && !organizationService.hasProjects(organizationName)
+            status != OrganizationStatus.DELETED || !organizationService.hasProjects(organizationName)
         }
         .switchIfEmptyToResponseException(HttpStatus.CONFLICT) {
             "There are projects connected to $organizationName. Please delete all of them and try again."
@@ -357,15 +357,15 @@ internal class OrganizationController(
             when (status) {
                 OrganizationStatus.BANNED -> {
                     organizationService.banOrganization(organization)
-                    ResponseEntity.ok("Organization banned")
+                    ResponseEntity.ok("Successfully banned the organization")
                 }
                 OrganizationStatus.DELETED -> {
                     organizationService.deleteOrganization(organization)
-                    ResponseEntity.ok("Organization deleted")
+                    ResponseEntity.ok("Successfully deleted the organization")
                 }
                 OrganizationStatus.CREATED -> {
                     organizationService.recoverOrganization(organization)
-                    ResponseEntity.ok("Organization recovered")
+                    ResponseEntity.ok("Successfully recovered the organization")
                 }
             }
         }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -325,6 +325,7 @@ internal class OrganizationController(
     )
     @Parameters(
         Parameter(name = "organizationName", `in` = ParameterIn.PATH, description = "name of an organization", required = true),
+        Parameter(name = "status", `in` = ParameterIn.QUERY, description = "type of status being set", required = true),
     )
     @ApiResponse(responseCode = "200", description = "Successfully change status an organization.")
     @ApiResponse(responseCode = "403", description = "Not enough permission for this action on organization.")

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/OrganizationRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/OrganizationRepository.kt
@@ -41,9 +41,17 @@ ValidateRepository {
      */
     fun findByNameStartingWithAndStatus(prefix: String, status: OrganizationStatus): List<Organization>
 
+    fun findByNameStartingWithAndStatusIn(prefix: String, status: List<OrganizationStatus>): List<Organization>
+
     /**
      * @param status
      * @return list of organizations with required status
      */
     fun findByStatus(status: OrganizationStatus): List<Organization>
+
+    /**
+     * @param status
+     * @return list of organizations with required status
+     */
+    fun findByStatusIn(status: List<OrganizationStatus>): List<Organization>
 }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/OrganizationRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/OrganizationRepository.kt
@@ -41,17 +41,9 @@ ValidateRepository {
      */
     fun findByNameStartingWithAndStatus(prefix: String, status: OrganizationStatus): List<Organization>
 
-    fun findByNameStartingWithAndStatusIn(prefix: String, status: List<OrganizationStatus>): List<Organization>
-
     /**
      * @param status
      * @return list of organizations with required status
      */
     fun findByStatus(status: OrganizationStatus): List<Organization>
-
-    /**
-     * @param status
-     * @return list of organizations with required status
-     */
-    fun findByStatusIn(status: List<OrganizationStatus>): List<Organization>
 }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
@@ -45,7 +45,7 @@ class OrganizationPermissionEvaluator(
 
         return when {
             oldStatus == newStatus -> false
-            oldStatus.isBanned() || newStatus.isBanned() ->
+            oldStatus.isBan() || newStatus.isBan() ->
                 hasPermission(authentication, organization, Permission.BAN)
             else -> hasPermission(authentication, organization, Permission.DELETE)
         }
@@ -146,5 +146,5 @@ class OrganizationPermissionEvaluator(
     }
 }
 
-private fun OrganizationStatus.isBanned(): Boolean =
+private fun OrganizationStatus.isBan(): Boolean =
         this == OrganizationStatus.BANNED

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
@@ -1,10 +1,12 @@
 package com.saveourtool.save.backend.security
 
 import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.backend.controllers.OrganizationController
 import com.saveourtool.save.backend.service.LnkUserOrganizationService
 import com.saveourtool.save.backend.utils.hasRole
 import com.saveourtool.save.domain.Role
 import com.saveourtool.save.entities.Organization
+import com.saveourtool.save.entities.OrganizationStatus
 import com.saveourtool.save.entities.User
 import com.saveourtool.save.permission.Permission
 
@@ -33,6 +35,17 @@ class OrganizationPermissionEvaluator(
         return lnkUserOrganizationService.findRoleByUserIdAndOrganization(userId, organization).isHigherOrEqualThan(role)
     }
 
+    fun permissionChangeOrganizationStatus(authentication: Authentication?, organization: Organization, newStatus: OrganizationStatus): Boolean {
+        val oldStatus = organization.status
+
+        return when {
+            oldStatus == newStatus -> false
+            oldStatus.isBanned() || newStatus.isBanned() ->
+                hasPermission(authentication, organization, Permission.BAN)
+            else -> hasPermission(authentication, organization, Permission.DELETE)
+        }
+    }
+
     /**
      * @param authentication [Authentication] describing an authenticated request
      * @param organization
@@ -51,6 +64,7 @@ class OrganizationPermissionEvaluator(
             Permission.READ -> hasReadAccess(userId, organizationRole)
             Permission.WRITE -> hasWriteAccess(userId, organizationRole)
             Permission.DELETE -> hasDeleteAccess(userId, organizationRole)
+            Permission.BAN -> hasBanAccess(userId, organizationRole)
         }
     }
 
@@ -70,7 +84,10 @@ class OrganizationPermissionEvaluator(
             userId?.let { organizationRole == Role.ADMIN } ?: false
 
     private fun hasDeleteAccess(userId: Long?, organizationRole: Role): Boolean =
-            userId?.let { organizationRole.isHigherOrEqualThan(Role.OWNER) } ?: false
+        hasBanAccess(userId, organizationRole) || userId?.let { organizationRole == Role.OWNER } ?: false
+
+    private fun hasBanAccess(userId: Long?, organizationRole: Role): Boolean =
+        userId?.let { organizationRole == Role.SUPER_ADMIN } ?: false
 
     /**
      * In case we widen number of users that can manage roles in an organization, there is a separate method.
@@ -123,3 +140,7 @@ class OrganizationPermissionEvaluator(
         val contestCreatorMinimalRole = Role.ADMIN
     }
 }
+
+private fun OrganizationStatus.isBanned(): Boolean =
+    this == OrganizationStatus.BANNED
+

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
@@ -44,7 +44,7 @@ class OrganizationPermissionEvaluator(
         val oldStatus = organization.status
 
         return when {
-            oldStatus == newStatus -> false
+            oldStatus == newStatus -> throw IllegalStateException("invalid status")
             oldStatus.isBan() || newStatus.isBan() ->
                 hasPermission(authentication, organization, Permission.BAN)
             else -> hasPermission(authentication, organization, Permission.DELETE)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
@@ -1,7 +1,6 @@
 package com.saveourtool.save.backend.security
 
 import com.saveourtool.save.authservice.utils.AuthenticationDetails
-import com.saveourtool.save.backend.controllers.OrganizationController
 import com.saveourtool.save.backend.service.LnkUserOrganizationService
 import com.saveourtool.save.backend.utils.hasRole
 import com.saveourtool.save.domain.Role
@@ -35,7 +34,13 @@ class OrganizationPermissionEvaluator(
         return lnkUserOrganizationService.findRoleByUserIdAndOrganization(userId, organization).isHigherOrEqualThan(role)
     }
 
-    fun permissionChangeOrganizationStatus(authentication: Authentication?, organization: Organization, newStatus: OrganizationStatus): Boolean {
+    /**
+     * @param authentication [Authentication] describing an authenticated request
+     * @param organization is organization in which we want to change the status
+     * @param newStatus is new status in [organization]
+     * @return whether user described by [authentication] can have permission on change [organization] status on [newStatus]
+     */
+    fun hasPermissionToChangeStatus(authentication: Authentication?, organization: Organization, newStatus: OrganizationStatus): Boolean {
         val oldStatus = organization.status
 
         return when {
@@ -84,10 +89,10 @@ class OrganizationPermissionEvaluator(
             userId?.let { organizationRole == Role.ADMIN } ?: false
 
     private fun hasDeleteAccess(userId: Long?, organizationRole: Role): Boolean =
-        hasBanAccess(userId, organizationRole) || userId?.let { organizationRole == Role.OWNER } ?: false
+            hasBanAccess(userId, organizationRole) || userId?.let { organizationRole == Role.OWNER } ?: false
 
     private fun hasBanAccess(userId: Long?, organizationRole: Role): Boolean =
-        userId?.let { organizationRole == Role.SUPER_ADMIN } ?: false
+            userId?.let { organizationRole == Role.SUPER_ADMIN } ?: false
 
     /**
      * In case we widen number of users that can manage roles in an organization, there is a separate method.
@@ -142,5 +147,4 @@ class OrganizationPermissionEvaluator(
 }
 
 private fun OrganizationStatus.isBanned(): Boolean =
-    this == OrganizationStatus.BANNED
-
+        this == OrganizationStatus.BANNED

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
@@ -39,6 +39,7 @@ class OrganizationPermissionEvaluator(
      * @param organization is organization in which we want to change the status
      * @param newStatus is new status in [organization]
      * @return whether user described by [authentication] can have permission on change [organization] status on [newStatus]
+     * @throws IllegalStateException
      */
     fun hasPermissionToChangeStatus(authentication: Authentication?, organization: Organization, newStatus: OrganizationStatus): Boolean {
         val oldStatus = organization.status

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluator.kt
@@ -89,7 +89,7 @@ class ProjectPermissionEvaluator(
             userId?.let { projectRole == Role.ADMIN } ?: false
 
     private fun hasDeleteAccess(userId: Long?, projectRole: Role): Boolean =
-        hasBanAccess(userId, projectRole) || userId?.let { projectRole == Role.OWNER } ?: false
+            hasBanAccess(userId, projectRole) || userId?.let { projectRole == Role.OWNER } ?: false
 
     private fun hasBanAccess(userId: Long?, projectRole: Role): Boolean = userId?.let { projectRole == Role.SUPER_ADMIN } ?: false
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluator.kt
@@ -35,8 +35,7 @@ class ProjectPermissionEvaluator(
     fun hasPermission(authentication: Authentication?, project: Project, permission: Permission): Boolean {
         authentication ?: return when (permission) {
             Permission.READ -> project.public
-            Permission.WRITE -> false
-            Permission.DELETE -> false
+            Permission.BAN, Permission.DELETE, Permission.WRITE -> false
         }
         if (authentication.hasRole(Role.SUPER_ADMIN)) {
             return true
@@ -49,6 +48,7 @@ class ProjectPermissionEvaluator(
             Permission.READ -> project.public || hasReadAccess(userId, projectRole)
             Permission.WRITE -> hasWriteAccess(userId, projectRole)
             Permission.DELETE -> hasDeleteAccess(userId, projectRole)
+            Permission.BAN -> hasBanAccess(userId, projectRole)
         }
     }
 
@@ -88,9 +88,10 @@ class ProjectPermissionEvaluator(
     private fun hasWriteAccess(userId: Long?, projectRole: Role): Boolean = hasDeleteAccess(userId, projectRole) ||
             userId?.let { projectRole == Role.ADMIN } ?: false
 
-    private fun hasDeleteAccess(userId: Long?, projectRole: Role): Boolean = userId?.let {
-        projectRole == Role.OWNER || projectRole == Role.SUPER_ADMIN
-    } ?: false
+    private fun hasDeleteAccess(userId: Long?, projectRole: Role): Boolean =
+        hasBanAccess(userId, projectRole) || userId?.let { projectRole == Role.OWNER } ?: false
+
+    private fun hasBanAccess(userId: Long?, projectRole: Role): Boolean = userId?.let { projectRole == Role.SUPER_ADMIN } ?: false
 
     /**
      * @param authentication

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/TestSuitePermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/TestSuitePermissionEvaluator.kt
@@ -30,7 +30,8 @@ class TestSuitePermissionEvaluator(
     ): Boolean = lnkOrganizationTestSuiteService.getDto(organization, testSuite).rights.let { currentRights ->
         when (permission) {
             Permission.READ -> testSuite.isPublic || canAccessTestSuite(currentRights)
-            Permission.WRITE, Permission.DELETE, Permission.BAN -> canMaintainTestSuite(currentRights)
+            Permission.WRITE, Permission.DELETE -> canMaintainTestSuite(currentRights)
+            Permission.BAN -> throw IllegalStateException("Permission is not correct")
         }
     }
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/TestSuitePermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/TestSuitePermissionEvaluator.kt
@@ -30,7 +30,7 @@ class TestSuitePermissionEvaluator(
     ): Boolean = lnkOrganizationTestSuiteService.getDto(organization, testSuite).rights.let { currentRights ->
         when (permission) {
             Permission.READ -> testSuite.isPublic || canAccessTestSuite(currentRights)
-            Permission.WRITE, Permission.DELETE -> canMaintainTestSuite(currentRights)
+            Permission.WRITE, Permission.DELETE, Permission.BAN -> canMaintainTestSuite(currentRights)
         }
     }
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
@@ -4,7 +4,6 @@ import com.saveourtool.save.backend.repository.OrganizationRepository
 import com.saveourtool.save.domain.OrganizationSaveStatus
 import com.saveourtool.save.entities.Organization
 import com.saveourtool.save.entities.OrganizationStatus
-import com.saveourtool.save.entities.Project
 import com.saveourtool.save.entities.ProjectStatus.*
 import com.saveourtool.save.filters.OrganizationFilters
 import org.springframework.security.core.Authentication
@@ -44,6 +43,7 @@ class OrganizationService(
      * Mark organization with [organizationName] as deleted
      *
      * @param organizationName an [Organization]'s name to delete
+     * @param newStatus is new status for [organizationName]
      * @return deleted organization
      */
     @Suppress("UnsafeCallOnNullableType")
@@ -61,17 +61,18 @@ class OrganizationService(
      * @param organization an [Organization] to delete
      * @return deleted organization
      */
-    fun deleteOrganization(organization: Organization): Organization {
-        return if (!hasProjects(organization.name))
-            changeOrganizationStatus(organization.name, OrganizationStatus.DELETED)
-        else organization
+    fun deleteOrganization(organization: Organization): Organization = if (!hasProjects(organization.name)) {
+        changeOrganizationStatus(organization.name, OrganizationStatus.DELETED)
+    } else {
+        organization
     }
 
     /**
      * Mark organization with [organization] as created.
      * If an organization was previously banned, then all its projects become deleted.
      *
-     * @param organizationName an [Organization] to create
+     * @param organization an [Organization] to create
+     * @param organization
      * @return deleted organization
      */
     fun recoverOrganization(organization: Organization): Organization {
@@ -97,8 +98,6 @@ class OrganizationService(
         }
         return changeOrganizationStatus(organization.name, OrganizationStatus.BANNED)
     }
-
-
 
     /**
      * @param organizationName the unique name of the organization.

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
@@ -47,7 +47,7 @@ class OrganizationService(
      * @return deleted organization
      */
     @Suppress("UnsafeCallOnNullableType")
-    fun changeOrganizationStatus(organizationName: String, newStatus: OrganizationStatus): Organization = getByName(organizationName)
+    fun changeOrganizationStatus(organization: Organization, newStatus: OrganizationStatus): Organization = organization
         .apply {
             status = newStatus
         }
@@ -62,7 +62,7 @@ class OrganizationService(
      * @return deleted organization
      */
     fun deleteOrganization(organization: Organization): Organization = if (!hasProjects(organization.name)) {
-        changeOrganizationStatus(organization.name, OrganizationStatus.DELETED)
+        changeOrganizationStatus(organization, OrganizationStatus.DELETED)
     } else {
         organization
     }
@@ -82,7 +82,7 @@ class OrganizationService(
                 projectService.updateProject(it)
             }
         }
-        return changeOrganizationStatus(organization.name, OrganizationStatus.CREATED)
+        return changeOrganizationStatus(organization, OrganizationStatus.CREATED)
     }
 
     /**
@@ -96,7 +96,7 @@ class OrganizationService(
             it.status = BANNED
             projectService.updateProject(it)
         }
-        return changeOrganizationStatus(organization.name, OrganizationStatus.BANNED)
+        return changeOrganizationStatus(organization, OrganizationStatus.BANNED)
     }
 
     /**

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
@@ -75,6 +75,7 @@ class OrganizationService(
      * @param organization
      * @return deleted organization
      */
+    @Transactional
     fun recoverOrganization(organization: Organization): Organization {
         if (organization.status == OrganizationStatus.BANNED) {
             projectService.getAllByOrganizationName(organization.name).forEach {
@@ -91,6 +92,7 @@ class OrganizationService(
      * @param organization an [Organization] to ban
      * @return deleted organization
      */
+    @Transactional
     fun banOrganization(organization: Organization): Organization {
         projectService.getAllByOrganizationName(organization.name).forEach {
             it.status = BANNED

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/OrganizationService.kt
@@ -40,10 +40,10 @@ class OrganizationService(
     }
 
     /**
-     * Mark organization with [organizationName] as deleted
+     * Mark organization with [organization] as deleted
      *
-     * @param organizationName an [Organization]'s name to delete
-     * @param newStatus is new status for [organizationName]
+     * @param newStatus is new status for [organization]
+     * @param organization is organization in which the status will be changed
      * @return deleted organization
      */
     @Suppress("UnsafeCallOnNullableType")

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/LnkUserOrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/LnkUserOrganizationControllerTest.kt
@@ -220,6 +220,7 @@ class LnkUserOrganizationControllerTest {
                 Permission.READ -> organizationRole.priority >= Role.VIEWER.priority
                 Permission.WRITE -> organizationRole.priority >= Role.ADMIN.priority
                 Permission.DELETE -> organizationRole.priority >= Role.OWNER.priority
+                Permission.BAN -> organizationRole.priority== Role.OWNER.priority
             }
         }
         given(lnkUserOrganizationService.getUserByName(any())).willAnswer { invocationOnMock ->

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/LnkUserOrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/LnkUserOrganizationControllerTest.kt
@@ -220,7 +220,7 @@ class LnkUserOrganizationControllerTest {
                 Permission.READ -> organizationRole.priority >= Role.VIEWER.priority
                 Permission.WRITE -> organizationRole.priority >= Role.ADMIN.priority
                 Permission.DELETE -> organizationRole.priority >= Role.OWNER.priority
-                Permission.BAN -> organizationRole.priority== Role.OWNER.priority
+                Permission.BAN -> organizationRole.priority== Role.SUPER_ADMIN.priority
             }
         }
         given(lnkUserOrganizationService.getUserByName(any())).willAnswer { invocationOnMock ->

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
@@ -128,8 +128,19 @@ class OrganizationControllerTest {
     @WithMockUser(value = "admin", roles = ["VIEWER"])
     fun `delete organization with owner permission`() {
         mutateMockedUserAndLink(organization, adminUser, Role.OWNER)
-        webClient.delete()
-            .uri("/api/$v1/organizations/${organization.name}/change-status&status=${OrganizationStatus.DELETED}")
+        webClient.post()
+            .uri("/api/$v1/organizations/${organization.name}/change-status?status=${OrganizationStatus.DELETED}")
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    @WithMockUser(value = "JohDoe", roles = ["VIEWER"])
+    fun `ban organization with super-admin permission`() {
+        mutateMockedUserAndLink(organization, johnDoeUser, Role.SUPER_ADMIN)
+        webClient.post()
+            .uri("/api/$v1/organizations/${organization.name}/change-status?status=${OrganizationStatus.BANNED}")
             .exchange()
             .expectStatus()
             .isOk
@@ -139,7 +150,7 @@ class OrganizationControllerTest {
     @WithMockUser(value = "JohDoe", roles = ["VIEWER"])
     fun `delete organization without owner permission`() {
         mutateMockedUserAndLink(organization, johnDoeUser, Role.VIEWER)
-        webClient.delete()
+        webClient.post()
             .uri("/api/$v1/organizations/${organization.name}/change-status?status=${OrganizationStatus.DELETED}")
             .exchange()
             .expectStatus()

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
@@ -130,7 +130,7 @@ class OrganizationControllerTest {
     fun `delete organization with owner permission`() {
         mutateMockedUserAndLink(organization, adminUser, Role.OWNER)
         webClient.delete()
-            .uri("/api/$v1/organizations/${organization.name}/delete")
+            .uri("/api/$v1/organizations/${organization.name}/change-status&status=${OrganizationStatus.DELETED}")
             .exchange()
             .expectStatus()
             .isOk
@@ -141,7 +141,7 @@ class OrganizationControllerTest {
     fun `delete organization without owner permission`() {
         mutateMockedUserAndLink(organization, johnDoeUser, Role.VIEWER)
         webClient.delete()
-            .uri("/api/$v1/organizations/${organization.name}/delete")
+            .uri("/api/$v1/organizations/${organization.name}/change-status?status=${OrganizationStatus.DELETED}")
             .exchange()
             .expectStatus()
             .isForbidden

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/PermissionControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/PermissionControllerTest.kt
@@ -253,8 +253,8 @@ class PermissionControllerTest {
             when (it.arguments[2] as Permission?) {
                 null -> false
                 Permission.READ -> permission != null
-                Permission.WRITE -> permission == Permission.WRITE || permission == Permission.DELETE
-                Permission.DELETE -> permission == Permission.DELETE
+                Permission.WRITE -> permission == Permission.WRITE || permission == Permission.DELETE || permission == Permission.BAN
+                Permission.DELETE -> permission == Permission.DELETE || permission == Permission.BAN
                 Permission.BAN -> permission == Permission.BAN
             }
         }

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/PermissionControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/PermissionControllerTest.kt
@@ -255,6 +255,7 @@ class PermissionControllerTest {
                 Permission.READ -> permission != null
                 Permission.WRITE -> permission == Permission.WRITE || permission == Permission.DELETE
                 Permission.DELETE -> permission == Permission.DELETE
+                Permission.BAN -> permission == Permission.BAN
             }
         }
         given(projectService.findUserByName(any())).willAnswer { invocationOnMock ->

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluatorTest.kt
@@ -33,6 +33,8 @@ class OrganizationPermissionEvaluatorTest {
     @MockBean private lateinit var userDetailsService: UserDetailsService
     private lateinit var mockOrganization: Organization
 
+    private val ownerPermissions = Permission.values().filterNot { it == Permission.BAN }.toTypedArray()
+
     @BeforeEach
     fun setUp() {
         mockOrganization = Organization.stub(99)
@@ -41,16 +43,16 @@ class OrganizationPermissionEvaluatorTest {
     @Test
     fun `permissions for organization owners`() {
         userShouldHavePermissions(
-            "super_admin", Role.SUPER_ADMIN, Role.OWNER, *Permission.values(), userId = 99
+            "super_admin", Role.SUPER_ADMIN, Role.OWNER,  *Permission.values(), userId = 99
         )
         userShouldHavePermissions(
-            "admin", Role.ADMIN, Role.OWNER, *Permission.values(), userId = 99
+            "admin", Role.ADMIN, Role.OWNER, *ownerPermissions, userId = 99
         )
         userShouldHavePermissions(
-            "owner", Role.OWNER, Role.OWNER, *Permission.values(), userId = 99
+            "owner", Role.OWNER, Role.OWNER, *ownerPermissions, userId = 99
         )
         userShouldHavePermissions(
-            "viewer", Role.VIEWER, Role.OWNER, *Permission.values(), userId = 99
+            "viewer", Role.VIEWER, Role.OWNER, *ownerPermissions, userId = 99
         )
     }
 

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -77,7 +77,6 @@ class ProjectPermissionEvaluatorTest {
 
     @Test
     fun `permissions for project owners`() {
-        ownerPermissions.forEach { println(it.name) }
         mockProject.userId = 99
         userShouldHavePermissions(
             "super_admin", Role.SUPER_ADMIN, Role.OWNER, *Permission.values(), userId = 99

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -35,6 +35,8 @@ class ProjectPermissionEvaluatorTest {
     @MockBean private lateinit var userDetailsService: UserDetailsService
     private lateinit var mockProject: Project
 
+    private val ownerPermissions = Permission.values().filterNot { it == Permission.BAN }.toTypedArray()
+
     @BeforeEach
     fun setUp() {
         mockProject = Project.stub(99)
@@ -75,18 +77,19 @@ class ProjectPermissionEvaluatorTest {
 
     @Test
     fun `permissions for project owners`() {
+        ownerPermissions.forEach { println(it.name) }
         mockProject.userId = 99
         userShouldHavePermissions(
             "super_admin", Role.SUPER_ADMIN, Role.OWNER, *Permission.values(), userId = 99
         )
         userShouldHavePermissions(
-            "admin", Role.ADMIN, Role.OWNER, *Permission.values(), userId = 99
+            "admin", Role.ADMIN, Role.OWNER, *ownerPermissions, userId = 99
         )
         userShouldHavePermissions(
-            "owner", Role.OWNER, Role.OWNER, *Permission.values(), userId = 99
+            "owner", Role.OWNER, Role.OWNER, *ownerPermissions, userId = 99
         )
         userShouldHavePermissions(
-            "viewer", Role.VIEWER, Role.OWNER, *Permission.values(), userId = 99
+            "viewer", Role.VIEWER, Role.OWNER, *ownerPermissions, userId = 99
         )
     }
 

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/OrganizationStatus.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/OrganizationStatus.kt
@@ -8,6 +8,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class OrganizationStatus {
     /**
+     * Organization banned
+     */
+    BANNED,
+
+    /**
      * Organization created
      */
     CREATED,
@@ -16,10 +21,5 @@ enum class OrganizationStatus {
      * Organization deleted
      */
     DELETED,
-
-    /**
-     * Organization banned
-     */
-    BANNED,
     ;
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/OrganizationStatus.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/OrganizationStatus.kt
@@ -16,5 +16,10 @@ enum class OrganizationStatus {
      * Organization deleted
      */
     DELETED,
+
+    /**
+     * Organization banned
+     */
+    BANNED,
     ;
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/ProjectStatus.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/ProjectStatus.kt
@@ -8,6 +8,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class ProjectStatus {
     /**
+     * Project deleted
+     */
+    BANNED,
+
+    /**
      * Project created
      */
     CREATED,
@@ -16,10 +21,5 @@ enum class ProjectStatus {
      * Project deleted
      */
     DELETED,
-
-    /**
-     * Project deleted
-     */
-    BANNED,
     ;
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/ProjectStatus.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/ProjectStatus.kt
@@ -16,5 +16,10 @@ enum class ProjectStatus {
      * Project deleted
      */
     DELETED,
+
+    /**
+     * Project deleted
+     */
+    BANNED,
     ;
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/permission/Permission.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/permission/Permission.kt
@@ -4,5 +4,5 @@ package com.saveourtool.save.permission
  * Permissions that operations may require on certain objects
  */
 enum class Permission {
-    DELETE, READ, WRITE, BAN
+    BAN, DELETE, READ, WRITE
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/permission/Permission.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/permission/Permission.kt
@@ -4,5 +4,5 @@ package com.saveourtool.save.permission
  * Permissions that operations may require on certain objects
  */
 enum class Permission {
-    DELETE, READ, WRITE
+    DELETE, READ, WRITE, BAN
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
@@ -165,7 +165,7 @@ internal class OrganizationAdminView : AbstractView<Props, OrganizationAdminStat
      * the externally supplied [ErrorHandler].
      *
      * @param organization the project to delete.
-     * @return the lambda which delentes [organization].
+     * @return the lambda which deletes [organization].
      * @see ErrorHandler
      */
     private fun deleteOrganization(organization: Organization): suspend WithRequestStatusContext.(ErrorHandler) -> Unit = { errorHandler ->

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
@@ -3,23 +3,18 @@
 package com.saveourtool.save.frontend.components.views
 
 import com.saveourtool.save.entities.Organization
+import com.saveourtool.save.entities.OrganizationStatus
 import com.saveourtool.save.frontend.components.modal.ModalDialogStrings
 import com.saveourtool.save.frontend.components.tables.TableProps
 import com.saveourtool.save.frontend.components.tables.tableComponent
 import com.saveourtool.save.frontend.externals.fontawesome.faTrashAlt
 import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
+import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.frontend.utils.ErrorHandler
-import com.saveourtool.save.frontend.utils.WithRequestStatusContext
-import com.saveourtool.save.frontend.utils.apiUrl
 import com.saveourtool.save.frontend.utils.classLoadingHandler
-import com.saveourtool.save.frontend.utils.decodeFromJsonString
-import com.saveourtool.save.frontend.utils.delete
 import com.saveourtool.save.frontend.utils.deleteButton
-import com.saveourtool.save.frontend.utils.get
-import com.saveourtool.save.frontend.utils.jsonHeaders
 import com.saveourtool.save.frontend.utils.noopLoadingHandler
 import com.saveourtool.save.frontend.utils.noopResponseHandler
-import com.saveourtool.save.frontend.utils.unpackMessageOrHttpStatus
 import csstype.ClassName
 import react.ChildrenBuilder
 import react.FC
@@ -170,15 +165,16 @@ internal class OrganizationAdminView : AbstractView<Props, OrganizationAdminStat
      * the externally supplied [ErrorHandler].
      *
      * @param organization the project to delete.
-     * @return the lambda which deletes [organization].
+     * @return the lambda which delentes [organization].
      * @see ErrorHandler
      */
     private fun deleteOrganization(organization: Organization): suspend WithRequestStatusContext.(ErrorHandler) -> Unit = { errorHandler ->
-        val response = delete(
-            url = "$apiUrl/organizations/${organization.name}/delete",
+        val response = post(
+            "$apiUrl/organizations/${organization.name}/change-status?status=${OrganizationStatus.DELETED}",
             headers = jsonHeaders,
+            body = undefined,
             loadingHandler = ::noopLoadingHandler,
-            errorHandler = ::noopResponseHandler,
+            responseHandler = ::noopResponseHandler,
         )
         if (response.ok) {
             setState {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/DeleteOrganizationButton.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/DeleteOrganizationButton.kt
@@ -6,6 +6,7 @@
 
 package com.saveourtool.save.frontend.components.views.usersettings
 
+import com.saveourtool.save.entities.OrganizationStatus
 import com.saveourtool.save.frontend.components.modal.displayModal
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.frontend.utils.noopLoadingHandler
@@ -31,11 +32,12 @@ val deleteOrganizationButton: FC<DeleteOrganizationButtonProps> = FC { props ->
 
     val deleteOrganization = useDeferredRequest {
         val responseFromDeleteOrganization =
-                delete(
-                    "$apiUrl/organizations/${props.organizationName}/delete",
+                post(
+                    "$apiUrl/organizations/${props.organizationName}/change-status?status=${OrganizationStatus.DELETED}",
                     headers = jsonHeaders,
+                    body = undefined,
                     loadingHandler = ::noopLoadingHandler,
-                    errorHandler = ::noopResponseHandler,
+                    responseHandler = ::noopResponseHandler,
                 )
         if (responseFromDeleteOrganization.ok) {
             props.onDeletionSuccess()


### PR DESCRIPTION
## Whats added:
- Add field ```banned``` in OrganizationStatus and ProjectStatus
- Add deleted, banned and recovery Organization logic
- Add new permission ```BAN```
- Correct tests

## Issue
This pull request close #1436 