### PR TITLE
Suppress `DSL_SCOPE_VIOLATION` in `.kts` scrips

### DIFF
--- a/authentication-service/build.gradle.kts
+++ b/authentication-service/build.gradle.kts
@@ -1,5 +1,4 @@
-import com.saveourtool.save.buildutils.*
-
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     id("com.saveourtool.save.buildutils.spring-boot-configuration")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.saveourtool.save.buildutils.*
 
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.versioning-configuration")
     id("com.saveourtool.save.buildutils.code-quality-convention")

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlin.plugin.serialization)

--- a/save-api-cli/build.gradle.kts
+++ b/save-api-cli/build.gradle.kts
@@ -1,3 +1,4 @@
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     application
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")

--- a/save-api/build.gradle.kts
+++ b/save-api/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     id("com.saveourtool.save.buildutils.code-quality-convention")

--- a/save-backend/build.gradle.kts
+++ b/save-backend/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.saveourtool.save.buildutils.*
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension

--- a/save-cloud-common/build.gradle.kts
+++ b/save-cloud-common/build.gradle.kts
@@ -1,3 +1,4 @@
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlin.plugin.serialization)

--- a/save-demo-cpg/build.gradle.kts
+++ b/save-demo-cpg/build.gradle.kts
@@ -1,6 +1,6 @@
-import com.saveourtool.save.buildutils.*
 import org.springframework.boot.gradle.tasks.run.BootRun
 
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     id("com.saveourtool.save.buildutils.spring-boot-app-configuration")

--- a/save-demo/build.gradle.kts
+++ b/save-demo/build.gradle.kts
@@ -1,7 +1,6 @@
-import com.saveourtool.save.buildutils.*
-
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     id("com.saveourtool.save.buildutils.spring-boot-app-configuration")

--- a/save-orchestrator-common/build.gradle.kts
+++ b/save-orchestrator-common/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.saveourtool.save.buildutils.*
-
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.saveourtool.save.buildutils.*
-
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/save-preprocessor/build.gradle.kts
+++ b/save-preprocessor/build.gradle.kts
@@ -1,3 +1,4 @@
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     alias(libs.plugins.kotlin.plugin.serialization)

--- a/save-sandbox/build.gradle.kts
+++ b/save-sandbox/build.gradle.kts
@@ -1,7 +1,6 @@
-import com.saveourtool.save.buildutils.*
-
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+@Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     id("com.saveourtool.save.buildutils.kotlin-jvm-configuration")
     id("com.saveourtool.save.buildutils.spring-boot-app-configuration")


### PR DESCRIPTION
### What's done:

 * IDEA no longer highlights occurrences of `alias(libs.*)` in the `plugins {}` section in red.
 * This is a Gradle issue, see https://github.com/gradle/gradle/issues/22797.