### PR TITLE
Renaming in ContainerService

### DIFF
--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/AgentsController.kt
@@ -78,7 +78,7 @@ class AgentsController(
                     )
                         .doOnError(WebClientResponseException::class) { exception ->
                             log.error("Unable to save agents, backend returned code ${exception.statusCode}", exception)
-                            containerService.cleanup(request.executionId)
+                            containerService.cleanupAllByExecution(request.executionId)
                         }
                         .thenReturn(containerIds)
                 }
@@ -107,7 +107,7 @@ class AgentsController(
      */
     @PostMapping("/cleanup")
     fun cleanup(@RequestParam executionId: Long): Mono<EmptyResponse> = Mono.fromCallable {
-        containerService.cleanup(executionId)
+        containerService.cleanupAllByExecution(executionId)
     }
         .flatMap {
             Mono.just(ResponseEntity.ok().build())

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
@@ -19,11 +19,10 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
-import reactor.kotlin.core.util.function.component1
-import reactor.kotlin.core.util.function.component2
 
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
+import reactor.kotlin.core.publisher.switchIfEmpty
 
 /**
  * Controller for heartbeat
@@ -62,7 +61,7 @@ class HeartbeatController(private val agentService: AgentService,
             .toMono()
             .flatMap {
                 // store new state into DB
-                agentService.updateAgentStatusesWithDto(
+                agentService.updateAgentStatus(
                     AgentStatusDto(heartbeat.state, heartbeat.agentInfo.containerId)
                 )
             }
@@ -97,31 +96,25 @@ class HeartbeatController(private val agentService: AgentService,
 
     private fun handleVacantAgent(containerId: String): Mono<HeartbeatResponse> =
             agentService.getNextRunConfig(containerId)
-                .asyncEffectIf({ this is NewJobResponse }) {
-                    agentService.updateAgentStatusesWithDto(AgentStatusDto(BUSY, containerId))
+                .asyncEffect {
+                    agentService.updateAgentStatus(AgentStatusDto(BUSY, containerId))
                 }
-                .zipWhen {
+                .switchIfEmpty {
                     // Check if all agents have completed their jobs; if true - we can terminate agent [containerId].
                     // fixme: if orchestrator can shut down some agents while others are still doing work, this call won't be needed
                     // but maybe we'll want to keep running agents in case we need to re-run some tests on other agents e.g. in case of a crash.
-                    if (it is WaitResponse) {
-                        agentService.areAllAgentsIdleOrFinished(containerId)
-                    } else {
-                        Mono.just(false)
-                    }
-                }
-                .flatMap { (response, shouldStop) ->
-                    if (shouldStop) {
-                        agentService.updateAgentStatusesWithDto(AgentStatusDto(TERMINATED, containerId))
-                            .thenReturn<HeartbeatResponse>(TerminateResponse)
-                            .defaultIfEmpty(ContinueResponse)
-                            .doOnSuccess {
-                                logger.info("Agent id=$containerId will receive ${TerminateResponse::class.simpleName} and should shutdown gracefully")
-                                ensureGracefulShutdown(containerId)
-                            }
-                    } else {
-                        Mono.just(response)
-                    }
+                    agentService.areAllAgentsIdleOrFinished(containerId)
+                        .filter { it }
+                        .flatMap {
+                            agentService.updateAgentStatus(AgentStatusDto(TERMINATED, containerId))
+                                .thenReturn<HeartbeatResponse>(TerminateResponse)
+                                .defaultIfEmpty(ContinueResponse)
+                                .doOnSuccess {
+                                    logger.info("Agent id=$containerId will receive ${TerminateResponse::class.simpleName} and should shutdown gracefully")
+                                    ensureGracefulShutdown(containerId)
+                                }
+                        }
+                        .defaultIfEmpty(WaitResponse)
                 }
 
     private fun handleFinishedAgent(containerId: String, isSavingSuccessful: Boolean): Mono<HeartbeatResponse> = if (isSavingSuccessful) {
@@ -146,7 +139,7 @@ class HeartbeatController(private val agentService: AgentService,
             interval = shutdownTimeoutSeconds / numChecks,
             numberOfChecks = numChecks.toLong(),
         ) {
-            containerService.isStoppedByContainerId(containerId)
+            containerService.isStopped(containerId)
         }
             .doOnNext { successfullyStopped ->
                 if (!successfullyStopped) {

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/controller/HeartbeatController.kt
@@ -18,11 +18,11 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
 import reactor.kotlin.core.publisher.toMono
 
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
-import reactor.kotlin.core.publisher.switchIfEmpty
 
 /**
  * Controller for heartbeat

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/AgentService.kt
@@ -48,13 +48,11 @@ class AgentService(
      * Sets new tests ids
      *
      * @param containerId
-     * @return [Mono] of [NewJobResponse] or [WaitResponse]
+     * @return [Mono] of [NewJobResponse] if there is some job to do or [Mono.empty]
      */
     internal fun getNextRunConfig(containerId: String): Mono<HeartbeatResponse> =
             orchestratorAgentService.getNextRunConfig(containerId)
                 .map { NewJobResponse(it) }
-                .cast(HeartbeatResponse::class.java)
-                .defaultIfEmpty(WaitResponse)
 
     /**
      * Save new agents to the DB and insert their statuses. This logic is performed in two consecutive requests.
@@ -80,12 +78,12 @@ class AgentService(
         .last()
 
     /**
-     * @param agentState [AgentStatus] to update in the DB
+     * @param agentStatus [AgentStatus] to update in the DB
      * @return a Mono containing bodiless entity of response or an empty Mono if request has failed
      */
-    fun updateAgentStatusesWithDto(agentState: AgentStatusDto): Mono<EmptyResponse> =
+    fun updateAgentStatus(agentStatus: AgentStatusDto): Mono<EmptyResponse> =
             orchestratorAgentService
-                .updateAgentStatus(agentState)
+                .updateAgentStatus(agentStatus)
                 .onErrorResume(WebClientException::class) {
                     log.warn("Couldn't update agent statuses because of backend failure", it)
                     Mono.empty()

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/ContainerService.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/ContainerService.kt
@@ -116,12 +116,12 @@ class ContainerService(
      * @param containerId id of an container
      * @return true if agent is stopped
      */
-    fun isStoppedByContainerId(containerId: String): Boolean = containerRunner.isStopped(containerId)
+    fun isStopped(containerId: String): Boolean = containerRunner.isStopped(containerId)
 
     /**
      * @param executionId ID of execution
      */
-    fun cleanup(executionId: Long) {
+    fun cleanupAllByExecution(executionId: Long) {
         containerRunner.cleanupAllByExecution(executionId)
     }
 

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/service/HeartBeatInspector.kt
@@ -79,10 +79,10 @@ class HeartBeatInspector(
         }
 
         crashedAgents.removeIf { containerId ->
-            containerService.isStoppedByContainerId(containerId)
+            containerService.isStopped(containerId)
         }
         agentsLatestHeartBeatsMap.filterKeys { containerId ->
-            containerService.isStoppedByContainerId(containerId)
+            containerService.isStopped(containerId)
         }.forEach { (containerId, _) ->
             logger.debug("Agent $containerId is already stopped, will stop watching it")
             agentsLatestHeartBeatsMap.remove(containerId)

--- a/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/agents/AgentsControllerTest.kt
+++ b/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/agents/AgentsControllerTest.kt
@@ -104,6 +104,6 @@ class AgentsControllerTest {
             .isOk
 
         Thread.sleep(2_500)
-        verify(containerService, times(1)).cleanup(anyLong())
+        verify(containerService, times(1)).cleanupAllByExecution(anyLong())
     }
 }

--- a/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -151,7 +151,7 @@ class HeartbeatControllerTest {
 
     @Test
     fun `should send Terminate signal to idle agents when there are no tests left`() {
-        whenever(containerService.isStoppedByContainerId(any())).thenReturn(true)
+        whenever(containerService.isStopped(any())).thenReturn(true)
         val agentStatusDtos = listOf(
             AgentStatusDto(AgentState.IDLE, "test-1"),
             AgentStatusDto(AgentState.IDLE, "test-2"),


### PR DESCRIPTION
### What's done:
- renamed **isStoppedByContainerId** to **isStopped**
- renamed **cleanup** to **cleanupByExecutionId**
- refactored `getNextRunConfig` to return Mono.empty if there is no job