### PR TITLE
Fix typo in `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ liquibaseTaskPrefix=liquibase
 # The following properties control the environment for building Docker images. To point tasks to Minikube's Docker Daemon,
 # run `docker port minikube` and look for mapping of 2376; run `minikube docker-env` and look for `$Env:DOCKER_CERT_PATH`
 #build.docker.host=https://127.0.0.1:49156
-#build.docker.tsl-verify=true
+#build.docker.tls-verify=true
 #build.docker.cert-path=C:\\Users\\<User>\\.minikube\\certs
 
 # gradle performance


### PR DESCRIPTION
Turns out, `400 Bad Request` from Docker API I was getting locally were caused by querying via HTTP, even though HTTPS should've been enabled. But property value wasn't being read and `http` is being used by default.