### PR TITLE
build: Pin version of `paketo` builder to the last working one

### DIFF
--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -101,6 +101,11 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
+      - name: Set up Python 3.10.9
+        id: python
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: 3.10.9
       - name: Install system packages
         # libcurl is needed for ktor-client-curl
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -101,11 +101,6 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-      - name: Set up Python 3.10.9
-        id: python
-        uses: actions/setup-python@v3.0.0
-        with:
-          python-version: 3.10.9
       - name: Install system packages
         # libcurl is needed for ktor-client-curl
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/save-cloud-charts/save-cloud/Chart.lock
+++ b/save-cloud-charts/save-cloud/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 6.49.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 19.2.2
+  version: 19.3.0
 - name: promtail
   repository: https://grafana.github.io/helm-charts
-  version: 6.7.4
+  version: 6.8.1
 - name: loki
   repository: https://grafana.github.io/helm-charts
-  version: 3.8.0
+  version: 3.8.1
 - name: neo4j
   repository: https://helm.neo4j.com/neo4j
   version: 5.3.0
-digest: sha256:38cef66aa6f85d7d99c0e21afbc025122c03f353cbc24bc3604537441969fcd8
-generated: "2023-01-02T10:44:34.941097715Z"
+digest: sha256:35a9342e94f2ec21d5cec98f5766f948c615c8ff4e393be911eb609595d4f7c9
+generated: "2023-01-09T01:42:37.700599599Z"

--- a/save-demo-cpg/builder/Dockerfile
+++ b/save-demo-cpg/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM paketobuildpacks/builder:base
+FROM paketobuildpacks/builder:0.3.135-base
 
 USER root
 RUN apt update && apt install -y software-properties-common && \


### PR DESCRIPTION
Using `builder = "ghcr.io/saveourtool/builder@sha256:ea2b2446f665fed9b24f76ca58efd6f36df79da5e6f529b1b8e97597ed72c305"` (which is the last custom builder image to yield successful results) seems to fix the problem with build. It's based on builder `0.3.135-base`; at least this version should work. This version of the builder also contains `cpython@1.8.0` and `pipenv@1.12.0`, as we suspect one of these builders causes problems.

For the record: untagged versions are still listed at https://github.com/saveourtool/save-cloud/pkgs/container/builder/versions; SHA of builder image was logged in https://github.com/saveourtool/save-cloud/actions/runs/3820228701/jobs/6498384602; matching tag can be found at https://hub.docker.com/layers/paketobuildpacks/builder/0.3.135-base/images/sha256-7e3429ba538ec53b30a52353ab8d51cc76571ed84e1f95da02568eefdd3d10c8?context=explore

To test if it works, we can build builder image from branch and then build `demo-cpg` image from branch.
Edit: built images from branch, it's working again.