### PR TITLE
Use the `closeAndReleaseSonatypeStagingRepository` task when releasing

### DIFF
--- a/.github/workflows/save-api-release.yml
+++ b/.github/workflows/save-api-release.yml
@@ -39,7 +39,7 @@ jobs:
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
             publishToSonatype
-            closeSonatypeStagingRepository
+            closeAndReleaseSonatypeStagingRepository
       - name: Status git after
         if: ${{ always() }}
         run: git status


### PR DESCRIPTION
 * Requires no manual actions with https://oss.sonatype.org
 * See https://github.com/gradle-nexus/publish-plugin for more details.