### PR TITLE
Changed logDriver to useLoki property

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/SaveApplication.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/SaveApplication.kt
@@ -4,17 +4,12 @@ import com.saveourtool.save.backend.configs.ConfigProperties
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.core.io.Resource
 import org.springframework.http.ResponseEntity
 import reactor.core.publisher.Flux
 import java.nio.ByteBuffer
 
-typealias ByteArrayResponse = ResponseEntity<ByteArray>
 typealias StringResponse = ResponseEntity<String>
-typealias EmptyResponse = ResponseEntity<Void>
 typealias ByteBufferFluxResponse = ResponseEntity<Flux<ByteBuffer>>
-typealias ResourceResponse = ResponseEntity<Resource>
-typealias StringList = List<String>
 
 /**
  * An entrypoint for spring for save-backend

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
@@ -1,7 +1,6 @@
 package com.saveourtool.save.backend.controllers
 
 import com.saveourtool.save.authservice.utils.username
-import com.saveourtool.save.backend.EmptyResponse
 import com.saveourtool.save.backend.StringResponse
 import com.saveourtool.save.backend.configs.ConfigProperties
 import com.saveourtool.save.backend.service.*
@@ -14,6 +13,7 @@ import com.saveourtool.save.execution.TestingType
 import com.saveourtool.save.permission.Permission
 import com.saveourtool.save.request.CreateExecutionRequest
 import com.saveourtool.save.spring.utils.applyAll
+import com.saveourtool.save.utils.EmptyResponse
 import com.saveourtool.save.utils.blockingToMono
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.getLogger

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesSourceService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesSourceService.kt
@@ -1,7 +1,5 @@
 package com.saveourtool.save.backend.service
 
-import com.saveourtool.save.backend.EmptyResponse
-import com.saveourtool.save.backend.StringList
 import com.saveourtool.save.backend.configs.ConfigProperties
 import com.saveourtool.save.backend.repository.TestSuitesSourceRepository
 import com.saveourtool.save.domain.EntitySaveStatus
@@ -10,6 +8,8 @@ import com.saveourtool.save.entities.Organization
 import com.saveourtool.save.entities.TestSuitesSource
 import com.saveourtool.save.testsuite.TestSuitesSourceDto
 import com.saveourtool.save.testsuite.TestSuitesSourceFetchMode
+import com.saveourtool.save.utils.EmptyResponse
+import com.saveourtool.save.utils.StringList
 import com.saveourtool.save.utils.orNotFound
 
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/KotlinUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/KotlinUtils.kt
@@ -1,0 +1,7 @@
+/**
+ * Utilities for Kotlin
+ */
+
+package com.saveourtool.save.utils
+
+typealias StringList = List<String>

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/KotlinUtilsJvm.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/KotlinUtilsJvm.kt
@@ -1,0 +1,9 @@
+/**
+ * Utilities for Kotlin
+ */
+
+package com.saveourtool.save.utils
+
+import org.springframework.http.ResponseEntity
+
+typealias EmptyResponse = ResponseEntity<Void>

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/Utils.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/Utils.kt
@@ -17,7 +17,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
-import org.springframework.http.ResponseEntity
 
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
@@ -27,8 +26,6 @@ import java.util.function.Supplier
 import java.util.zip.GZIPOutputStream
 
 internal const val DOCKER_METRIC_PREFIX = "save.orchestrator.docker"
-
-internal typealias BodilessResponseEntity = ResponseEntity<Void>
 
 /**
  * Execute this async docker command while recording its execution duration.

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -54,7 +54,6 @@ data class ConfigProperties(
     data class DockerSettings(
         val host: String,
         val useLoki: Boolean = true,
-        val loggingDriver: String,
         val runtime: String? = null,
         val registry: String = "docker.io/library",
         val testResourcesVolumeType: String = "volume",

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.context.properties.ConstructorBinding
  * @property docker configuration for docker API
  * @property kubernetes configuration for setup in Kubernetes
  * @property dockerResourcesLifetime time, after which resources (images, containers, etc) should be released
+ * @property containerNamePrefix a prefix for container name
  * @property agentsCount a number of agents to start for every [Execution]
  * @property shutdown configuration related to process of shutting down groups of agents for executions
  * @property aptExtraFlags additional flags that will be passed to `apt-get` when building image for tests
@@ -29,6 +30,7 @@ data class ConfigProperties(
     val docker: DockerSettings?,
     val kubernetes: KubernetesSettings?,
     val dockerResourcesLifetime: String = "720h",
+    val containerNamePrefix: String = "save-execution-",
     val agentsCount: Int,
     val shutdown: ShutdownSettings,
     val aptExtraFlags: String = "",
@@ -41,15 +43,17 @@ data class ConfigProperties(
 ) {
     /**
      * @property host hostname of docker daemon
+     * @property useLoki this flag enables loki logging
      * @property runtime OCI compliant runtime for docker
-     * @property loggingDriver logging driver for the container
      * @property registry docker registry to pull images for test executions from
      * @property testResourcesVolumeType Type of Docker volume (bind/volume). `bind` should only be used for local running and for tests.
      * @property testResourcesVolumeName Name of a Docker volume which acts as a temporary storage of resources for execution.
      * Nullable, because it's not required in Kubernetes
+     * @property loggingDriver
      */
     data class DockerSettings(
         val host: String,
+        val useLoki: Boolean = true,
         val loggingDriver: String,
         val runtime: String? = null,
         val registry: String = "docker.io/library",

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -49,7 +49,6 @@ data class ConfigProperties(
      * @property testResourcesVolumeType Type of Docker volume (bind/volume). `bind` should only be used for local running and for tests.
      * @property testResourcesVolumeName Name of a Docker volume which acts as a temporary storage of resources for execution.
      * Nullable, because it's not required in Kubernetes
-     * @property loggingDriver
      */
     data class DockerSettings(
         val host: String,

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
@@ -2,12 +2,12 @@ package com.saveourtool.save.orchestrator.controller
 
 import com.saveourtool.save.entities.AgentDto
 import com.saveourtool.save.execution.ExecutionStatus
-import com.saveourtool.save.orchestrator.BodilessResponseEntity
 import com.saveourtool.save.orchestrator.runner.AgentRunner
 import com.saveourtool.save.orchestrator.service.AgentService
 import com.saveourtool.save.orchestrator.service.DockerService
 import com.saveourtool.save.orchestrator.utils.LoggingContextImpl
 import com.saveourtool.save.request.RunExecutionRequest
+import com.saveourtool.save.utils.EmptyResponse
 import com.saveourtool.save.utils.info
 
 import com.github.dockerjava.api.exception.DockerClientException
@@ -43,7 +43,7 @@ class AgentsController(
      */
     @Suppress("TOO_LONG_FUNCTION", "LongMethod", "UnsafeCallOnNullableType")
     @PostMapping("/initializeAgents")
-    fun initialize(@RequestBody request: RunExecutionRequest): Mono<BodilessResponseEntity> {
+    fun initialize(@RequestBody request: RunExecutionRequest): Mono<EmptyResponse> {
         val response = Mono.just(ResponseEntity<Void>(HttpStatus.ACCEPTED))
             .subscribeOn(agentService.scheduler)
         return response.doOnSuccess {
@@ -115,11 +115,11 @@ class AgentsController(
      * @return empty response
      */
     @PostMapping("/cleanup")
-    fun cleanup(@RequestParam executionId: Long) = Mono.fromCallable {
+    fun cleanup(@RequestParam executionId: Long): Mono<EmptyResponse> = Mono.fromCallable {
         dockerService.cleanup(executionId)
     }
         .flatMap {
-            Mono.just(ResponseEntity<Void>(HttpStatus.OK))
+            Mono.just(ResponseEntity.ok().build())
         }
 
     companion object {

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component
 @Profile("kubernetes")
 class KubernetesManager(
     private val kc: KubernetesClient,
-    configProperties: ConfigProperties,
+    private val configProperties: ConfigProperties,
 ) : AgentRunner {
     private val kubernetesSettings = requireNotNull(configProperties.kubernetes) {
         "orchestrator.kubernetes.* properties are required in this profile"
@@ -161,7 +161,7 @@ class KubernetesManager(
 
     override fun getContainerIdentifier(containerId: String): String = containerId
 
-    private fun jobNameForExecution(executionId: Long) = "save-execution-$executionId"
+    private fun jobNameForExecution(executionId: Long) = "${configProperties.containerNamePrefix}$executionId"
 
     @Suppress("TOO_LONG_FUNCTION")
     private fun agentContainerSpec(

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentRepository.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentRepository.kt
@@ -5,8 +5,8 @@ import com.saveourtool.save.agent.AgentRunConfig
 import com.saveourtool.save.agent.TestExecutionDto
 import com.saveourtool.save.entities.*
 import com.saveourtool.save.execution.ExecutionStatus
-import com.saveourtool.save.orchestrator.BodilessResponseEntity
 import com.saveourtool.save.test.TestBatch
+import com.saveourtool.save.utils.EmptyResponse
 
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
@@ -48,7 +48,7 @@ interface AgentRepository {
      * @param agentStates list of [AgentStatusDto] to update/insert in the DB
      * @return a Mono without body
      */
-    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<BodilessResponseEntity>
+    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<EmptyResponse>
 
     /**
      * Get List of [TestExecutionDto] for agent [containerId] have status READY_FOR_TESTING
@@ -80,7 +80,7 @@ interface AgentRepository {
         executionId: Long,
         executionStatus: ExecutionStatus,
         failReason: String?,
-    ): Mono<BodilessResponseEntity>
+    ): Mono<EmptyResponse>
 
     /**
      * @param containerId containerId of an agent
@@ -95,5 +95,5 @@ interface AgentRepository {
      * @param onlyReadyForTesting mark only [TestExecution] with status [com.saveourtool.save.domain.TestResultStatus.READY_FOR_TESTING]
      * @return a Mono without body
      */
-    fun markTestExecutionsOfAgentsAsFailed(containerIds: Collection<String>, onlyReadyForTesting: Boolean): Mono<BodilessResponseEntity>
+    fun markTestExecutionsOfAgentsAsFailed(containerIds: Collection<String>, onlyReadyForTesting: Boolean): Mono<EmptyResponse>
 }

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
@@ -6,7 +6,6 @@ import com.saveourtool.save.entities.AgentDto
 import com.saveourtool.save.entities.AgentStatus
 import com.saveourtool.save.entities.AgentStatusDto
 import com.saveourtool.save.execution.ExecutionStatus
-import com.saveourtool.save.orchestrator.BodilessResponseEntity
 import com.saveourtool.save.orchestrator.config.ConfigProperties
 import com.saveourtool.save.orchestrator.runner.AgentRunner
 import com.saveourtool.save.utils.*
@@ -63,7 +62,7 @@ class AgentService(
      * @return Mono with response body
      * @throws WebClientResponseException if any of the requests fails
      */
-    fun saveAgentsWithInitialStatuses(agents: List<AgentDto>): Mono<BodilessResponseEntity> = agentRepository
+    fun saveAgentsWithInitialStatuses(agents: List<AgentDto>): Mono<EmptyResponse> = agentRepository
         .addAgents(agents)
         .flatMap {
             agentRepository.updateAgentStatusesWithDto(agents.map { agent ->
@@ -75,7 +74,7 @@ class AgentService(
      * @param agentState [AgentStatus] to update in the DB
      * @return a Mono containing bodiless entity of response or an empty Mono if request has failed
      */
-    fun updateAgentStatusesWithDto(agentState: AgentStatusDto): Mono<BodilessResponseEntity> =
+    fun updateAgentStatusesWithDto(agentState: AgentStatusDto): Mono<EmptyResponse> =
             agentRepository
                 .updateAgentStatusesWithDto(listOf(agentState))
                 .onErrorResume(WebClientException::class) {
@@ -138,7 +137,7 @@ class AgentService(
     private fun markExecutionBasedOnAgentStates(
         executionId: Long,
         agentIds: List<String>,
-    ): Mono<BodilessResponseEntity> {
+    ): Mono<EmptyResponse> {
         // all { STOPPED_BY_ORCH || TERMINATED } -> FINISHED
         // all { CRASHED } -> ERROR; set all test executions to CRASHED
         return agentRepository
@@ -169,7 +168,7 @@ class AgentService(
      * @param failReason to show to user in case of error status
      * @return a bodiless response entity
      */
-    fun updateExecution(executionId: Long, executionStatus: ExecutionStatus, failReason: String? = null): Mono<BodilessResponseEntity> =
+    fun updateExecution(executionId: Long, executionStatus: ExecutionStatus, failReason: String? = null): Mono<EmptyResponse> =
             agentRepository.updateExecutionByDto(executionId, executionStatus, failReason)
 
     /**
@@ -220,7 +219,7 @@ class AgentService(
     fun markTestExecutionsAsFailed(
         agentsList: Collection<String>,
         onlyReadyForTesting: Boolean
-    ): Mono<BodilessResponseEntity> = agentRepository.markTestExecutionsOfAgentsAsFailed(agentsList, onlyReadyForTesting)
+    ): Mono<EmptyResponse> = agentRepository.markTestExecutionsOfAgentsAsFailed(agentsList, onlyReadyForTesting)
 
     private fun Collection<AgentStatusDto>.areIdleOrFinished() = all {
         it.state == IDLE || it.state == FINISHED || it.state == STOPPED_BY_ORCH || it.state == CRASHED || it.state == TERMINATED

--- a/save-orchestrator-common/src/main/resources/META-INF/save-orchestrator-common/application-docker-socket.properties
+++ b/save-orchestrator-common/src/main/resources/META-INF/save-orchestrator-common/application-docker-socket.properties
@@ -1,3 +1,2 @@
 orchestrator.docker.host=unix:///var/run/docker.sock
 orchestrator.docker.runtime=runsc
-orchestrator.docker.logging-driver=loki

--- a/save-orchestrator-common/src/main/resources/META-INF/save-orchestrator-common/application-docker-tcp.properties
+++ b/save-orchestrator-common/src/main/resources/META-INF/save-orchestrator-common/application-docker-tcp.properties
@@ -1,3 +1,3 @@
 orchestrator.docker.host=tcp://localhost:2375
 orchestrator.docker.runtime=runc
-orchestrator.docker.logging-driver=json
+orchestrator.docker.use-loki=false

--- a/save-orchestrator-common/src/test/resources/application.properties
+++ b/save-orchestrator-common/src/test/resources/application.properties
@@ -1,7 +1,7 @@
 orchestrator.shutdown.checks-interval-millis=100
 orchestrator.shutdown.graceful-timeout-seconds=60
 orchestrator.shutdown.graceful-num-checks=10
-orchestrator.docker.logging-driver=json
+orchestrator.docker.use-loki=false
 orchestrator.docker.test-resources-volume-type=bind
 orchestrator.agents-count=1
 orchestrator.adjust-resource-owner=false

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/SavePreprocessor.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/SavePreprocessor.kt
@@ -4,13 +4,7 @@ import com.saveourtool.save.preprocessor.config.ConfigProperties
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.reactive.config.EnableWebFlux
-
-typealias TextResponse = ResponseEntity<String>
-typealias EmptyResponse = ResponseEntity<Void>
-typealias StatusResponse = ResponseEntity<HttpStatus>
 
 /**
  * An entrypoint for spring for save-preprocessor

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/service/TestDiscoveringService.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/service/TestDiscoveringService.kt
@@ -7,15 +7,16 @@ import com.saveourtool.save.core.utils.buildActivePlugins
 import com.saveourtool.save.core.utils.processInPlace
 import com.saveourtool.save.entities.TestSuite
 import com.saveourtool.save.plugins.fix.FixPlugin
-import com.saveourtool.save.preprocessor.EmptyResponse
 import com.saveourtool.save.preprocessor.utils.toHash
 import com.saveourtool.save.test.TestDto
 import com.saveourtool.save.test.collectPluginNames
 import com.saveourtool.save.testsuite.TestSuiteDto
 import com.saveourtool.save.testsuite.TestSuitesSourceDto
+import com.saveourtool.save.utils.EmptyResponse
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.info
 import com.saveourtool.save.utils.thenJust
+
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
@@ -27,6 +28,7 @@ import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.core.util.function.component1
 import reactor.kotlin.core.util.function.component2
+
 import kotlin.io.path.absolutePathString
 
 /**

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/service/TestsPreprocessorToBackendBridge.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/service/TestsPreprocessorToBackendBridge.kt
@@ -1,12 +1,13 @@
 package com.saveourtool.save.preprocessor.service
 
 import com.saveourtool.save.entities.*
-import com.saveourtool.save.preprocessor.EmptyResponse
 import com.saveourtool.save.preprocessor.config.ConfigProperties
 import com.saveourtool.save.spring.utils.applyAll
 import com.saveourtool.save.test.TestDto
 import com.saveourtool.save.testsuite.*
+import com.saveourtool.save.utils.EmptyResponse
 import com.saveourtool.save.utils.debug
+
 import org.slf4j.LoggerFactory
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 import org.springframework.core.io.Resource
@@ -18,6 +19,7 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+
 import java.time.Instant
 
 /**

--- a/save-sandbox/src/main/resources/application.properties
+++ b/save-sandbox/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.liquibase.enabled=false
 sandbox.file-storage-location=/home/cnb/files
 # suppress inspection "HttpUrlsUsage"
 sandbox.agent-settings.sandbox-url=http://host.docker.internal:${server.port}
+orchestrator.container-name-prefix=sandbox-execution-
 orchestrator.agents-count=1
 spring.jpa.hibernate.use-new-id-generator-mappings=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect


### PR DESCRIPTION
Refactoring logging (extracted from #1368):
* changed `log-driver` to `use-loki`
* make prefix for save agent configurable: to distinguish save agent for sandbox and save-cloud 
* remove random number for container name: now we copy an execution by creating a new one