### PR TITLE
Refactored `OrchestratorAgentService`

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/internal/AgentsController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/internal/AgentsController.kt
@@ -116,42 +116,38 @@ class AgentsController(
 
     /**
      * @param executionId ID of [Execution]
-     * @param agents list of [AgentDto]s to save into the DB
-     * @return a list of IDs, assigned to the agents
+     * @param agent [AgentDto] to save into the DB
+     * @return an ID, assigned to the agent
      */
     @PostMapping("/agents/insert")
-    fun addAgents(
+    fun addAgent(
         @RequestParam executionId: Long,
-        @RequestBody agents: List<AgentDto>,
-    ): List<Long> {
-        log.debug("Saving agents $agents")
-        return agents
-            .map { it.toEntity() }
-            .let { agentService.saveAll(executionId, it) }
-            .map { it.requiredId() }
+        @RequestBody agent: AgentDto,
+    ): Long {
+        log.debug { "Saving agent $agent" }
+        return agentService.save(executionId, agent.toEntity())
+            .requiredId()
     }
 
     /**
-     * @param agentStates list of [AgentStatus]es to update in the DB
+     * @param agentStatus [AgentStatus] to update in the DB
      * @throws ResponseStatusException code 409 if agent has already its final state that shouldn't be updated
      */
-    @PostMapping("/updateAgentStatusesWithDto")
+    @PostMapping("/updateAgentStatus")
     @Transactional
-    fun updateAgentStatusesWithDto(@RequestBody agentStates: List<AgentStatusDto>) {
-        agentStates.forEach { agentState ->
-            val agentStatus = agentStatusRepository.findTopByAgentContainerIdOrderByEndTimeDescIdDesc(agentState.containerId)
-            when (val latestState = agentStatus?.state) {
-                AgentState.TERMINATED ->
-                    throw ResponseStatusException(HttpStatus.CONFLICT, "Agent ${agentState.containerId} has state $latestState and shouldn't be updated")
-                agentState.state -> {
-                    // updating time
-                    agentStatus.endTime = agentState.time.toJavaLocalDateTime()
-                    agentStatusRepository.save(agentStatus)
-                }
-                else -> {
-                    // insert new agent status
-                    agentStatusRepository.save(agentState.toEntity { getAgentByContainerId(it) })
-                }
+    fun updateAgentStatus(@RequestBody agentStatus: AgentStatusDto) {
+        val latestAgentStatus = agentStatusRepository.findTopByAgentContainerIdOrderByEndTimeDescIdDesc(agentStatus.containerId)
+        when (val latestState = latestAgentStatus?.state) {
+            AgentState.TERMINATED ->
+                throw ResponseStatusException(HttpStatus.CONFLICT, "Agent ${agentStatus.containerId} has state $latestState and shouldn't be updated")
+            agentStatus.state -> {
+                // updating time
+                latestAgentStatus.endTime = agentStatus.time.toJavaLocalDateTime()
+                agentStatusRepository.save(latestAgentStatus)
+            }
+            else -> {
+                // insert new agent status
+                agentStatusRepository.save(agentStatus.toEntity { getAgentByContainerId(it) })
             }
         }
     }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/AgentService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/AgentService.kt
@@ -106,6 +106,18 @@ class AgentService(
 
     /**
      * @param executionId ID of [Execution]
+     * @param agent [Agent] to assign to provided [Execution]
+     * @return saved [Agent]
+     */
+    internal fun save(executionId: Long, agent: Agent): Agent {
+        val execution = executionService.getExecution(executionId)
+        val savedAgent = agentRepository.save(agent)
+        lnkExecutionAgentRepository.save(LnkExecutionAgent(execution, savedAgent))
+        return savedAgent
+    }
+
+    /**
+     * @param executionId ID of [Execution]
      * @param agents list of [Agent] to assign to provided [Execution]
      * @return list of saved [Agent]
      */

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/AgentsControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/AgentsControllerTest.kt
@@ -155,7 +155,7 @@ class AgentsControllerTest {
             .uri("/internal/updateAgentStatus")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
-            .bodyValue(listOf(body))
+            .bodyValue(body)
             .exchange()
             .expectStatus()
             .isOk

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/AgentsControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/AgentsControllerTest.kt
@@ -63,13 +63,11 @@ class AgentsControllerTest {
     fun `should save agent statuses`() {
         webTestClient
             .method(HttpMethod.POST)
-            .uri("/internal/updateAgentStatusesWithDto")
+            .uri("/internal/updateAgentStatus")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .bodyValue(
-                listOf(
-                    AgentStatusDto(AgentState.IDLE, "container-1")
-                )
+                AgentStatusDto(AgentState.IDLE, "container-1")
             )
             .exchange()
             .expectStatus()
@@ -87,13 +85,11 @@ class AgentsControllerTest {
 
         webTestClient
             .method(HttpMethod.POST)
-            .uri("/internal/updateAgentStatusesWithDto")
+            .uri("/internal/updateAgentStatus")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .bodyValue(
-                listOf(
-                    AgentStatusDto(AgentState.IDLE, "container-2", LocalDateTime(2020, Month.MAY, 10, 16, 30, 20))
-                )
+                AgentStatusDto(AgentState.IDLE, "container-2", LocalDateTime(2020, Month.MAY, 10, 16, 30, 20))
             )
             .exchange()
             .expectStatus()
@@ -156,7 +152,7 @@ class AgentsControllerTest {
     private fun updateAgentStatuses(body: AgentStatusDto) {
         webTestClient
             .method(HttpMethod.POST)
-            .uri("/internal/updateAgentStatusesWithDto")
+            .uri("/internal/updateAgentStatus")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .bodyValue(listOf(body))

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
@@ -17,6 +17,7 @@ import reactor.core.publisher.Mono
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.onErrorResume
+import reactor.kotlin.core.publisher.toFlux
 import java.time.Duration
 
 /**
@@ -66,13 +67,17 @@ class AgentService(
     fun saveAgentsWithInitialStatuses(
         executionId: Long,
         agents: List<AgentDto>,
-    ): Mono<EmptyResponse> = orchestratorAgentService
-        .addAgents(executionId, agents)
-        .flatMap {
-            orchestratorAgentService.updateAgentStatusesWithDto(agents.map { agent ->
-                AgentStatusDto(STARTING, agent.containerId)
-            })
+    ): Mono<EmptyResponse> = agents.toFlux()
+        .flatMap { agent ->
+            orchestratorAgentService
+                .addAgent(executionId, agent)
+                .flatMap {
+                    orchestratorAgentService.updateAgentStatus(
+                        AgentStatusDto(STARTING, agent.containerId)
+                    )
+                }
         }
+        .last()
 
     /**
      * @param agentState [AgentStatus] to update in the DB
@@ -80,7 +85,7 @@ class AgentService(
      */
     fun updateAgentStatusesWithDto(agentState: AgentStatusDto): Mono<EmptyResponse> =
             orchestratorAgentService
-                .updateAgentStatusesWithDto(listOf(agentState))
+                .updateAgentStatus(agentState)
                 .onErrorResume(WebClientException::class) {
                     log.warn("Couldn't update agent statuses because of backend failure", it)
                     Mono.empty()

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/OrchestratorAgentService.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/OrchestratorAgentService.kt
@@ -8,10 +8,8 @@ import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.test.TestBatch
 import com.saveourtool.save.utils.EmptyResponse
 
-import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 
-typealias IdList = List<Long>
 typealias AgentStatusList = List<AgentStatusDto>
 typealias TestExecutionList = List<TestExecutionDto>
 
@@ -36,20 +34,19 @@ interface OrchestratorAgentService {
     fun getNextRunConfig(containerId: String): Mono<AgentRunConfig>
 
     /**
-     * Save new agents to the DB and insert their statuses. This logic is performed in two consecutive requests.
+     * Save new agents to the DB and insert their statuses
      *
      * @param executionId ID of an execution
-     * @param agents list of [AgentDto]s to save in the DB
-     * @return Mono with IDs of saved [Agent]s
-     * @throws WebClientResponseException if any of the requests fails
-     */
-    fun addAgents(executionId: Long, agents: List<AgentDto>): Mono<IdList>
-
-    /**
-     * @param agentStates list of [AgentStatusDto] to update/insert in the DB
+     * @param agent [AgentDto] to save in the DB
      * @return a Mono without body
      */
-    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<EmptyResponse>
+    fun addAgent(executionId: Long, agent: AgentDto): Mono<EmptyResponse>
+
+    /**
+     * @param agentStatus [AgentStatusDto] to update/insert in the DB
+     * @return a Mono without body
+     */
+    fun updateAgentStatus(agentStatus: AgentStatusDto): Mono<EmptyResponse>
 
     /**
      * Get List of [TestExecutionDto] for agent [containerId] have status READY_FOR_TESTING

--- a/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/agents/AgentsControllerTest.kt
+++ b/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/agents/AgentsControllerTest.kt
@@ -68,9 +68,9 @@ class AgentsControllerTest {
 
         whenever(containerService.startContainersAndUpdateExecution(any(), anyList()))
             .thenReturn(Flux.just(1L, 2L, 3L))
-        whenever(orchestratorAgentService.addAgents(anyLong(), anyList()))
-            .thenReturn(listOf<Long>(1, 2).toMono())
-        whenever(orchestratorAgentService.updateAgentStatusesWithDto(anyList()))
+        whenever(orchestratorAgentService.addAgent(anyLong(), any()))
+            .thenReturn(ResponseEntity.ok().build<Void>().toMono())
+        whenever(orchestratorAgentService.updateAgentStatus(any()))
             .thenReturn(ResponseEntity.ok().build<Void>().toMono())
         // /updateExecutionByDto is not mocked, because it's performed by DockerService, and it's mocked in these tests
 

--- a/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -79,7 +79,7 @@ class HeartbeatControllerTest {
     fun checkAcceptingHeartbeat() {
         val heartBeatBusy = Heartbeat("test".toAgentInfo(), AgentState.BUSY, ExecutionProgress(0, -1L), Clock.System.now() + 30.seconds)
 
-        whenever(orchestratorAgentService.updateAgentStatusesWithDto(any()))
+        whenever(orchestratorAgentService.updateAgentStatus(any()))
             .thenReturn(ResponseEntity.ok().build<Void>().toMono())
         webClient.post()
             .uri("/heartbeat")
@@ -89,7 +89,7 @@ class HeartbeatControllerTest {
             .exchange()
             .expectStatus()
             .isOk
-        verify(orchestratorAgentService).updateAgentStatusesWithDto(any())
+        verify(orchestratorAgentService).updateAgentStatus(any())
     }
 
     @Test
@@ -380,7 +380,7 @@ class HeartbeatControllerTest {
         }
 
         repeat(mockUpdateAgentStatusesCount) {
-            whenever(orchestratorAgentService.updateAgentStatusesWithDto(any()))
+            whenever(orchestratorAgentService.updateAgentStatus(any()))
                 .thenReturn(ResponseEntity.ok().build<Void>().toMono())
         }
         if (mockAgentStatusesForSameExecution) {
@@ -418,7 +418,7 @@ class HeartbeatControllerTest {
         testBatchNullable?.let {
             verify(orchestratorAgentService).getNextRunConfig(any())
         }
-        verify(orchestratorAgentService, times(mockUpdateAgentStatusesCount)).updateAgentStatusesWithDto(any())
+        verify(orchestratorAgentService, times(mockUpdateAgentStatusesCount)).updateAgentStatus(any())
         if (mockAgentStatusesForSameExecution) {
             verify(orchestratorAgentService).getAgentsStatusesForSameExecution(any())
         }

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/BackendOrchestratorAgentService.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/BackendOrchestratorAgentService.kt
@@ -52,12 +52,12 @@ class BackendOrchestratorAgentService(
         .toBodilessEntity()
 
     override fun updateAgentStatus(agentStatus: AgentStatusDto): Mono<EmptyResponse> =
-        webClientBackend
-            .post()
-            .uri("/updateAgentStatus")
-            .bodyValue(listOf(agentStatus))
-            .retrieve()
-            .toBodilessEntity()
+            webClientBackend
+                .post()
+                .uri("/updateAgentStatus")
+                .bodyValue(listOf(agentStatus))
+                .retrieve()
+                .toBodilessEntity()
 
     override fun getReadyForTestingTestExecutions(containerId: String): Mono<TestExecutionList> = webClientBackend.get()
         .uri("/test-executions/get-by-container-id?containerId=$containerId&status=${TestResultStatus.READY_FOR_TESTING}")

--- a/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/BackendOrchestratorAgentService.kt
+++ b/save-orchestrator/src/main/kotlin/com/saveourtool/save/orchestrator/service/BackendOrchestratorAgentService.kt
@@ -44,20 +44,20 @@ class BackendOrchestratorAgentService(
         .retrieve()
         .bodyToMono()
 
-    override fun addAgents(executionId: Long, agents: List<AgentDto>): Mono<IdList> = webClientBackend
+    override fun addAgent(executionId: Long, agent: AgentDto): Mono<EmptyResponse> = webClientBackend
         .post()
         .uri("/agents/insert?executionId=$executionId")
-        .bodyValue(agents)
+        .bodyValue(agent)
         .retrieve()
-        .bodyToMono()
+        .toBodilessEntity()
 
-    override fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<EmptyResponse> =
-            webClientBackend
-                .post()
-                .uri("/updateAgentStatusesWithDto")
-                .bodyValue(agentStates)
-                .retrieve()
-                .toBodilessEntity()
+    override fun updateAgentStatus(agentStatus: AgentStatusDto): Mono<EmptyResponse> =
+        webClientBackend
+            .post()
+            .uri("/updateAgentStatus")
+            .bodyValue(listOf(agentStatus))
+            .retrieve()
+            .toBodilessEntity()
 
     override fun getReadyForTestingTestExecutions(containerId: String): Mono<TestExecutionList> = webClientBackend.get()
         .uri("/test-executions/get-by-container-id?containerId=$containerId&status=${TestResultStatus.READY_FOR_TESTING}")

--- a/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/service/SandboxOrchestratorAgentService.kt
+++ b/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/service/SandboxOrchestratorAgentService.kt
@@ -10,7 +10,6 @@ import com.saveourtool.save.entities.AgentStatusesForExecution
 import com.saveourtool.save.entities.toEntity
 import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.orchestrator.service.AgentStatusList
-import com.saveourtool.save.orchestrator.service.IdList
 import com.saveourtool.save.orchestrator.service.OrchestratorAgentService
 import com.saveourtool.save.orchestrator.service.TestExecutionList
 import com.saveourtool.save.request.RunExecutionRequest
@@ -88,28 +87,18 @@ class SandboxOrchestratorAgentService(
             )
         }
 
-    override fun addAgents(executionId: Long, agents: List<AgentDto>): Mono<IdList> = blockingToMono {
-        val execution = sandboxExecutionRepository.findByIdOrNull(executionId)
-            .orNotFound {
-                "Not found execution by id $executionId"
-            }
-        agents
-            .map { it.toEntity() }
-            .let { sandboxAgentRepository.saveAll(it) }
-            .map {
-                SandboxLnkExecutionAgent(
-                    execution = execution,
-                    agent = it
-                )
-            }
-            .let { sandboxLnkExecutionAgentRepository.saveAll(it) }
-            .map { it.agent.requiredId() }
-    }
+    override fun addAgent(executionId: Long, agent: AgentDto): Mono<EmptyResponse> = getExecutionAsMono(executionId)
+        .map { execution ->
+            val savedAgent = sandboxAgentRepository.save(agent.toEntity())
+            sandboxLnkExecutionAgentRepository.save(SandboxLnkExecutionAgent(
+                execution = execution,
+                agent = savedAgent
+            ))
+            ResponseEntity.ok().build()
+        }
 
-    override fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<EmptyResponse> = blockingToMono {
-        agentStates
-            .map { it.toEntity(this::getAgent) }
-            .let { sandboxAgentStatusRepository.saveAll(it) }
+    override fun updateAgentStatus(agentStatus: AgentStatusDto): Mono<EmptyResponse> = blockingToMono {
+        sandboxAgentStatusRepository.save(agentStatus.toEntity(this::getAgent))
             .let {
                 ResponseEntity.ok().build()
             }


### PR DESCRIPTION
It's part of future task when `Agent` will be created by receiving a first heartbeat and will be created one by one

### What's done:
- refactored `/addAgents` to `/addAgent`
- refactored `/updateAgentStatusesWithDto` to `/updateAgentStatus`