### PR TITLE
[DEMO] hotfix for DIKTAT_CONFIG_NAME

### DIFF
--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/Constants.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/Constants.kt
@@ -4,7 +4,7 @@
 
 package com.saveourtool.save.demo.utils
 
-const val KOTLIN_TEST_NAME = "Test.kt"
+const val KOTLIN_TEST_NAME = "Main.kt"
 const val DIKTAT_CONFIG_NAME = "diktat-analysis.yml"
 const val REPORT_FILE_NAME = "report"
 const val LOG_FILE_NAME = "logs"

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/Constants.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/Constants.kt
@@ -5,6 +5,6 @@
 package com.saveourtool.save.demo.utils
 
 const val KOTLIN_TEST_NAME = "Test.kt"
-const val DIKTAT_CONFIG_NAME = "diktat-analysis.yaml"
+const val DIKTAT_CONFIG_NAME = "diktat-analysis.yml"
 const val REPORT_FILE_NAME = "report"
 const val LOG_FILE_NAME = "logs"


### PR DESCRIPTION
### What's done:
 * Renamed `diktat-analysis.yaml` to `diktat-analysis.yml`