### PR TITLE
Refactored ExecutionService

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/RunExecutionController.kt
@@ -80,17 +80,19 @@ class RunExecutionController(
         .validateAccess(authentication) { it }
         .validateContestEnrollment(request)
         .flatMap {
-            executionService.createNew(
-                projectCoordinates = request.projectCoordinates,
-                testSuiteIds = request.testSuiteIds,
-                files = request.files,
-                username = authentication.username(),
-                sdk = request.sdk,
-                execCmd = request.execCmd,
-                batchSizeForAnalyzer = request.batchSizeForAnalyzer,
-                testingType = request.testingType,
-                contestName = request.contestName,
-            )
+            blockingToMono {
+                executionService.createNew(
+                    projectCoordinates = request.projectCoordinates,
+                    testSuiteIds = request.testSuiteIds,
+                    files = request.files,
+                    username = authentication.username(),
+                    sdk = request.sdk,
+                    execCmd = request.execCmd,
+                    batchSizeForAnalyzer = request.batchSizeForAnalyzer,
+                    testingType = request.testingType,
+                    contestName = request.contestName,
+                )
+            }
         }
         .subscribeOn(Schedulers.boundedElastic())
         .flatMap { execution ->
@@ -121,7 +123,7 @@ class RunExecutionController(
                 execution.project.name
             )
         }
-        .flatMap { executionService.createNewCopy(it, authentication.username()) }
+        .flatMap { blockingToMono { executionService.createNewCopy(it, authentication.username()) } }
         .flatMap { execution ->
             Mono.just(execution.toAcceptedResponse())
                 .doOnSuccess {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ExecutionService.kt
@@ -6,7 +6,6 @@ import com.saveourtool.save.domain.*
 import com.saveourtool.save.entities.*
 import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.execution.TestingType
-import com.saveourtool.save.utils.blockingToMono
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.orNotFound
 
@@ -16,7 +15,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
-import reactor.core.publisher.Mono
 
 import java.time.LocalDateTime
 import java.util.Optional

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ExecutionService.kt
@@ -201,13 +201,13 @@ class ExecutionService(
         batchSizeForAnalyzer: String?,
         testingType: TestingType,
         contestName: String?,
-    ): Mono<Execution> = blockingToMono {
+    ): Execution {
         val project = with(projectCoordinates) {
             projectService.findByNameAndOrganizationNameAndCreatedStatus(projectName, organizationName).orNotFound {
                 "Not found project $projectName in $organizationName"
             }
         }
-        doCreateNew(
+        return doCreateNew(
             project = project,
             testSuiteIds = testSuiteIds,
             allTests = testSuiteIds.flatMap { testRepository.findAllByTestSuiteId(it) }
@@ -232,9 +232,9 @@ class ExecutionService(
     fun createNewCopy(
         execution: Execution,
         username: String,
-    ): Mono<Execution> = blockingToMono {
+    ): Execution {
         val testSuiteIds = lnkExecutionTestSuiteService.getAllTestSuiteIdsByExecutionId(execution.requiredId())
-        doCreateNew(
+        return doCreateNew(
             project = execution.project,
             testSuiteIds = testSuiteIds,
             allTests = execution.allTests,

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkContestExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkContestExecutionService.kt
@@ -3,11 +3,9 @@ package com.saveourtool.save.backend.service
 import com.saveourtool.save.backend.repository.ContestRepository
 import com.saveourtool.save.backend.repository.LnkContestExecutionRepository
 import com.saveourtool.save.entities.*
-import com.saveourtool.save.utils.blockingToMono
-import com.saveourtool.save.utils.switchIfEmptyToNotFound
+import com.saveourtool.save.utils.orNotFound
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
-import reactor.core.publisher.Mono
 
 /**
  * Service of [LnkContestExecution]
@@ -58,15 +56,12 @@ class LnkContestExecutionService(
     /**
      * @param execution
      * @param contestName
-     * @return [Mono] containing a created [LnkContestExecution] or `Mono.error` with code 404
+     * @return a created [LnkContestExecution] or exception with code 404
      */
-    fun createLink(execution: Execution, contestName: String): Mono<LnkContestExecution> = blockingToMono {
-        contestRepository.findByName(contestName)
-    }
-        .switchIfEmptyToNotFound()
-        .map {
-            lnkContestExecutionRepository.save(
-                LnkContestExecution(execution = execution, contest = it)
-            )
-        }
+    fun createLink(execution: Execution, contestName: String): LnkContestExecution = lnkContestExecutionRepository.save(
+        LnkContestExecution(
+            execution = execution,
+            contest = contestRepository.findByName(contestName).orNotFound()
+        )
+    )
 }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -222,32 +222,6 @@ class TestSuitesService(
         }
     }
 
-    /**
-     * @param testSuiteIds IDs of [TestSuite]
-     * @return a single version got from test suites
-     */
-    fun getSingleVersionByIds(testSuiteIds: List<Long>): String {
-        require(testSuiteIds.isNotEmpty()) {
-            "No test suite is selected"
-        }
-        val testSuites = testSuiteIds.map { getById(it) }
-        testSuites.map { it.source }
-            .distinctBy { it.requiredId() }
-            .also { sources ->
-                require(sources.size == 1) {
-                    "Only a single test suites source is allowed for a run, but got: $sources"
-                }
-            }
-        return testSuites.map { it.version }
-            .distinct()
-            .also { versions ->
-                require(versions.size == 1) {
-                    "Only a single version is supported, but got: $versions"
-                }
-            }
-            .single()
-    }
-
     private fun getSavedEntityByDto(
         dto: TestSuiteDto,
     ): TestSuite = testSuiteRepository.findByNameAndTagsAndSourceAndVersion(


### PR DESCRIPTION
### What's done:
- moved `singleSourceName` and `singleVersion` to `ExecutionService`
- moved  `blockingToMono` outside from `createNew` and `createNewCopy`

It's part of #1670