### PR TITLE
Add the core test analysis functionality

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ detekt = "1.22.0"
 liquibase-core = "4.18.0"
 docker-java = "3.2.14"
 jgit = "6.4.0.202211300538-r"
+mockito = "4.5.1"
 mockito-kotlin = "4.1.0"
 # only in save-cli
 log4j = "2.19.0"
@@ -147,6 +148,7 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", ve
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version = "5.5.4" }
 

--- a/save-api/src/main/kotlin/com/saveourtool/save/api/SaveCloudClientEx.kt
+++ b/save-api/src/main/kotlin/com/saveourtool/save/api/SaveCloudClientEx.kt
@@ -2,6 +2,7 @@
 
 package com.saveourtool.save.api
 
+import com.saveourtool.save.agent.TestExecutionDto
 import com.saveourtool.save.api.errors.SaveCloudError
 import com.saveourtool.save.api.impl.DefaultSaveCloudClient
 import com.saveourtool.save.domain.FileInfo
@@ -153,6 +154,18 @@ interface SaveCloudClientEx {
     ): Either<SaveCloudError, List<ContestDto>>
 
     /**
+     * Lists test runs (along with their results) for the batch execution
+     * specified by [executionId].
+     *
+     * @param executionId the identifier which uniquely identifies the batch
+     *   execution.
+     * @return either the list of test runs, or the error if an error has
+     *   occurred.
+     * @see ExecutionDto.listTestRuns
+     */
+    suspend fun listTestRuns(executionId: Long): Either<SaveCloudError, List<TestExecutionDto>>
+
+    /**
      * Lists projects within this organization.
      *
      * @return either the list of projects, or the error if an error has
@@ -211,12 +224,20 @@ interface SaveCloudClientEx {
 
     /**
      * @param projectName the name of the project.
+     * @param contestName the optional name of the contest.
      * @return either the list of executions, or the error if an error has
      *  occurred.
      * @see SaveCloudClientEx.listExecutions
      */
-    suspend fun Organization.listExecutions(projectName: String): Either<SaveCloudError, List<ExecutionDto>> =
-            listExecutions(organizationName = name, projectName)
+    suspend fun Organization.listExecutions(
+        projectName: String,
+        contestName: String? = null,
+    ): Either<SaveCloudError, List<ExecutionDto>> =
+            listExecutions(
+                organizationName = name,
+                projectName,
+                contestName,
+            )
 
     /**
      * @param projectName the name of the project.
@@ -254,6 +275,16 @@ interface SaveCloudClientEx {
                 projectName,
                 limit
             )
+
+    /**
+     * Lists test runs (along with their results) for this batch execution.
+     *
+     * @return either the list of test runs, or the error if an error has
+     *   occurred.
+     * @see SaveCloudClientEx.listTestRuns
+     */
+    suspend fun ExecutionDto.listTestRuns(): Either<SaveCloudError, List<TestExecutionDto>> =
+            listTestRuns(id)
 
     /**
      * The factory object.

--- a/save-api/src/main/kotlin/com/saveourtool/save/api/impl/DefaultSaveCloudClient.kt
+++ b/save-api/src/main/kotlin/com/saveourtool/save/api/impl/DefaultSaveCloudClient.kt
@@ -2,6 +2,7 @@
 
 package com.saveourtool.save.api.impl
 
+import com.saveourtool.save.agent.TestExecutionDto
 import com.saveourtool.save.api.SaveCloudClientEx
 import com.saveourtool.save.api.errors.SaveCloudError
 import com.saveourtool.save.api.errors.TimeoutError
@@ -275,6 +276,19 @@ internal class DefaultSaveCloudClient(
                 }
             }
 
+    override suspend fun listTestRuns(
+        executionId: Long
+    ): Either<SaveCloudError, List<TestExecutionDto>> =
+            postAndCheck(
+                "/test-executions",
+                requestBody = EmptyContent,
+                contentType = Application.Json,
+                EXECUTION_ID to executionId,
+                CHECK_DEBUG_INFO to true,
+                PAGE to 0,
+                SIZE to Integer.MAX_VALUE,
+            )
+
     private suspend inline fun <reified T> getAndCheck(
         absolutePath: String,
         requestBody: Any = EmptyContent,
@@ -326,13 +340,16 @@ internal class DefaultSaveCloudClient(
         @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
         private val logger = getLogger<DefaultSaveCloudClient>()
         private const val AMOUNT = "amount"
+        private const val CHECK_DEBUG_INFO = "checkDebugInfo"
         private const val DEFAULT_API_VERSION = v1
         private const val EXECUTION_ID = "executionId"
         private const val NAME = "name"
         private const val ORGANIZATION_NAME = "organizationName"
+        private const val PAGE = "page"
         private const val PERMISSION = "permission"
         private const val POLL_DELAY_MILLIS = 100L
         private const val PROJECT_NAME = "projectName"
+        private const val SIZE = "size"
         private const val UPLOADED_MILLIS = "uploadedMillis"
         private val fileWithVersion =
                 Regex("""^(?<basename>.+?)-(?<version>\d+(?:\.\d+)*)(?<extension>(?:\.[^.\s-]+)+?)?$""")

--- a/save-cloud-charts/save-cloud/.gitignore
+++ b/save-cloud-charts/save-cloud/.gitignore
@@ -1,0 +1,1 @@
+/save-cloud-*.tgz

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,5 +22,6 @@ include("save-sandbox")
 include("authentication-service")
 include("save-demo")
 include("save-demo-cpg")
+include("test-analysis-core")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/test-analysis-core/.gitignore
+++ b/test-analysis-core/.gitignore
@@ -1,0 +1,5 @@
+/.asciidoctor/
+/diag-*.png
+/README.docx
+/README.html
+/README.pdf

--- a/test-analysis-core/README.adoc
+++ b/test-analysis-core/README.adoc
@@ -1,0 +1,26 @@
+= Test Analysis
+:toc:
+
+== Features
+
+* Collection of scalar xref:#metrics[test metrics].
+* _Sliding window_ of a configurable size.
+* xref:#algorithms[Test analysis].
+
+[#metrics]
+=== Test Metrics
+
+* The number of successful runs;
+* The number of failures;
+* The number of status "flips" (i.e. "success -> failure" and "failure -> success"
+transitions across consecutive test runs);
+* Failure rate;
+* Flip rate;
+* Average test duration;
+* Median test duration.
+
+[#algorithms]
+=== Algorithms
+
+* _Flaky test_ detection based on _flip rate_ (the default threshold is *30%*).
+* _Regression_ detection.

--- a/test-analysis-core/build.gradle.kts
+++ b/test-analysis-core/build.gradle.kts
@@ -1,11 +1,9 @@
-import com.saveourtool.save.buildutils.configureJacoco
-import com.saveourtool.save.buildutils.configurePublishing
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     id("com.saveourtool.save.buildutils.code-quality-convention")
-    `maven-publish`
+    id("com.saveourtool.save.buildutils.publishing-configuration")
 }
 
 java {
@@ -53,6 +51,3 @@ publishing {
         }
     }
 }
-
-configureJacoco()
-configurePublishing()

--- a/test-analysis-core/build.gradle.kts
+++ b/test-analysis-core/build.gradle.kts
@@ -1,0 +1,58 @@
+import com.saveourtool.save.buildutils.configureJacoco
+import com.saveourtool.save.buildutils.configurePublishing
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+
+plugins {
+    id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
+    id("com.saveourtool.save.buildutils.code-quality-convention")
+    `maven-publish`
+}
+
+java {
+    withSourcesJar()
+}
+
+dependencies {
+    /*
+     * Necessary, because otherwise Gradle will try to resolve "org.slf4j:slf4j-api:."
+     * (the transitive dependency of "projects.saveCloudCommon")
+     * and fail to find the undefined version.
+     */
+    implementation(project.dependencies.platform(libs.spring.boot.dependencies))
+    api(projects.saveCloudCommon)
+
+    testApi(libs.assertj.core)
+    testApi(libs.mockito.kotlin)
+    testApi(libs.mockito.junit.jupiter)
+    testApi(libs.junit.jupiter.api)
+    testApi(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+
+    testLogging {
+        showStandardStreams = true
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        exceptionFormat = FULL
+        events("passed", "skipped")
+    }
+
+    filter {
+        includeTestsMatching("com.saveourtool.save.test.analysis.*")
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+}
+
+configureJacoco()
+configurePublishing()

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/Algorithm.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/Algorithm.kt
@@ -1,0 +1,13 @@
+package com.saveourtool.save.test.analysis.algorithms
+
+import com.saveourtool.save.test.analysis.api.TestRuns
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.api.metrics.TestMetrics
+import com.saveourtool.save.test.analysis.api.results.IrregularTest
+
+/**
+ * A heuristic algorithm which accepts test history ([TestRuns]), pre-calculated
+ * metrics ([TestMetrics]) and returns either a result ([IrregularTest]), or
+ * `null` if this algorithm hasn't detected anything special about the test.
+ */
+fun interface Algorithm : Function2<TestRuns, RegularTestMetrics, IrregularTest?>

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysis.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysis.kt
@@ -8,10 +8,30 @@ import com.saveourtool.save.test.analysis.api.results.IrregularTest
 /**
  * _Flip-rate_ based flaky test detection algorithm.
  *
+ * A test _flip_ is a status change (either from _successful_ to a _failed_ or
+ * vice versa) over two consecutive test runs.
+ *
+ * A _flip rate_ is the ratio of the actual flip number to the maximum possible
+ * flip number (i.e. run count minus one, see
+ * [RegularTestMetrics.flipRate] and [RegularTestMetrics.flipRatePercentage]):
+ *
+ * ```
+ *         N          + N
+ *          pass➔fail    fail➔pass
+ * R     = ────────────────────────
+ *  flip          N    - 1
+ *                 run
+ * ```
+ *
+ * If the _flip rate_ exceeds a certain [threshold][flipRateThreshold], the test
+ * is considered _flaky_.
+ *
  * @param minimumRunCount the minimum run count a sample should have to be
  *   representative.
  * @param flipRateThreshold the _flip rate_ threshold.
  *   If the threshold is exceeded, the test is considered _flaky_.
+ * @see RegularTestMetrics.flipRate
+ * @see RegularTestMetrics.flipRatePercentage
  */
 @Suppress("FLOAT_IN_ACCURATE_CALCULATIONS")
 class FlipRateAnalysis(

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysis.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysis.kt
@@ -1,0 +1,42 @@
+package com.saveourtool.save.test.analysis.algorithms
+
+import com.saveourtool.save.test.analysis.api.TestRuns
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.api.results.FlakyTest
+import com.saveourtool.save.test.analysis.api.results.IrregularTest
+
+/**
+ * _Flip-rate_ based flaky test detection algorithm.
+ *
+ * @param minimumRunCount the minimum run count a sample should have to be
+ *   representative.
+ * @param flipRateThreshold the _flip rate_ threshold.
+ *   If the threshold is exceeded, the test is considered _flaky_.
+ */
+@Suppress("FLOAT_IN_ACCURATE_CALCULATIONS")
+class FlipRateAnalysis(
+    private val minimumRunCount: Int,
+    private val flipRateThreshold: Double,
+) : Algorithm {
+    init {
+        require(minimumRunCount > 0) {
+            "Minimum run count should be positive: $minimumRunCount"
+        }
+        require(0.0 < flipRateThreshold && flipRateThreshold < 1.0) {
+            "Flip Rate threshold should be in range (0.0, 1.0): $flipRateThreshold"
+        }
+    }
+
+    override fun invoke(runs: TestRuns, metrics: RegularTestMetrics): IrregularTest? {
+        require(runs.size == metrics.runCount) {
+            "${runs.size} != ${metrics.runCount}"
+        }
+
+        return when {
+            metrics.flipRate > flipRateThreshold && metrics.runCount >= minimumRunCount ->
+                FlakyTest("Flip rate of ${metrics.flipRatePercentage}% over ${metrics.runCount} run(s)")
+
+            else -> null
+        }
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysis.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysis.kt
@@ -29,7 +29,7 @@ class FlipRateAnalysis(
 
     override fun invoke(runs: TestRuns, metrics: RegularTestMetrics): IrregularTest? {
         require(runs.size == metrics.runCount) {
-            "${runs.size} != ${metrics.runCount}"
+            "Runs and metrics report different run count: ${runs.size} != ${metrics.runCount}"
         }
 
         return when {

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/PermanentFailureDetection.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/PermanentFailureDetection.kt
@@ -11,7 +11,7 @@ import com.saveourtool.save.test.analysis.api.results.PermanentFailure
 class PermanentFailureDetection : Algorithm {
     override fun invoke(runs: TestRuns, metrics: RegularTestMetrics): IrregularTest? {
         require(runs.size == metrics.runCount) {
-            "${runs.size} != ${metrics.runCount}"
+            "Runs and metrics report different run count: ${runs.size} != ${metrics.runCount}"
         }
 
         return when (metrics.failureRate) {

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/PermanentFailureDetection.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/PermanentFailureDetection.kt
@@ -1,0 +1,22 @@
+package com.saveourtool.save.test.analysis.algorithms
+
+import com.saveourtool.save.test.analysis.api.TestRuns
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.api.results.IrregularTest
+import com.saveourtool.save.test.analysis.api.results.PermanentFailure
+
+/**
+ * _Permanent failure_ detection algorithm.
+ */
+class PermanentFailureDetection : Algorithm {
+    override fun invoke(runs: TestRuns, metrics: RegularTestMetrics): IrregularTest? {
+        require(runs.size == metrics.runCount) {
+            "${runs.size} != ${metrics.runCount}"
+        }
+
+        return when (metrics.failureRate) {
+            1.0 -> PermanentFailure("All ${metrics.runCount} run(s) have failed")
+            else -> null
+        }
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/RegressionDetection.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/RegressionDetection.kt
@@ -1,0 +1,67 @@
+package com.saveourtool.save.test.analysis.algorithms
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.test.analysis.api.TestRuns
+import com.saveourtool.save.test.analysis.api.TestStatusProvider
+import com.saveourtool.save.test.analysis.api.TestStatusProviderScope
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.api.results.IrregularTest
+import com.saveourtool.save.test.analysis.api.results.Regression
+
+/**
+ * Regression detection algorithm.
+ *
+ * @param minimumRunCount the minimum run count a sample should have to be
+ *   representative.
+ * @property testStatusProvider the test status provider.
+ */
+class RegressionDetection(
+    private val minimumRunCount: Int,
+    override val testStatusProvider: TestStatusProvider<TestResultStatus>,
+) : Algorithm, TestStatusProviderScope<TestResultStatus> {
+    init {
+        require(minimumRunCount > 0) {
+            "Minimum run count should be positive: $minimumRunCount"
+        }
+    }
+
+    @Suppress("NestedBlockDepth")
+    override fun invoke(runs: TestRuns, metrics: RegularTestMetrics): IrregularTest? {
+        require(runs.size == metrics.runCount) {
+            "${runs.size} != ${metrics.runCount}"
+        }
+
+        return when {
+            metrics.runCount >= minimumRunCount -> when (metrics.failureRate) {
+                /*
+                 * Permanent success.
+                 */
+                0.0 -> null
+
+                /*
+                 * Permanent failure.
+                 */
+                1.0 -> null
+
+                else -> when (metrics.flipCount) {
+                    /*
+                     * Statistics for a regression contains exactly a single flip.
+                     */
+                    1 -> with(testStatusProvider) {
+                        when {
+                            runs.first().isSuccess() && runs.last().isFailure() -> Regression("1 regression over ${metrics.runCount} run(s)")
+                            else -> null
+                        }
+                    }
+
+                    else -> null
+                }
+            }
+
+            /*
+             * Non-representative sample.
+             */
+            else -> null
+        }
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/RegressionDetection.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/algorithms/RegressionDetection.kt
@@ -28,7 +28,7 @@ class RegressionDetection(
     @Suppress("NestedBlockDepth")
     override fun invoke(runs: TestRuns, metrics: RegularTestMetrics): IrregularTest? {
         require(runs.size == metrics.runCount) {
-            "${runs.size} != ${metrics.runCount}"
+            "Runs and metrics report different run count: ${runs.size} != ${metrics.runCount}"
         }
 
         return when {

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestAnalysisService.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestAnalysisService.kt
@@ -1,0 +1,62 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.test.analysis.algorithms.FlipRateAnalysis
+import com.saveourtool.save.test.analysis.algorithms.PermanentFailureDetection
+import com.saveourtool.save.test.analysis.algorithms.RegressionDetection
+import com.saveourtool.save.test.analysis.api.results.AnalysisResult
+import com.saveourtool.save.test.analysis.internal.DefaultTestAnalysisService
+
+/**
+ * Analyzes test runs for the given test id; see [analyze] for details.
+ *
+ * @see analyze
+ */
+interface TestAnalysisService {
+    /**
+     * The statistical data about test runs this service uses during analysis.
+     */
+    val statisticsStorage: TestStatisticsStorage
+
+    /**
+     * Analyzes test runs for the given test [id] and returns the list of
+     * results.
+     *
+     * @param id the unique test id.
+     * @return the list of analysis results for the given test [id].
+     */
+    fun analyze(id: TestId): List<AnalysisResult>
+
+    companion object Factory {
+        /**
+         * The default [flip rate threshold][FlipRateAnalysis.flipRateThreshold].
+         */
+        private const val FLIP_RATE_THRESHOLD = 0.3
+
+        /**
+         * The minimum number of test runs for a sample to be considered
+         * representative.
+         */
+        internal const val MINIMUM_RUN_COUNT = 10
+
+        /**
+         * Creates a new service instance.
+         *
+         * @param statisticsStorage the statistical data about test runs to be
+         *   used during analysis.
+         * @return a new instance of the default implementation.
+         */
+        operator fun invoke(statisticsStorage: TestStatisticsStorage): TestAnalysisService =
+                DefaultTestAnalysisService(
+                    statisticsStorage,
+                    FlipRateAnalysis(
+                        MINIMUM_RUN_COUNT,
+                        FLIP_RATE_THRESHOLD,
+                    ),
+                    RegressionDetection(
+                        MINIMUM_RUN_COUNT,
+                        statisticsStorage.testStatusProvider,
+                    ),
+                    PermanentFailureDetection(),
+                )
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestId.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestId.kt
@@ -1,9 +1,21 @@
 package com.saveourtool.save.test.analysis.api
 
+import com.saveourtool.save.entities.Test
+
 /**
  * A test executed within a particular project (the same test executed in a
  * different project even within the same organization will have a different
  * [hash]).
+ *
+ * This is similar to [Test.hash] in a sense that both identify a series of test
+ * runs (so that these runs can be statistically analyzed).
+ * The difference is that the same [Test] executed for different projects
+ * (e.g.: _KtLint_ vs _Diktat_, or _Diktat 1.2.3_ vs Diktat _1.2.4_) or within
+ * different organizations will have different [TestId]'s.
+ *
+ * In terms of CI and unit testing, [TestId] is like a _JUnit_ or _TestNG_ test
+ * name (`ClassName.testMethodName`), partitioned by organization name and
+ * project name.
  *
  * To create a [TestId] instance, use [TestIdGenerator.testId].
  *

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestId.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestId.kt
@@ -1,0 +1,13 @@
+package com.saveourtool.save.test.analysis.api
+
+/**
+ * A test executed within a particular project (the same test executed in a
+ * different project even within the same organization will have a different
+ * [hash]).
+ *
+ * To create a [TestId] instance, use [TestIdGenerator.testId].
+ *
+ * @property hash the SHA hash that uniquely identifies this test.
+ */
+@JvmInline
+value class TestId internal constructor(private val hash: String)

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestIdGenerator.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestIdGenerator.kt
@@ -1,0 +1,44 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.test.analysis.internal.DefaultTestIdGenerator
+
+/**
+ * Generates unique test ids.
+ */
+fun interface TestIdGenerator {
+    /**
+     * Generates a unique test id.
+     *
+     * @param organizationName the name of the organization.
+     * @param projectName the name of the project.
+     * @param testSuiteSourceName the name of the test suite source.
+     * @param testSuiteVersion the version of the test suite.
+     * @param testSuiteName the name of the test suite.
+     * @param pluginName the name of the `save-cli` plug-in ("warn", "fix", etc.).
+     * @param filePath the path to the file within the test suite.
+     * @return the generated unique test id.
+     */
+    @Suppress(
+        "LongParameterList",
+        "TOO_MANY_PARAMETERS",
+    )
+    fun testId(
+        organizationName: String,
+        projectName: String,
+        testSuiteSourceName: String?,
+        testSuiteVersion: String?,
+        testSuiteName: String?,
+        pluginName: String,
+        filePath: String,
+    ): TestId
+
+    companion object {
+        /**
+         * Creates a new service instance.
+         *
+         * @return a new instance of the default implementation.
+         */
+        operator fun invoke(): TestIdGenerator =
+                DefaultTestIdGenerator()
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestRun.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestRun.kt
@@ -1,0 +1,14 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.domain.TestResultStatus
+import kotlin.time.Duration
+
+/**
+ * @property status the implementation-specific test status.
+ * @property durationOrNull test duration (if batch size is 1) or batch duration
+ *   (otherwise).
+ */
+data class TestRun(
+    val status: TestResultStatus,
+    val durationOrNull: Duration?
+)

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestRuns.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestRuns.kt
@@ -1,0 +1,9 @@
+@file:JvmName("TestRuns")
+@file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package com.saveourtool.save.test.analysis.api
+
+/**
+ * The list of [TestRun] instances.
+ */
+typealias TestRuns = List<TestRun>

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestStatisticsStorage.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestStatisticsStorage.kt
@@ -1,0 +1,154 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.test.analysis.api.metrics.NoDataAvailable
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.api.metrics.TestMetrics
+import kotlin.time.Duration
+import kotlin.time.DurationUnit.MILLISECONDS
+import kotlin.time.toDuration
+
+/**
+ * The storage of statistical data about test runs.
+ */
+interface TestStatisticsStorage : TestStatusProviderScope<TestResultStatus> {
+    /**
+     * Returns the detailed statistics about all test runs for the given [id].
+     *
+     * @param ignoreIndeterminate whether runs with an indeterminate test status
+     *   should be ignored.
+     *   The default is `true`.
+     * @param id the unique test identifier.
+     * @return the list of [TestRun] instances for the given test [id].
+     */
+    fun getExecutionStatistics(
+        id: TestId,
+        ignoreIndeterminate: Boolean = true,
+    ): TestRuns
+
+    /**
+     * Returns the aggregate statistics for the given [id].
+     *
+     * @param id the unique test identifier.
+     * @return the scalar test metrics for the given test [id].
+     */
+    fun getTestMetrics(id: TestId): TestMetrics =
+            with(testStatusProvider) {
+                val testRuns = getExecutionStatistics(id)
+
+                when {
+                    testRuns.isEmpty() -> NoDataAvailable
+                    else -> RegularTestMetrics(
+                        successCount = testRuns.count { it.isSuccess() },
+                        failureCount = testRuns.count { it.isFailure() },
+                        flipCount = testRuns.flipCount(),
+                        ignoredCount = testRuns.count { it.isIgnored() },
+                        averageDurationOrNull = testRuns.averageDurationOrNull(),
+                        medianDurationOrNull = testRuns.medianDurationOrNull(),
+                    )
+                }
+            }
+
+    private fun TestRuns.averageDurationOrNull(): Duration? =
+            with(testStatusProvider) {
+                check(!isEmpty())
+
+                val durationsMillis = asSequence()
+                    .map(TestRun::durationOrNull)
+                    .filterNotNull()
+                    .map(Duration::inWholeMilliseconds)
+                    .toList()
+
+                when {
+                    durationsMillis.isEmpty() -> null
+                    else -> durationsMillis
+                        .average()
+                        .toLong()
+                        .toDuration(MILLISECONDS)
+                }
+            }
+
+    private fun TestRuns.medianDurationOrNull(): Duration? =
+            with(testStatusProvider) {
+                check(!isEmpty())
+
+                val durationsMillis: ArrayList<Long> = asSequence()
+                    .map(TestRun::durationOrNull)
+                    .filterNotNull()
+                    .map(Duration::inWholeMilliseconds)
+                    .toCollection(arrayListOf())
+                    .apply(MutableList<Long>::sort)
+
+                when {
+                    durationsMillis.isEmpty() -> null
+
+                    else -> durationsMillis
+                        .median()
+                        .toLong()
+                        .toDuration(MILLISECONDS)
+                }
+            }
+
+    private fun TestRuns.flipCount(): Int =
+            when (size) {
+                0 -> 0
+
+                /*
+                 * It requires at least two consecutive runs for a single flip
+                 * to occur.
+                 */
+                1 -> 0
+
+                else -> foldIndexed(0 to null as TestRun?) { index, (previousFlipCount, previousTestRun), testRun ->
+                    val flipCount = when (index) {
+                        0 -> 0
+                        else -> when {
+                            isFlip(checkNotNull(previousTestRun), testRun) -> previousFlipCount + 1
+                            else -> previousFlipCount
+                        }
+                    }
+
+                    flipCount to testRun
+                }.first
+            }
+
+    private fun isFlip(previous: TestRun, current: TestRun): Boolean =
+            with(testStatusProvider) {
+                when {
+                    previous.isSuccess() -> current.isFailure()
+                    previous.isFailure() -> current.isSuccess()
+                    else -> false
+                }
+            }
+
+    private companion object {
+        /**
+         * @return the median of the _sorted_ list.
+         */
+        @Suppress(
+            "MAGIC_NUMBER",
+            "FLOAT_IN_ACCURATE_CALCULATIONS",
+        )
+        private fun ArrayList<Long>.median(): Double =
+                when {
+                    isEmpty() -> Double.NaN
+
+                    /*
+                     * Evenly-sized, non-empty.
+                     */
+                    size % 2 == 0 -> {
+                        val rightIndex = size / 2
+                        val leftIndex = rightIndex - 1
+                        (this[leftIndex] + this[rightIndex]) / 2.0
+                    }
+
+                    /*
+                     * Oddly-sized.
+                     */
+                    else -> {
+                        val index = (size - 1) / 2
+                        this[index].toDouble()
+                    }
+                }
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestStatusProvider.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestStatusProvider.kt
@@ -1,0 +1,74 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.test.analysis.internal.DefaultTestStatusProvider
+
+/**
+ * Converts the implementation-specific test status into one of the following
+ * flags:
+ *
+ *  - success,
+ *  - failure,
+ *  - ignored,
+ *  - indeterminate.
+ *
+ * @param T the implementation-specific test status.
+ */
+interface TestStatusProvider<T : Enum<T>> {
+    /**
+     * @return `true` if the implementation-specific test status is a "success".
+     * @see TestRun.isSuccess
+     */
+    fun T.isSuccess(): Boolean
+
+    /**
+     * @return `true` if the implementation-specific test status is a "failure".
+     * @see TestRun.isFailure
+     */
+    fun T.isFailure(): Boolean
+
+    /**
+     * @return `true` if the implementation-specific test status is "ignored".
+     * @see TestRun.isIgnored
+     */
+    fun T.isIgnored(): Boolean
+
+    /**
+     * @return `true` if the implementation-specific test status is neither a
+     *   "success", nor a "failure", nor "ignored".
+     * @see TestRun.isIndeterminate
+     */
+    fun T.isIndeterminate(): Boolean
+
+    /**
+     * @return `true` if this test run is successful.
+     */
+    fun TestRun.isSuccess(): Boolean
+
+    /**
+     * @return `true` if this test run is a failure.
+     */
+    fun TestRun.isFailure(): Boolean
+
+    /**
+     * @return `true` if this test run is an ignored one (i.e. the test was not
+     *   run).
+     */
+    fun TestRun.isIgnored(): Boolean
+
+    /**
+     * @return `true` if this test run is neither [successful][TestRun.isSuccess],
+     *   nor a [failure][TestRun.isFailure], nor [ignored][TestRun.isIgnored].
+     */
+    fun TestRun.isIndeterminate(): Boolean
+
+    companion object Factory {
+        /**
+         * Creates a new test status provider service.
+         *
+         * @return a new instance of the default implementation.
+         */
+        operator fun invoke(): TestStatusProvider<TestResultStatus> =
+                DefaultTestStatusProvider()
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestStatusProviderScope.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/TestStatusProviderScope.kt
@@ -1,0 +1,14 @@
+package com.saveourtool.save.test.analysis.api
+
+/**
+ * Inheritors of this interface will have a [TestStatusProvider] instance in
+ * their scope.
+ *
+ * @see TestStatusProvider
+ */
+interface TestStatusProviderScope<T : Enum<T>> {
+    /**
+     * The test status provider.
+     */
+    val testStatusProvider: TestStatusProvider<T>
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/NoDataAvailable.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/NoDataAvailable.kt
@@ -1,0 +1,3 @@
+package com.saveourtool.save.test.analysis.api.metrics
+
+object NoDataAvailable : TestMetrics

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/RegularTestMetrics.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/RegularTestMetrics.kt
@@ -33,6 +33,9 @@ data class RegularTestMetrics(
         get() = successCount + failureCount + ignoredCount
 
     /**
+     * The ratio (between 0% and 100%) of the failure count to the
+     * [run count][runCount], within the _sliding window_.
+     *
      * @see failureRate
      */
     val failureRatePercentage: Int
@@ -46,12 +49,22 @@ data class RegularTestMetrics(
         }
 
     /**
+     * The ratio (between 0.0 and 1.0) of the failure count to the
+     * [run count][runCount], within the _sliding window_.
+     *
      * @see failureRatePercentage
      */
     val failureRate: Double
         get() = failureRatePercentage / 100.0
 
     /**
+     * The ratio (between 0% and 100%) of the actual flip count to the maximum
+     * possible flip count (i.e. [run count][runCount] minus one), within the
+     * _sliding window_.
+     *
+     * A test _flip_ is a status change (either from _successful_ to a _failed_
+     * or vice versa) over two consecutive test runs.
+     *
      * @see flipRate
      */
     val flipRatePercentage: Int
@@ -72,6 +85,13 @@ data class RegularTestMetrics(
         }
 
     /**
+     * The ratio (between 0.0 and 1.0) of the actual flip count to the maximum
+     * possible flip count (i.e. [run count][runCount] minus one), within the
+     * _sliding window_.
+     *
+     * A test _flip_ is a status change (either from _successful_ to a _failed_
+     * or vice versa) over two consecutive test runs.
+     *
      * @see flipRatePercentage
      */
     val flipRate: Double

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/RegularTestMetrics.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/RegularTestMetrics.kt
@@ -1,0 +1,79 @@
+package com.saveourtool.save.test.analysis.api.metrics
+
+import kotlin.time.Duration
+
+/**
+ * @property successCount the number of successful test runs in a sample.
+ * @property failureCount the number of failed test runs in a sample.
+ * @property flipCount the number of test status "flips" in a sample.
+ * @property ignoredCount the number of times the test was ignored (skipped).
+ * @property averageDurationOrNull average test duration (if batch size is 1) or
+ *   average batch duration (otherwise).
+ * @property medianDurationOrNull median test duration (if batch size is 1) or
+ *   median batch duration (otherwise).
+ */
+@Suppress(
+    "MagicNumber",
+    "FLOAT_IN_ACCURATE_CALCULATIONS",
+    "MAGIC_NUMBER",
+    "CUSTOM_GETTERS_SETTERS",
+)
+data class RegularTestMetrics(
+    val successCount: Int,
+    val failureCount: Int,
+    val flipCount: Int,
+    val ignoredCount: Int,
+    val averageDurationOrNull: Duration?,
+    val medianDurationOrNull: Duration?
+) : TestMetrics {
+    /**
+     * The run count of this test within the _sliding window_.
+     */
+    val runCount: Int
+        get() = successCount + failureCount + ignoredCount
+
+    /**
+     * @see failureRate
+     */
+    val failureRatePercentage: Int
+        get() = when (runCount) {
+            0 -> 0
+
+            /*
+             * Ignored runs, if any, decrease the failure rate.
+             */
+            else -> failureCount * 100 / runCount
+        }
+
+    /**
+     * @see failureRatePercentage
+     */
+    val failureRate: Double
+        get() = failureRatePercentage / 100.0
+
+    /**
+     * @see flipRate
+     */
+    val flipRatePercentage: Int
+        get() = when (runCount) {
+            0 -> 0
+
+            /*
+             * It requires at least two consecutive runs for a single flip.
+             * to occur.
+             */
+            1 -> 0
+
+            else -> {
+                val maxFlipCount = runCount - 1
+
+                flipCount * 100 / maxFlipCount
+            }
+        }
+
+    /**
+     * @see flipRatePercentage
+     */
+    val flipRate: Double
+        get() = flipRatePercentage / 100.0
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/TestMetrics.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/metrics/TestMetrics.kt
@@ -1,0 +1,10 @@
+package com.saveourtool.save.test.analysis.api.metrics
+
+import com.saveourtool.save.test.analysis.api.TestStatisticsStorage
+
+/**
+ * Scalar test metrics returned by [TestStatisticsStorage.getTestMetrics].
+ *
+ * @see TestStatisticsStorage.getTestMetrics
+ */
+sealed interface TestMetrics

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/AnalysisResult.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/AnalysisResult.kt
@@ -1,0 +1,12 @@
+package com.saveourtool.save.test.analysis.api.results
+
+import com.saveourtool.save.test.analysis.algorithms.Algorithm
+import com.saveourtool.save.test.analysis.api.TestAnalysisService
+
+/**
+ * The analysis result returned by [Algorithm] or [TestAnalysisService.analyze].
+ *
+ * @see Algorithm
+ * @see TestAnalysisService.analyze
+ */
+sealed interface AnalysisResult

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/FlakyTest.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/FlakyTest.kt
@@ -1,0 +1,6 @@
+package com.saveourtool.save.test.analysis.api.results
+
+/**
+ * @property detailMessage the detail message string of this result.
+ */
+data class FlakyTest(override val detailMessage: String = "") : IrregularTest

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/IrregularTest.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/IrregularTest.kt
@@ -1,0 +1,8 @@
+package com.saveourtool.save.test.analysis.api.results
+
+interface IrregularTest : AnalysisResult {
+    /**
+     * The detail message string of this result.
+     */
+    val detailMessage: String
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/PermanentFailure.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/PermanentFailure.kt
@@ -1,0 +1,12 @@
+package com.saveourtool.save.test.analysis.api.results
+
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+
+/**
+ * A permanent failure &mdash; a test that has a 100%
+ * [failure rate][RegularTestMetrics.failureRate].
+ *
+ * @property detailMessage the detail message string of this result.
+ * @see RegularTestMetrics.failureRate
+ */
+data class PermanentFailure(override val detailMessage: String = "") : IrregularTest

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/Regression.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/Regression.kt
@@ -1,0 +1,6 @@
+package com.saveourtool.save.test.analysis.api.results
+
+/**
+ * @property detailMessage the detail message string of this result.
+ */
+data class Regression(override val detailMessage: String = "") : IrregularTest

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/RegularTest.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/api/results/RegularTest.kt
@@ -1,0 +1,6 @@
+package com.saveourtool.save.test.analysis.api.results
+
+object RegularTest : AnalysisResult {
+    override fun toString(): String =
+            javaClass.simpleName
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/DefaultTestAnalysisService.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/DefaultTestAnalysisService.kt
@@ -1,0 +1,39 @@
+package com.saveourtool.save.test.analysis.internal
+
+import com.saveourtool.save.test.analysis.algorithms.Algorithm
+import com.saveourtool.save.test.analysis.api.TestAnalysisService
+import com.saveourtool.save.test.analysis.api.TestId
+import com.saveourtool.save.test.analysis.api.TestStatisticsStorage
+import com.saveourtool.save.test.analysis.api.metrics.NoDataAvailable
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.api.results.AnalysisResult
+import com.saveourtool.save.test.analysis.api.results.RegularTest
+
+/**
+ * The default implementation of [TestAnalysisService].
+ *
+ * @property statisticsStorage the storage of statistical data about test runs.
+ * @property algorithms the algorithms used by this service.
+ */
+internal class DefaultTestAnalysisService(
+    override val statisticsStorage: TestStatisticsStorage,
+    private vararg val algorithms: Algorithm
+) : TestAnalysisService {
+    override fun analyze(id: TestId): List<AnalysisResult> {
+        val testRuns = statisticsStorage.getExecutionStatistics(id)
+
+        return when (val metrics = statisticsStorage.getTestMetrics(id)) {
+            is NoDataAvailable -> listOf(RegularTest)
+            is RegularTestMetrics -> algorithms
+                .asSequence()
+                .map { algorithm ->
+                    algorithm(testRuns, metrics)
+                }
+                .filterNotNull()
+                .toList()
+                .ifEmpty {
+                    listOf(RegularTest)
+                }
+        }
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/DefaultTestIdGenerator.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/DefaultTestIdGenerator.kt
@@ -1,0 +1,123 @@
+package com.saveourtool.save.test.analysis.internal
+
+import com.saveourtool.save.test.analysis.api.TestId
+import com.saveourtool.save.test.analysis.api.TestIdGenerator
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+
+/**
+ * The default implementation of [TestIdGenerator], which uses the strongest
+ * SHA-2 hash available.
+ */
+internal class DefaultTestIdGenerator : TestIdGenerator {
+    @Suppress("TOO_MANY_PARAMETERS")
+    override fun testId(
+        organizationName: String,
+        projectName: String,
+        testSuiteSourceName: String?,
+        testSuiteVersion: String?,
+        testSuiteName: String?,
+        pluginName: String,
+        filePath: String
+    ): TestId =
+            TestId(
+                toHash(
+                    organizationName,
+                    projectName,
+                    testSuiteSourceName,
+                    testSuiteVersion,
+                    testSuiteName,
+                    pluginName,
+                    filePath,
+                )
+            )
+
+    private companion object {
+        @Suppress(
+            "LongParameterList",
+            "TOO_MANY_PARAMETERS",
+            "AVOID_NULL_CHECKS",
+        )
+        private fun toHash(
+            organizationName: String,
+            projectName: String,
+            testSuiteSourceName: String?,
+            testSuiteVersion: String?,
+            testSuiteName: String?,
+            pluginName: String,
+            filePath: String,
+        ): String {
+            val digest = firstDigestInstance(
+                "SHA-512",
+                "SHA-384",
+                "SHA-256"
+            )
+
+            sequenceOf(
+                organizationName,
+                projectName,
+                testSuiteSourceName,
+                testSuiteVersion,
+                testSuiteName,
+                pluginName,
+                filePath,
+            ).forEach { value ->
+                /*-
+                 * TLV without the tag ("LV").
+                 *
+                 * Even if the "V" field is `null`, the digest is still updated
+                 * with data in order to avoid collisions.
+                 */
+                val length = value?.length ?: -1
+                digest.update(length)
+
+                if (value != null) {
+                    digest.update(value)
+                }
+            }
+
+            return digest.digest().toHexString()
+        }
+
+        private fun ByteArray.toHexString(): String =
+                joinToString(separator = "") { eachByte ->
+                    "%02x".format(eachByte)
+                }
+
+        @Suppress(
+            "MagicNumber",
+            "MAGIC_NUMBER",
+        )
+        private fun Int.toByteArray(): ByteArray {
+            val buffer = ByteArray(4)
+
+            /*
+             * Big-endian, most significant byte first.
+             */
+            buffer.forEachIndexed { index, _ ->
+                buffer[index] = (this shr (8 * (3 - index))).toByte()
+            }
+
+            return buffer
+        }
+
+        private fun MessageDigest.update(input: Int): Unit =
+                update(input.toByteArray())
+
+        private fun MessageDigest.update(input: String): Unit =
+                update(input.toByteArray())
+
+        private fun firstDigestInstance(vararg algorithms: String): MessageDigest =
+                algorithms
+                    .asSequence()
+                    .map { algorithm ->
+                        try {
+                            MessageDigest.getInstance(algorithm)
+                        } catch (_: NoSuchAlgorithmException) {
+                            null
+                        }
+                    }
+                    .filterNotNull()
+                    .first()
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/DefaultTestStatusProvider.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/DefaultTestStatusProvider.kt
@@ -1,0 +1,41 @@
+package com.saveourtool.save.test.analysis.internal
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.domain.TestResultStatus.FAILED
+import com.saveourtool.save.domain.TestResultStatus.IGNORED
+import com.saveourtool.save.domain.TestResultStatus.PASSED
+import com.saveourtool.save.test.analysis.api.TestRun
+import com.saveourtool.save.test.analysis.api.TestStatusProvider
+
+/**
+ * The default implementation of [TestStatusProvider] which uses test statuses
+ * provided by [TestResultStatus].
+ *
+ * @see TestStatusProvider
+ * @see TestResultStatus
+ */
+internal class DefaultTestStatusProvider : TestStatusProvider<TestResultStatus> {
+    override fun TestResultStatus.isSuccess(): Boolean =
+            this == PASSED
+
+    override fun TestResultStatus.isFailure(): Boolean =
+            this == FAILED
+
+    override fun TestResultStatus.isIgnored(): Boolean =
+            this == IGNORED
+
+    override fun TestResultStatus.isIndeterminate(): Boolean =
+            !isSuccess() && !isFailure() && !isIgnored()
+
+    override fun TestRun.isSuccess(): Boolean =
+            status.isSuccess()
+
+    override fun TestRun.isFailure(): Boolean =
+            status.isFailure()
+
+    override fun TestRun.isIgnored(): Boolean =
+            status.isIgnored()
+
+    override fun TestRun.isIndeterminate(): Boolean =
+            status.isIndeterminate()
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/MemoryBacked.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/MemoryBacked.kt
@@ -1,0 +1,82 @@
+package com.saveourtool.save.test.analysis.internal
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.test.analysis.api.TestId
+import com.saveourtool.save.test.analysis.api.TestRun
+import com.saveourtool.save.test.analysis.api.TestRuns
+import com.saveourtool.save.test.analysis.api.TestStatisticsStorage
+import com.saveourtool.save.test.analysis.api.TestStatusProvider
+import java.util.LinkedList
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The memory-backed [TestStatisticsStorage] implementation.
+ *
+ * @property testStatusProvider the converter from the implementation-specific
+ *   test status into boolean success/failure flags.
+ * @property slidingWindowSize the size of the sliding window (the maximum sample
+ *   size preserved in memory for any given test).
+ * @see TestStatisticsStorage
+ */
+class MemoryBacked(
+    override val testStatusProvider: TestStatusProvider<TestResultStatus> = TestStatusProvider(),
+    private val slidingWindowSize: Int = DEFAULT_SLIDING_WINDOW_SIZE,
+) : MutableTestStatisticsStorage {
+    private val groupedTestRuns: MutableMap<TestId, MutableTestRuns> = ConcurrentHashMap()
+
+    override fun getExecutionStatistics(
+        id: TestId,
+        ignoreIndeterminate: Boolean,
+    ): TestRuns =
+            with(testStatusProvider) {
+                val testRuns = groupedTestRuns[id].orEmpty()
+
+                when {
+                    ignoreIndeterminate -> testRuns.asSequence().filterNot { testRun ->
+                        testRun.isIndeterminate()
+                    }.toList()
+
+                    else -> testRuns
+                }
+            }
+
+    override fun updateExecutionStatistics(id: TestId, testRun: TestRun) {
+        groupedTestRuns.compute(id) { _, oldValue: MutableTestRuns? ->
+            /*-
+             * Create a copy instead of modifying the existing list:
+             *
+             * 1. For the mutation to be idempotent (not an issue with CHM,
+             *    but definitely an issue with CSLM).
+             * 2. To avoid a `ConcurrentModificationException` (a reader thread
+             *    may be currently iterating over this very list). If the list
+             *    is being resized, because the state may be only partially
+             *    visible, an NPE (not only a CME) may get thrown on the reader
+             *    thread.
+             *
+             * This is a poor-man's COWAL implementation (where COWAL is not
+             * actually necessary), since we won't be able to atomically
+             * add-and-evict anyway.
+             *
+             * Consider rewriting using `EvictingQueue` (Guava) or
+             * `CircularFifoQueue` (Apache commons-collections).
+             */
+            LinkedList(oldValue.orEmpty()).apply {
+                /*
+                 * A naïve implementation which expects that `add(Int, TestRun)`
+                 * is never invoked.
+                 */
+                val isAdded = add(testRun)
+                while (isAdded && size > slidingWindowSize) {
+                    remove()
+                }
+            }
+        }
+    }
+
+    override fun clear() =
+            groupedTestRuns.clear()
+
+    private companion object {
+        private const val DEFAULT_SLIDING_WINDOW_SIZE = Int.MAX_VALUE
+    }
+}

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/MutableTestRuns.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/MutableTestRuns.kt
@@ -1,0 +1,8 @@
+@file:JvmName("MutableTestRuns")
+@file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package com.saveourtool.save.test.analysis.internal
+
+import com.saveourtool.save.test.analysis.api.TestRun
+
+internal typealias MutableTestRuns = MutableList<TestRun>

--- a/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/MutableTestStatisticsStorage.kt
+++ b/test-analysis-core/src/main/kotlin/com/saveourtool/save/test/analysis/internal/MutableTestStatisticsStorage.kt
@@ -1,0 +1,26 @@
+package com.saveourtool.save.test.analysis.internal
+
+import com.saveourtool.save.test.analysis.api.TestId
+import com.saveourtool.save.test.analysis.api.TestRun
+import com.saveourtool.save.test.analysis.api.TestStatisticsStorage
+
+/**
+ * A [TestStatisticsStorage] which allows the statistical data stored to be
+ * mutated.
+ */
+interface MutableTestStatisticsStorage : TestStatisticsStorage {
+    /**
+     * Updates stored statistical data for the test specified by [id] with a new
+     * [testRun].
+     *
+     * @param id the unique id of the test.
+     * @param testRun the recent test run information with a status and optional
+     *   duration.
+     */
+    fun updateExecutionStatistics(id: TestId, testRun: TestRun)
+
+    /**
+     * Clears any statistical data collected.
+     */
+    fun clear()
+}

--- a/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysisTest.kt
+++ b/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/algorithms/FlipRateAnalysisTest.kt
@@ -1,0 +1,45 @@
+package com.saveourtool.save.test.analysis.algorithms
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * @see FlipRateAnalysis
+ */
+class FlipRateAnalysisTest {
+    @Test
+    fun `minimum run count of zero should result in a failure`() {
+        assertThatThrownBy {
+            FlipRateAnalysis(minimumRunCount = 0, 0.5)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Minimum run count should be positive: 0")
+    }
+
+    @Test
+    fun `negative minimum run count should result in a failure`() {
+        assertThatThrownBy {
+            FlipRateAnalysis(minimumRunCount = -1, 0.5)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Minimum run count should be positive: -1")
+    }
+
+    @Test
+    fun `flip rate threshold of 0 should result in a failure`() {
+        assertThatThrownBy {
+            FlipRateAnalysis(30, flipRateThreshold = 0.0)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Flip Rate threshold should be in range (0.0, 1.0): 0.0")
+    }
+
+    @Test
+    fun `flip rate threshold of 1 should result in a failure`() {
+        assertThatThrownBy {
+            FlipRateAnalysis(30, flipRateThreshold = 1.0)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Flip Rate threshold should be in range (0.0, 1.0): 1.0")
+    }
+}

--- a/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/algorithms/RegressionDetectionTest.kt
+++ b/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/algorithms/RegressionDetectionTest.kt
@@ -1,0 +1,33 @@
+package com.saveourtool.save.test.analysis.algorithms
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.test.analysis.api.TestStatusProvider
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+/**
+ * @see RegressionDetection
+ */
+@ExtendWith(MockitoExtension::class)
+class RegressionDetectionTest {
+    @Test
+    fun `minimum run count of zero should result in a failure`(@Mock testStatusProvider: TestStatusProvider<TestResultStatus>) {
+        assertThatThrownBy {
+            RegressionDetection(minimumRunCount = 0, testStatusProvider)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Minimum run count should be positive: 0")
+    }
+
+    @Test
+    fun `negative minimum run count should result in a failure`(@Mock testStatusProvider: TestStatusProvider<TestResultStatus>) {
+        assertThatThrownBy {
+            RegressionDetection(minimumRunCount = -1, testStatusProvider)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Minimum run count should be positive: -1")
+    }
+}

--- a/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestAnalysisServiceTest.kt
+++ b/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestAnalysisServiceTest.kt
@@ -1,0 +1,282 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.domain.TestResultStatus.FAILED
+import com.saveourtool.save.domain.TestResultStatus.IGNORED
+import com.saveourtool.save.domain.TestResultStatus.PASSED
+import com.saveourtool.save.test.analysis.api.TestAnalysisService.Factory.MINIMUM_RUN_COUNT
+import com.saveourtool.save.test.analysis.api.results.FlakyTest
+import com.saveourtool.save.test.analysis.api.results.PermanentFailure
+import com.saveourtool.save.test.analysis.api.results.Regression
+import com.saveourtool.save.test.analysis.api.results.RegularTest
+import com.saveourtool.save.test.analysis.internal.MemoryBacked
+import com.saveourtool.save.test.analysis.internal.MutableTestStatisticsStorage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * @see TestAnalysisService
+ */
+class TestAnalysisServiceTest {
+    private lateinit var storage: MutableTestStatisticsStorage
+
+    @Suppress("WRONG_NEWLINES")
+    private lateinit var analyzer: TestAnalysisService
+
+    @BeforeEach
+    fun beforeEach() {
+        storage = MemoryBacked(slidingWindowSize = Int.MAX_VALUE)
+        analyzer = TestAnalysisService(storage)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        storage.clear()
+    }
+
+    @Test
+    fun `when there's no data, a test should have the regular status`() {
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `permanent success`() {
+        repeat(times = 100) {
+            storage[testId] += TestRun(PASSED, null)
+        }
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `ignored test`() {
+        repeat(times = 100) {
+            storage[testId] += TestRun(IGNORED, null)
+        }
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `permanent failure`() {
+        val runCount = 100
+
+        repeat(times = runCount) {
+            storage[testId] += TestRun(FAILED, null)
+        }
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .allSatisfy { result ->
+                assertThat(result).isInstanceOfSatisfying(PermanentFailure::class.java) { (message) ->
+                    assertThat(message).isEqualTo("All $runCount run(s) have failed")
+                }
+            }
+    }
+
+    @Test
+    fun `permanent failure status should get cleared after one successful run`() {
+        val runCount = 100
+
+        repeat(times = runCount) {
+            storage[testId] += TestRun(FAILED, null)
+        }
+        assertThat(analyzer.analyze(testId))
+            .hasSize(1)
+            .allSatisfy { result ->
+                assertThat(result).isInstanceOfSatisfying(PermanentFailure::class.java) { (message) ->
+                    assertThat(message).isEqualTo("All $runCount run(s) have failed")
+                }
+            }
+
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(analyzer.analyze(testId))
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `flaky test`() {
+        val runCount = 100 * MINIMUM_RUN_COUNT
+
+        flakyTestRuns(runCount = runCount)
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .allSatisfy { result ->
+                assertThat(result).isInstanceOfSatisfying(FlakyTest::class.java) { (message) ->
+                    assertThat(message).isEqualTo("Flip rate of 100% over $runCount run(s)")
+                }
+            }
+    }
+
+    @Test
+    fun `flaky test, non-representative sample`() {
+        flakyTestRuns(runCount = MINIMUM_RUN_COUNT - 1)
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `flaky test status should get cleared after flip rate drops below the threshold`() {
+        val flakyRunCount = 100 * MINIMUM_RUN_COUNT
+
+        flakyTestRuns(runCount = flakyRunCount)
+        assertThat(analyzer.analyze(testId))
+            .hasSize(1)
+            .allSatisfy { result ->
+                assertThat(result).isInstanceOfSatisfying(FlakyTest::class.java) { (message) ->
+                    assertThat(message).isEqualTo("Flip rate of 100% over $flakyRunCount run(s)")
+                }
+            }
+
+        repeat(times = flakyRunCount * 3) {
+            storage[testId] += TestRun(FAILED, null)
+        }
+        assertThat(analyzer.analyze(testId))
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `test regression`() {
+        val runCount = 100 * MINIMUM_RUN_COUNT
+
+        regression(runCount = runCount)
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .allSatisfy { result ->
+                assertThat(result).isInstanceOfSatisfying(Regression::class.java) { (message) ->
+                    assertThat(message).isEqualTo("1 regression over $runCount run(s)")
+                }
+            }
+    }
+
+    @Test
+    fun `test regression, non-representative sample`() {
+        regression(runCount = MINIMUM_RUN_COUNT - 1)
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    @Test
+    fun `test regression status should get cleared after one successful run`() {
+        val runCount = 100 * MINIMUM_RUN_COUNT
+
+        regression(runCount = runCount)
+        assertThat(analyzer.analyze(testId))
+            .hasSize(1)
+            .allSatisfy { result ->
+                assertThat(result).isInstanceOfSatisfying(Regression::class.java) { (message) ->
+                    assertThat(message).isEqualTo("1 regression over $runCount run(s)")
+                }
+            }
+
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(analyzer.analyze(testId))
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    /**
+     * Makes sure that a continuous failure which gets eventually fixed doesn't
+     * trigger a [Regression] marker.
+     */
+    @Test
+    fun `fixed failure`() {
+        val runCount = 100 * MINIMUM_RUN_COUNT
+
+        fixedFailure(runCount = runCount)
+
+        val results = analyzer.analyze(testId)
+        assertThat(results)
+            .hasSize(1)
+            .containsExactly(RegularTest)
+    }
+
+    /**
+     * Creates [runCount] flaky test runs with a flip rate of about 100%.
+     */
+    private fun flakyTestRuns(runCount: Int) {
+        repeat(times = runCount) { actionIndex ->
+            val status = when {
+                actionIndex % 2 == 0 -> PASSED
+                else -> FAILED
+            }
+            storage[testId] += TestRun(status, null)
+        }
+    }
+
+    /**
+     * Simulates a regression over [runCount] runs.
+     */
+    private fun regression(runCount: Int) {
+        require(runCount >= 2)
+
+        val successCount = runCount / 2
+        val failureCount = runCount - successCount
+
+        repeat(times = successCount) {
+            storage[testId] += TestRun(PASSED, null)
+        }
+        repeat(times = failureCount) {
+            storage[testId] += TestRun(FAILED, null)
+        }
+    }
+
+    /**
+     * Simulates a permanent failure which got eventually fixed.
+     * This is the opposite of [regression].
+     *
+     * @see regression
+     */
+    private fun fixedFailure(@Suppress("SameParameterValue") runCount: Int) {
+        val successCount = runCount / 2
+        val failureCount = runCount - successCount
+
+        repeat(times = successCount) {
+            storage[testId] += TestRun(FAILED, null)
+        }
+        repeat(times = failureCount) {
+            storage[testId] += TestRun(PASSED, null)
+        }
+    }
+
+    private operator fun TestRuns.plusAssign(testRun: TestRun) {
+        storage.updateExecutionStatistics(testId, testRun)
+    }
+
+    private companion object {
+        private val testId = TestId("")
+
+        /**
+         * Returns the detailed statistics about all test runs for the given [id],
+         * ignoring runs with an indeterminate test status.
+         *
+         * @param id the unique test identifier.
+         * @see TestStatisticsStorage.getExecutionStatistics
+         */
+        private operator fun TestStatisticsStorage.get(id: TestId): TestRuns =
+                getExecutionStatistics(id)
+    }
+}

--- a/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestIdGeneratorTest.kt
+++ b/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestIdGeneratorTest.kt
@@ -1,0 +1,240 @@
+package com.saveourtool.save.test.analysis.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * @see TestIdGenerator
+ */
+@TestMethodOrder(DisplayName::class)
+class TestIdGeneratorTest {
+    private lateinit var testIdGenerator: TestIdGenerator
+
+    @BeforeEach
+    fun beforeEach() {
+        testIdGenerator = TestIdGenerator()
+    }
+
+    @Test
+    fun `repeated invocations with the same arguments should result in the same TestId`() {
+        val organizationName = "organizationName"
+        val projectName = "projectName"
+        val testSuiteSourceName = "testSuiteSourceName"
+        val testSuiteVersion = "testSuiteVersion"
+        val testSuiteName = "testSuiteName"
+        val pluginName = "pluginName"
+        val filePath = "filePath"
+
+        val testId0 = TestId(
+            organizationName = organizationName,
+            projectName = projectName,
+            testSuiteSourceName = testSuiteSourceName,
+            testSuiteVersion = testSuiteVersion,
+            testSuiteName = testSuiteName,
+            pluginName = pluginName,
+            filePath = filePath
+        )
+
+        val testId1 = TestId(
+            organizationName = organizationName,
+            projectName = projectName,
+            testSuiteSourceName = testSuiteSourceName,
+            testSuiteVersion = testSuiteVersion,
+            testSuiteName = testSuiteName,
+            pluginName = pluginName,
+            filePath = filePath
+        )
+
+        assertThat(testId0)
+            .isNotSameAs(testId1)
+            .isEqualTo(testId1)
+    }
+
+    /**
+     * Prevents from a naïve id generation algorithm, when all string arguments
+     * might have been concatenated into a single string (or a byte buffer) and
+     * hashed.
+     */
+    @Test
+    fun `arguments should not be concatenated when hashing`() {
+        val testId0 = TestId(
+            projectName = "projectName",
+            testSuiteSourceName = "",
+        )
+
+        val testId1 = TestId(
+            projectName = "",
+            testSuiteSourceName = "projectName",
+        )
+
+        val testId2 = TestId(
+            projectName = "proje",
+            testSuiteSourceName = "ctName",
+        )
+
+        assertThat(testId0).isNotEqualTo(testId1)
+        assertThat(testId1).isNotEqualTo(testId2)
+        assertThat(testId2).isNotEqualTo(testId0)
+    }
+
+    @Test
+    fun `nulls should be different from an empty string when hashing`() {
+        val organizationName = "organizationName"
+        val projectName = "projectName"
+        val testSuiteVersion = "testSuiteVersion"
+        val testSuiteName = "testSuiteName"
+        val pluginName = "pluginName"
+        val filePath = "filePath"
+
+        val testId0 = TestId(
+            organizationName = organizationName,
+            projectName = projectName,
+            testSuiteSourceName = "",
+            testSuiteVersion = testSuiteVersion,
+            testSuiteName = testSuiteName,
+            pluginName = pluginName,
+            filePath = filePath
+        )
+
+        val testId1 = TestId(
+            organizationName = organizationName,
+            projectName = projectName,
+            testSuiteSourceName = null,
+            testSuiteVersion = testSuiteVersion,
+            testSuiteName = testSuiteName,
+            pluginName = pluginName,
+            filePath = filePath
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different organization names should result in different test ids`() {
+        val testId0 = TestId(
+            organizationName = "Organization A",
+        )
+
+        val testId1 = TestId(
+            organizationName = "Organization B",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different project names should result in different test ids`() {
+        val testId0 = TestId(
+            projectName = "Project A",
+        )
+
+        val testId1 = TestId(
+            projectName = "Project B",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different test suite source names should result in different test ids`() {
+        val testId0 = TestId(
+            testSuiteSourceName = "Test Suite Source A",
+        )
+
+        val testId1 = TestId(
+            testSuiteSourceName = "Test Suite Source B",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different test suite versions should result in different test ids`() {
+        val testId0 = TestId(
+            testSuiteVersion = "v1",
+        )
+
+        val testId1 = TestId(
+            testSuiteVersion = "v2",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different test suite names should result in different test ids`() {
+        val testId0 = TestId(
+            testSuiteName = "Test Suite Name A",
+        )
+
+        val testId1 = TestId(
+            testSuiteName = "Test Suite Name B",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different plugin names should result in different test ids`() {
+        val testId0 = TestId(
+            pluginName = "Warn",
+        )
+
+        val testId1 = TestId(
+            pluginName = "Fix",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Test
+    fun `different file paths should result in different test ids`() {
+        val testId0 = TestId(
+            filePath = "src/main/java",
+        )
+
+        val testId1 = TestId(
+            filePath = "src/main/kotlin",
+        )
+
+        assertThat(testId0)
+            .isNotEqualTo(testId1)
+    }
+
+    @Suppress(
+        "TestFunctionName",
+        "LongParameterList",
+        "FUNCTION_NAME_INCORRECT_CASE",
+        "TOO_MANY_PARAMETERS",
+    )
+    private fun TestId(
+        organizationName: String = "",
+        projectName: String = "",
+        testSuiteSourceName: String? = "",
+        testSuiteVersion: String? = "",
+        testSuiteName: String? = "",
+        pluginName: String = "",
+        filePath: String = "",
+    ): TestId =
+            with(testIdGenerator) {
+                testId(
+                    organizationName = organizationName,
+                    projectName = projectName,
+                    testSuiteSourceName = testSuiteSourceName,
+                    testSuiteVersion = testSuiteVersion,
+                    testSuiteName = testSuiteName,
+                    pluginName = pluginName,
+                    filePath = filePath,
+                )
+            }
+}

--- a/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestStatisticsStorageTest.kt
+++ b/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestStatisticsStorageTest.kt
@@ -1,0 +1,228 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.domain.TestResultStatus
+import com.saveourtool.save.domain.TestResultStatus.FAILED
+import com.saveourtool.save.domain.TestResultStatus.IGNORED
+import com.saveourtool.save.domain.TestResultStatus.PASSED
+import com.saveourtool.save.test.analysis.api.metrics.NoDataAvailable
+import com.saveourtool.save.test.analysis.api.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.internal.MemoryBacked
+import com.saveourtool.save.test.analysis.internal.MutableTestStatisticsStorage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.time.DurationUnit.MILLISECONDS
+import kotlin.time.DurationUnit.SECONDS
+import kotlin.time.toDuration
+
+/**
+ * @see TestStatisticsStorage
+ */
+class TestStatisticsStorageTest {
+    private lateinit var storage: MutableTestStatisticsStorage
+
+    @BeforeEach
+    fun beforeEach() {
+        storage = MemoryBacked(slidingWindowSize = Int.MAX_VALUE)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        storage.clear()
+    }
+
+    @Test
+    fun `execution statistics should get updated`() {
+        assertThat(storage.getExecutionStatistics(testId)).hasSize(0)
+
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(storage.getExecutionStatistics(testId)).hasSize(1)
+
+        storage[testId] += TestRun(FAILED, null)
+        assertThat(storage.getExecutionStatistics(testId)).hasSize(2)
+    }
+
+    @Test
+    fun `test metrics should get updated`() {
+        assertThat(storage.getTestMetrics(testId)).isEqualTo(NoDataAvailable)
+
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.failureRatePercentage).isZero
+            assertThat(metrics.flipRatePercentage).isZero
+
+            assertThat(metrics.failureRate).isZero
+            assertThat(metrics.flipRate).isZero
+
+            assertThat(metrics.runCount).isEqualTo(1)
+            assertThat(metrics.successCount).isEqualTo(1)
+            assertThat(metrics.failureCount).isEqualTo(0)
+            assertThat(metrics.ignoredCount).isZero
+
+            assertThat(metrics.averageDurationOrNull).isNull()
+            assertThat(metrics.medianDurationOrNull).isNull()
+        }
+
+        storage[testId] += TestRun(FAILED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.failureRatePercentage).isEqualTo(50)
+            assertThat(metrics.flipRatePercentage).isEqualTo(100)
+
+            assertThat(metrics.failureRate).isBetween(0.49, 0.51)
+            assertThat(metrics.flipRate).isEqualTo(1.0)
+
+            assertThat(metrics.runCount).isEqualTo(2)
+            assertThat(metrics.successCount).isEqualTo(1)
+            assertThat(metrics.failureCount).isEqualTo(1)
+            assertThat(metrics.ignoredCount).isZero
+
+            assertThat(metrics.averageDurationOrNull).isNull()
+            assertThat(metrics.medianDurationOrNull).isNull()
+        }
+    }
+
+    @Test
+    fun `flip count should be calculated correctly, case 1`() {
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.flipCount).isZero()
+        }
+
+        storage[testId] += TestRun(FAILED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.flipCount).isEqualTo(1)
+        }
+
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.flipCount).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `flip count should be calculated correctly, case 2`() {
+        storage[testId] += TestRun(FAILED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.flipCount).isZero()
+        }
+
+        storage[testId] += TestRun(PASSED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.flipCount).isEqualTo(1)
+        }
+
+        storage[testId] += TestRun(FAILED, null)
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.flipCount).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `average duration should be calculated correctly`() {
+        storage[testId] += TestRun(PASSED, 1L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 2L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 3L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 4L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 5L.toDuration(SECONDS))
+
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.averageDurationOrNull)
+                .isNotNull
+                .isEqualTo(3L.toDuration(SECONDS))
+        }
+    }
+
+    @Test
+    @Suppress("LONG_NUMERICAL_VALUES_SEPARATED")
+    fun `median duration should be calculated correctly`() {
+        storage[testId] += TestRun(PASSED, 1L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 2L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 3L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 4L.toDuration(SECONDS))
+        storage[testId] += TestRun(PASSED, 100500L.toDuration(SECONDS))
+
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.medianDurationOrNull)
+                .isNotNull
+                .isEqualTo(3L.toDuration(SECONDS))
+        }
+
+        storage[testId] += TestRun(PASSED, 100500L.toDuration(SECONDS))
+
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.medianDurationOrNull)
+                .isNotNull
+                .isEqualTo(3_500L.toDuration(MILLISECONDS))
+        }
+    }
+
+    @Test
+    fun `indeterminate test runs should be ignored by default`() {
+        enumValues<TestResultStatus>().asSequence()
+            .filterNot { it == PASSED }
+            .filterNot { it == FAILED }
+            .filterNot { it == IGNORED }
+            .forEach { status ->
+                storage[testId] += TestRun(status, null)
+            }
+
+        assertThat(storage.getTestMetrics(testId))
+            .isInstanceOf(NoDataAvailable::class.java)
+        assertThat(storage.getExecutionStatistics(testId))
+            .isEmpty()
+        assertThat(storage.getExecutionStatistics(testId, ignoreIndeterminate = false))
+            .isNotEmpty
+    }
+
+    @Test
+    fun `eviction should occur if sliding window size is limited`() {
+        val slidingWindowSize = 1000
+        storage = MemoryBacked(slidingWindowSize = slidingWindowSize)
+
+        repeat(times = slidingWindowSize) {
+            storage[testId] += TestRun(FAILED, null)
+        }
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.runCount).isEqualTo(slidingWindowSize)
+            assertThat(metrics.failureRate).isEqualTo(1.0)
+            assertThat(metrics.flipCount).isZero()
+        }
+
+        repeat(times = slidingWindowSize / 2) {
+            storage[testId] += TestRun(PASSED, null)
+        }
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.runCount).isEqualTo(slidingWindowSize)
+            assertThat(metrics.failureRate).isBetween(0.49, 0.51)
+            assertThat(metrics.flipCount).isEqualTo(1)
+        }
+
+        repeat(times = slidingWindowSize / 2) {
+            storage[testId] += TestRun(PASSED, null)
+        }
+        assertThat(storage.getTestMetrics(testId)).isInstanceOfSatisfying(RegularTestMetrics::class.java) { metrics ->
+            assertThat(metrics.runCount).isEqualTo(slidingWindowSize)
+            assertThat(metrics.failureRate).isEqualTo(0.0)
+            assertThat(metrics.flipCount).isZero()
+        }
+    }
+
+    private operator fun TestRuns.plusAssign(testRun: TestRun) {
+        storage.updateExecutionStatistics(testId, testRun)
+    }
+
+    private companion object {
+        private val testId = TestId("")
+
+        /**
+         * Returns the detailed statistics about all test runs for the given [id],
+         * ignoring runs with an indeterminate test status.
+         *
+         * @param id the unique test identifier.
+         * @see TestStatisticsStorage.getExecutionStatistics
+         */
+        private operator fun TestStatisticsStorage.get(id: TestId): TestRuns =
+                getExecutionStatistics(id)
+    }
+}

--- a/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestStatusProviderTest.kt
+++ b/test-analysis-core/src/test/kotlin/com/saveourtool/save/test/analysis/api/TestStatusProviderTest.kt
@@ -1,0 +1,25 @@
+package com.saveourtool.save.test.analysis.api
+
+import com.saveourtool.save.domain.TestResultStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * @see TestStatusProvider
+ */
+class TestStatusProviderTest {
+    @Test
+    @Suppress("WRONG_NEWLINES")
+    fun `test statuses should be mutually exclusive`() {
+        with(TestStatusProvider()) {
+            enumValues<TestResultStatus>().forEach { status ->
+                assertThat(
+                    status.isSuccess()
+                            xor status.isFailure()
+                            xor status.isIgnored()
+                            xor status.isIndeterminate()
+                ).describedAs(status.name).isTrue()
+            }
+        }
+    }
+}


### PR DESCRIPTION
# What's done:

 * Test run statistics can be collected, using a sliding window of
   a configurable size.
 * Unique test ids are generated using SHA-2.
 * Scalar test metrics can now be collected:
    * successful & failed run count,
    * flip rate,
    * failure rate,
    * average & median test duration.
 * Flaky test detection based on a flip rate (30% threshold).
 * Regression detection.
 * The list of individual test runs within the given batch exposed via the REST API.
 * See #659.