### PR TITLE
Reset page index after applying filters

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/tables/TableComponent.kt
@@ -27,6 +27,8 @@ import react.dom.html.ReactHTML.tbody
 import react.dom.html.ReactHTML.th
 import react.dom.html.ReactHTML.thead
 import react.dom.html.ReactHTML.tr
+import react.router.NavigateFunction
+import react.router.useNavigate
 import tanstack.react.table.renderCell
 import tanstack.react.table.renderHeader
 import tanstack.react.table.useReactTable
@@ -116,7 +118,7 @@ fun <D : RowData, P : TableProps<D>> tableComponent(
     additionalOptions: TableOptions<D>.() -> Unit = {},
     getRowProps: ((Row<D>) -> PropsWithStyle) = { jso() },
     renderExpandedRow: (ChildrenBuilder.(table: Table<D>, row: Row<D>) -> Unit)? = undefined,
-    commonHeader: ChildrenBuilder.(table: Table<D>) -> Unit = {},
+    commonHeader: ChildrenBuilder.(table: Table<D>, navigate: NavigateFunction) -> Unit = { _, _ -> },
     getAdditionalDependencies: (P) -> Array<dynamic> = { emptyArray() },
 ): FC<P> = FC { props ->
     require(useServerPaging xor (props.getPageCount == null)) {
@@ -210,6 +212,8 @@ fun <D : RowData, P : TableProps<D>> tableComponent(
         }
     }
 
+    val navigate = useNavigate()
+
     div {
         className = ClassName("${if (isTransparentGrid) "" else "card shadow"} mb-4")
         div {
@@ -228,7 +232,7 @@ fun <D : RowData, P : TableProps<D>> tableComponent(
                     width = 100.0
                     cellSpacing = "0"
                     thead {
-                        commonHeader(tableInstance)
+                        commonHeader(tableInstance, navigate)
                         tableInstance.getHeaderGroups().map { headerGroup ->
                             tr {
                                 id = headerGroup.id

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/ContestGlobalRatingView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/ContestGlobalRatingView.kt
@@ -148,7 +148,7 @@ class ContestGlobalRatingView : AbstractView<ContestGlobalRatingProps, ContestGl
         getAdditionalDependencies = {
             arrayOf(it)
         },
-        commonHeader = { tableInstance ->
+        commonHeader = { tableInstance, _ ->
             tr {
                 th {
                     colSpan = tableInstance.visibleColumnsCount()
@@ -214,7 +214,7 @@ class ContestGlobalRatingView : AbstractView<ContestGlobalRatingProps, ContestGl
         getAdditionalDependencies = {
             arrayOf(it)
         },
-        commonHeader = { tableInstance ->
+        commonHeader = { tableInstance, _ ->
             tr {
                 th {
                     colSpan = tableInstance.visibleColumnsCount()


### PR DESCRIPTION
Accidentally broken it again in #1488, but this seems to be a more appropriate fix

* Reset page index after applying filters
* Refactor setting new state of filters
* Pass `navigate` from `tableComponent` to `commonHeader` callback

Closes #1475