### PR TITLE
Conditionally display test analysis results

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -25,6 +25,8 @@ import com.saveourtool.save.frontend.components.tables.pageSize
 import com.saveourtool.save.frontend.components.tables.tableComponent
 import com.saveourtool.save.frontend.components.tables.value
 import com.saveourtool.save.frontend.components.tables.visibleColumnsCount
+import com.saveourtool.save.frontend.components.views.test.analysis.analysisResultsView
+import com.saveourtool.save.frontend.components.views.test.analysis.testMetricsView
 import com.saveourtool.save.frontend.http.getDebugInfoFor
 import com.saveourtool.save.frontend.http.getExecutionInfoFor
 import com.saveourtool.save.frontend.themes.Colors
@@ -76,6 +78,11 @@ external interface ExecutionProps : PropsWithChildren {
      * All filters in one value [filters]
      */
     var filters: TestExecutionFilters
+
+    /**
+     * Indicates whether test analysis is enabled or not.
+     */
+    var testAnalysisEnabled: Boolean
 }
 
 /**
@@ -223,6 +230,23 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                     Fragment.create {
                         td {
                             +"${it.value.testExecution.agentContainerId}"
+                        }
+                    }
+                }
+
+                if (props.testAnalysisEnabled) {
+                    column(id = "testMetrics", header = "Test Metrics") {
+                        td.create {
+                            testMetricsView {
+                                testMetrics = it.value.testMetrics
+                            }
+                        }
+                    }
+                    column(id = "testAnalysis", header = "Test Analysis") {
+                        td.create {
+                            analysisResultsView {
+                                analysisResults = it.value.analysisResults
+                            }
                         }
                     }
                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/AnalysisResultView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/AnalysisResultView.kt
@@ -1,0 +1,86 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.views.test.analysis
+
+import com.saveourtool.save.frontend.externals.fontawesome.faBug
+import com.saveourtool.save.frontend.externals.fontawesome.faCheckCircle
+import com.saveourtool.save.frontend.externals.fontawesome.faDice
+import com.saveourtool.save.frontend.externals.fontawesome.faPoo
+import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
+import com.saveourtool.save.test.analysis.results.AnalysisResult
+import com.saveourtool.save.test.analysis.results.FlakyTest
+import com.saveourtool.save.test.analysis.results.IrregularTest
+import com.saveourtool.save.test.analysis.results.PermanentFailure
+import com.saveourtool.save.test.analysis.results.Regression
+import com.saveourtool.save.test.analysis.results.RegularTest
+import csstype.ColorProperty
+import csstype.MarginRight
+import js.core.jso
+import react.ChildrenBuilder
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.abbr
+
+/**
+ * Displays a single [AnalysisResult].
+ *
+ * @see AnalysisResult
+ * @see AnalysisResultProps
+ */
+val analysisResultView: FC<AnalysisResultProps> = FC { props ->
+    nowrap("analysisResult") {
+        val result = props.analysisResult
+
+        abbr {
+            style = jso {
+                color = result.iconColor()
+                marginRight = "0.25em".unsafeCast<MarginRight>()
+            }
+            title = result.tooltipText()
+
+            icon(result)
+        }
+
+        +result.text()
+    }
+}
+
+/**
+ * Properties of [analysisResultView].
+ *
+ * @see analysisResultView
+ */
+external interface AnalysisResultProps : Props {
+    /**
+     * The analysis result to render.
+     */
+    var analysisResult: AnalysisResult
+}
+
+private fun ChildrenBuilder.icon(result: AnalysisResult): Unit =
+        when (result) {
+            is RegularTest -> fontAwesomeIcon(icon = faCheckCircle)
+            is FlakyTest -> fontAwesomeIcon(icon = faDice)
+            is PermanentFailure -> fontAwesomeIcon(icon = faPoo)
+            is Regression -> fontAwesomeIcon(icon = faBug)
+        }
+
+private fun AnalysisResult.iconColor(): ColorProperty =
+        when (this) {
+            is RegularTest -> successColor
+            is IrregularTest -> failureColor
+        }
+
+private fun AnalysisResult.text(): String =
+        when (this) {
+            is RegularTest -> "Regular test"
+            is IrregularTest -> detailMessage
+        }
+
+private fun AnalysisResult.tooltipText(): String =
+        when (this) {
+            is RegularTest -> "Regular Test"
+            is FlakyTest -> "Flaky Test"
+            is PermanentFailure -> "Permanent Failure"
+            is Regression -> "Regression"
+        }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/AnalysisResultsView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/AnalysisResultsView.kt
@@ -1,0 +1,57 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.views.test.analysis
+
+import com.saveourtool.save.test.analysis.results.AnalysisResult
+import csstype.ClassName
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.li
+import react.dom.html.ReactHTML.ul
+
+/**
+ * Displays a list of [AnalysisResult].
+ *
+ * @see AnalysisResult
+ * @see AnalysisResultsProps
+ */
+val analysisResultsView: FC<AnalysisResultsProps> = FC { props ->
+    div {
+        className = ClassName("analysisResults")
+
+        val results = props.analysisResults
+
+        when (results.size) {
+            0 -> noDataAvailable()
+
+            1 -> analysisResultView {
+                analysisResult = results[0]
+            }
+
+            else -> ul {
+                style = listStyle
+
+                results.forEach { result ->
+                    li {
+                        analysisResultView {
+                            analysisResult = result
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Properties of [analysisResultsView].
+ *
+ * @see analysisResultsView
+ */
+external interface AnalysisResultsProps : Props {
+    /**
+     * The analysis result to render.
+     */
+    var analysisResults: List<AnalysisResult>
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/TestMetricsView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/TestMetricsView.kt
@@ -1,0 +1,99 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.views.test.analysis
+
+import com.saveourtool.save.test.analysis.metrics.NoDataAvailable
+import com.saveourtool.save.test.analysis.metrics.RegularTestMetrics
+import com.saveourtool.save.test.analysis.metrics.TestMetrics
+import csstype.ClassName
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.li
+import react.dom.html.ReactHTML.ul
+
+/**
+ * Displays [TestMetrics].
+ *
+ * @see TestMetrics
+ * @see TestMetricsProps
+ */
+val testMetricsView: FC<TestMetricsProps> = FC { props ->
+    div {
+        className = ClassName("testMetrics")
+
+        when (val metrics = props.testMetrics) {
+            is NoDataAvailable -> noDataAvailable()
+            is RegularTestMetrics -> with(metrics) {
+                ul {
+                    style = listStyle
+
+                    li {
+                        nowrap {
+                            +"Test runs: "
+
+                            boldText(runCount)
+
+                            +" total / "
+
+                            boldText(failureCount) {
+                                color = failureColor
+                            }
+
+                            +" failure(s) / "
+
+                            boldText(ignoredCount)
+
+                            +" ignored"
+                        }
+                    }
+
+                    li {
+                        labelledValue {
+                            label = "Failure rate"
+                            value = "$failureRatePercentage%"
+                        }
+                    }
+
+                    li {
+                        labelledValue {
+                            label = "Flip rate"
+                            labelTooltip = FLIP_RATE_DESCRIPTION
+                            value = "$flipRatePercentage%"
+                        }
+                    }
+
+                    averageDurationOrNull?.let { averageDuration ->
+                        li {
+                            labelledValue {
+                                label = "Duration (average)"
+                                value = averageDuration
+                            }
+                        }
+                    }
+
+                    medianDurationOrNull?.let { medianDuration ->
+                        li {
+                            labelledValue {
+                                label = "Duration (median)"
+                                value = medianDuration
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Properties of [testMetricsView].
+ *
+ * @see testMetricsView
+ */
+external interface TestMetricsProps : Props {
+    /**
+     * The test metrics to render.
+     */
+    var testMetrics: TestMetrics
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/Utils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/test/analysis/Utils.kt
@@ -1,0 +1,133 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.views.test.analysis
+
+import csstype.ClassName
+import csstype.ColorProperty
+import csstype.FontWeight
+import csstype.PaddingLeft
+import csstype.WhiteSpace
+import js.core.JsoDsl
+import js.core.jso
+import react.CSSProperties
+import react.ChildrenBuilder
+import react.FC
+import react.Props
+import react.VFC
+import react.dom.html.ReactHTML.abbr
+import react.dom.html.ReactHTML.span
+
+internal const val FLIP_RATE_DESCRIPTION: String = """
+A flip is a test status change ${'\u2014'} either from "PASSED" to "FAILED", or vice versa.
+The Flip Rate is the ratio of such "flips" to the invocation count of a given test.
+
+A test which constantly fails, while having a 100% failure rate,
+will have its flip rate close to zero;
+a test which "flips" each time it is invoked will have the flip rate close to 100%.
+
+If the flip rate is too high, the test will be considered flaky.
+"""
+
+internal val listStyle: CSSProperties = jso {
+    paddingLeft = "1.0em".unsafeCast<PaddingLeft>()
+}
+
+/**
+ * The placeholder displayed when there's no data available.
+ */
+internal val noDataAvailable: FC<Props> = VFC {
+    span {
+        className = ClassName("noDataAvailable")
+
+        +"No data available"
+    }
+}
+
+internal val successColor: ColorProperty = "#59a869".unsafeCast<ColorProperty>()
+
+internal val failureColor: ColorProperty = "#a90f1a".unsafeCast<ColorProperty>()
+
+/**
+ * A value with a label and an optional tooltip.
+ *
+ * @see LabelledValueProps
+ */
+internal val labelledValue: FC<LabelledValueProps> = FC { props ->
+    nowrap {
+        span {
+            className = ClassName("label")
+
+            props.labelTooltip?.let { labelTooltip ->
+                abbr {
+                    title = labelTooltip
+                    +props.label
+                }
+            } ?: +props.label
+        }
+
+        +": "
+
+        boldText(props.value)
+    }
+}
+
+/**
+ * Properties of [labelledValue].
+ *
+ * @see labelledValue
+ */
+internal external interface LabelledValueProps : Props {
+    /**
+     * The label.
+     */
+    var label: String
+
+    /**
+     * The optional tooltip which explains the meaning of the [label].
+     */
+    var labelTooltip: String?
+
+    /**
+     * The value to be displayed.
+     */
+    var value: Any
+}
+
+/**
+ * Renders the [block] in a single line, w/o wrapping.
+ *
+ * @param block the block to render.
+ * @param classNames optional extra CSS class names.
+ */
+internal fun ChildrenBuilder.nowrap(
+    vararg classNames: String,
+    block: ChildrenBuilder.() -> Unit
+) {
+    span {
+        style = jso {
+            whiteSpace = WhiteSpace.nowrap
+        }
+        className = ClassName(classNames.joinToString(separator = " "))
+
+        block()
+    }
+}
+
+/**
+ * Renders the [text] in bold, optionally applying an [extra style][extraStyle].
+ *
+ * @param text the text to render.
+ * @param extraStyle an optional extra CSS style.
+ */
+internal fun ChildrenBuilder.boldText(
+    text: Any,
+    extraStyle: @JsoDsl CSSProperties.() -> Unit = {},
+): Unit =
+        span {
+            style = jso {
+                fontWeight = FontWeight.bold
+                extraStyle()
+            }
+
+            +text.toString()
+        }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/Icons.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/fontawesome/Icons.kt
@@ -199,3 +199,15 @@ external val faCaretSquareRight: FontAwesomeIconModule
 @JsModule("@fortawesome/free-solid-svg-icons/faSyncAlt")
 @JsNonModule
 external val faSyncAlt: FontAwesomeIconModule
+
+@JsModule("@fortawesome/free-solid-svg-icons/faPoo")
+@JsNonModule
+external val faPoo: FontAwesomeIconModule
+
+@JsModule("@fortawesome/free-solid-svg-icons/faDice")
+@JsNonModule
+external val faDice: FontAwesomeIconModule
+
+@JsModule("@fortawesome/free-solid-svg-icons/faBug")
+@JsNonModule
+external val faBug: FontAwesomeIconModule

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/routing/BasicRouting.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/routing/BasicRouting.kt
@@ -84,6 +84,7 @@ val basicRouting: FC<AppProps> = FC { props ->
                     tag = params.get("tag")
                 )
             }
+            testAnalysisEnabled = false
         }
     }
 


### PR DESCRIPTION
This is a part of Flaky Test Detector, see #659.

Now, `ExecutionView` may (depending on a flag value, the default is **off**) contain two extra columns which look like this:

![image](https://user-images.githubusercontent.com/73111822/212036311-1c7b414e-c202-4f4b-8ad8-8de171f9e97f.png)
