### PR TITLE
`SAVE on GitHub` button color in top bar

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/topbar/TopBarLinks.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/topbar/TopBarLinks.kt
@@ -107,10 +107,13 @@ private fun topBarLinks() = FC<TopBarLinksProps> { props ->
                 className = ClassName("nav-item")
                 if (elem.isExternalLink) {
                     a {
-                        className = ClassName("nav-link d-flex align-items-center me-2 active")
+                        className = ClassName("nav-link d-flex align-items-center text-light me-2 active")
                         style = jso { width = elem.width }
-                        href = elem.hrefAnchor
+//                        href = elem.hrefAnchor
                         +elem.text
+                        onClick = {
+                            window.open(elem.hrefAnchor)
+                        }
                     }
                 } else {
                     Link {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/topbar/TopBarLinks.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/topbar/TopBarLinks.kt
@@ -109,11 +109,8 @@ private fun topBarLinks() = FC<TopBarLinksProps> { props ->
                     a {
                         className = ClassName("nav-link d-flex align-items-center text-light me-2 active")
                         style = jso { width = elem.width }
-//                        href = elem.hrefAnchor
+                        href = elem.hrefAnchor
                         +elem.text
-                        onClick = {
-                            window.open(elem.hrefAnchor)
-                        }
                     }
                 } else {
                     Link {


### PR DESCRIPTION
### What's done:
* Fixed `SAVE on GitHub` button color to be text-light (as is for all the other buttons in top bar)

### Was:
![screenshot](https://user-images.githubusercontent.com/35039155/207819642-7f7db5eb-e43f-4f23-9f49-8476f7db70ae.png)

### How it looks now:
![screenshot](https://user-images.githubusercontent.com/35039155/207819805-f1746c79-3b7b-4a0b-ac48-20cc33d8ef55.png)
