### PR TITLE
Fix the way empty debug info is added to each test execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 build
 !ktlint/src/main/resources/config/.idea
 /.idea
+/.mailmap
 *.iml
 out
 .DS_Store

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -375,9 +375,14 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                     Json.decodeFromString<Array<TestExecutionDto>>(
                         it.text().await()
                     )
-                }.apply {
-                    asDynamic().debugInfo = null
-                }
+                }.map { testExecution ->
+                    /*
+                     * Add empty debug info to each test execution.
+                     */
+                    testExecution.apply {
+                        asDynamic().debugInfo = null
+                    }
+                }.toTypedArray()
             }
             getPageCount = { pageSize ->
                 val filtersQueryString = buildString {


### PR DESCRIPTION
Previously, debug info was added to the array as a whole.