### PR TITLE
Update `Execution.STATUS` on deleting `TestSuite`

### DIFF
--- a/db/v-2/events/event_scheduler.xml
+++ b/db/v-2/events/event_scheduler.xml
@@ -20,4 +20,19 @@
         </sql>
     </changeSet>
 
+    <changeSet id="event-delete-test-1" author="nulls" context="prod">
+        <sql>
+            DROP EVENT IF EXISTS delete_test;
+        </sql>
+    </changeSet>
+
+    <changeSet id="event-delete-test-2" author="nulls" context="prod">
+        <sql>
+            CREATE EVENT delete_test
+            ON SCHEDULE EVERY 1 DAY
+            STARTS TIMESTAMP(CURRENT_DATE + INTERVAL 1 HOUR)
+            DO DELETE FROM TEST WHERE DATEDIFF(NOW(), DATE_ADDED) >= 30;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkExecutionTestSuiteService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkExecutionTestSuiteService.kt
@@ -43,6 +43,13 @@ class LnkExecutionTestSuiteService(
         }
 
     /**
+     * @param executionId ID of manageable execution
+     */
+    fun deleteByExecution(executionId: Long) {
+        lnkExecutionTestSuiteRepository.deleteAll(lnkExecutionTestSuiteRepository.findByExecutionId(executionId))
+    }
+
+    /**
      * @param [lnkExecutionTestSuite] link execution to testSuites
      */
     fun save(lnkExecutionTestSuite: LnkExecutionTestSuite): LnkExecutionTestSuite = lnkExecutionTestSuiteRepository.save(lnkExecutionTestSuite)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -210,7 +210,6 @@ class TestSuitesService(
                 testRepository.deleteById(testId)
             }
             log.info("Delete test suite ${testSuite.name} with id ${testSuite.requiredId()}")
-
             testSuiteRepository.deleteById(testSuite.requiredId())
         }
 

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
@@ -80,6 +80,7 @@ import java.util.concurrent.TimeUnit
     MockBean(OriginalLoginRepository::class),
     MockBean(LnkContestProjectService::class),
     MockBean(LnkOrganizationTestSuiteService::class),
+    MockBean(LnkExecutionTestSuiteService::class),
 )
 @AutoConfigureWebTestClient
 @Suppress("UnsafeCallOnNullableType")


### PR DESCRIPTION
Due to cascade deleting, executionIds is empty on deleting `TestSuite` .

### What's done:
* Moved calculating executionId on early state

It closes #1579 