### PR TITLE
Introduced `TestsSourceVersionInfo` as replacement for `TestSuitesSourceSnapshotKey`

### DIFF
--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -6297,7 +6297,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestSuitesSourceSnapshotKey"
+                    "$ref": "#/components/schemas/TestsSourceVersionInfo"
                   }
                 }
               }
@@ -6310,7 +6310,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestSuitesSourceSnapshotKey"
+                    "$ref": "#/components/schemas/TestsSourceVersionInfo"
                   }
                 }
               }
@@ -6323,7 +6323,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestSuitesSourceSnapshotKey"
+                    "$ref": "#/components/schemas/TestsSourceVersionInfo"
                   }
                 }
               }
@@ -7042,7 +7042,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestSuitesSourceSnapshotKey"
+                    "$ref": "#/components/schemas/TestsSourceVersionInfo"
                   }
                 }
               }
@@ -7055,7 +7055,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestSuitesSourceSnapshotKey"
+                    "$ref": "#/components/schemas/TestsSourceVersionInfo"
                   }
                 }
               }
@@ -7068,7 +7068,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestSuitesSourceSnapshotKey"
+                    "$ref": "#/components/schemas/TestsSourceVersionInfo"
                   }
                 }
               }
@@ -9809,23 +9809,30 @@
           }
         }
       },
-      "TestSuitesSourceSnapshotKey": {
+      "TestsSourceVersionInfo": {
         "required": [
-          "creationTimeInMills",
+          "commitId",
+          "commitTime",
+          "creationTime",
           "organizationName",
-          "testSuitesSourceName",
+          "sourceName",
           "version"
         ],
         "type": "object",
         "properties": {
-          "creationTimeInMills": {
-            "type": "integer",
-            "format": "int64"
+          "commitId": {
+            "type": "string"
+          },
+          "commitTime": {
+            "$ref": "#/components/schemas/LocalDateTime"
+          },
+          "creationTime": {
+            "$ref": "#/components/schemas/LocalDateTime"
           },
           "organizationName": {
             "type": "string"
           },
-          "testSuitesSourceName": {
+          "sourceName": {
             "type": "string"
           },
           "version": {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ContestController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ContestController.kt
@@ -3,7 +3,6 @@ package com.saveourtool.save.backend.controllers
 import com.saveourtool.save.backend.StringResponse
 import com.saveourtool.save.backend.security.OrganizationPermissionEvaluator
 import com.saveourtool.save.backend.service.*
-import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
 import com.saveourtool.save.configs.ApiSwaggerSupport
 import com.saveourtool.save.configs.RequiresAuthorizationSourceHeader
 import com.saveourtool.save.entities.Contest
@@ -56,7 +55,7 @@ internal class ContestController(
     private val organizationPermissionEvaluator: OrganizationPermissionEvaluator,
     private val organizationService: OrganizationService,
     private val testSuitesService: TestSuitesService,
-    private val testSuitesSourceSnapshotStorage: TestSuitesSourceSnapshotStorage,
+    private val testsSourceVersionService: TestsSourceVersionService,
     private val lnkContestTestSuiteService: LnkContestTestSuiteService,
 ) {
     @GetMapping("/{contestName}")
@@ -205,7 +204,7 @@ internal class ContestController(
         .flatMap { (testSuite, test) ->
             Mono.zip(
                 testSuite.toMono(),
-                testSuitesSourceSnapshotStorage.getTestContent(TestFilesRequest(test.toDto(), testSuite.source.toDto(), testSuite.version))
+                testsSourceVersionService.getTestContent(TestFilesRequest(test.toDto(), testSuite.source.toDto(), testSuite.version))
             )
         }
         .map { (testSuite, testFilesContent) ->

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -4,12 +4,7 @@ import com.saveourtool.save.authservice.utils.AuthenticationDetails
 import com.saveourtool.save.backend.StringResponse
 import com.saveourtool.save.backend.configs.ConfigProperties
 import com.saveourtool.save.backend.security.OrganizationPermissionEvaluator
-import com.saveourtool.save.backend.service.GitService
-import com.saveourtool.save.backend.service.LnkUserOrganizationService
-import com.saveourtool.save.backend.service.OrganizationService
-import com.saveourtool.save.backend.service.TestSuitesService
-import com.saveourtool.save.backend.service.TestSuitesSourceService
-import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
+import com.saveourtool.save.backend.service.*
 import com.saveourtool.save.configs.ApiSwaggerSupport
 import com.saveourtool.save.configs.RequiresAuthorizationSourceHeader
 import com.saveourtool.save.domain.OrganizationSaveStatus
@@ -65,7 +60,7 @@ internal class OrganizationController(
     private val gitService: GitService,
     private val testSuitesSourceService: TestSuitesSourceService,
     private val testSuitesService: TestSuitesService,
-    private val testSuitesSourceSnapshotStorage: TestSuitesSourceSnapshotStorage,
+    private val testsSourceVersionService: TestsSourceVersionService,
     config: ConfigProperties,
 ) {
     private val webClientToPreprocessor = WebClient.create(config.preprocessorUrl)
@@ -514,13 +509,11 @@ internal class OrganizationController(
             organizationService.getGlobalRating(organizationName, authentication)
         }
 
-    private fun cleanupStorageData(testSuite: TestSuite) = testSuitesSourceSnapshotStorage.findKey(
+    private fun cleanupStorageData(testSuite: TestSuite) = testsSourceVersionService.delete(
         testSuite.source.organization.name,
         testSuite.source.name,
         testSuite.version,
-    ).flatMap { key ->
-        testSuitesSourceSnapshotStorage.delete(key)
-    }
+    )
 
     private fun getFilteredOrganizationDtoList(filters: OrganizationFilters): Flux<OrganizationDto> = blockingToFlux {
         organizationService.getFiltered(filters)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/TestSuitesSourceController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/TestSuitesSourceController.kt
@@ -140,6 +140,7 @@ class TestSuitesSourceController(
         responseCode = "404",
         description = "Either organization was not found by provided name or test suites source with such name in organization name was not found.",
     )
+    @Suppress("TOO_MANY_LINES_IN_LAMBDA")
     fun uploadSnapshot(
         @PathVariable organizationName: String,
         @PathVariable sourceName: String,

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/TestSuitesSourceController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/TestSuitesSourceController.kt
@@ -3,16 +3,18 @@ package com.saveourtool.save.backend.controllers
 import com.saveourtool.save.backend.ByteBufferFluxResponse
 import com.saveourtool.save.backend.StringResponse
 import com.saveourtool.save.backend.service.*
-import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
 import com.saveourtool.save.backend.utils.toResponseEntity
 import com.saveourtool.save.configs.ApiSwaggerSupport
 import com.saveourtool.save.configs.RequiresAuthorizationSourceHeader
 import com.saveourtool.save.domain.EntitySaveStatus
 import com.saveourtool.save.entities.*
 import com.saveourtool.save.entities.TestSuitesSource.Companion.toTestSuiteSource
+import com.saveourtool.save.test.TestsSourceVersionInfo
+import com.saveourtool.save.test.TestsSourceVersionInfoList
 import com.saveourtool.save.testsuite.*
 import com.saveourtool.save.utils.*
 import com.saveourtool.save.v1
+
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.Parameters
@@ -34,6 +36,9 @@ import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.core.util.function.component1
 import reactor.kotlin.core.util.function.component2
 
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
 typealias EntitySaveStatusResponse = ResponseEntity<EntitySaveStatus>
 typealias StringListResponse = ResponseEntity<List<String>>
 
@@ -48,7 +53,7 @@ typealias StringListResponse = ResponseEntity<List<String>>
 @Suppress("LongParameterList")
 class TestSuitesSourceController(
     private val testSuitesSourceService: TestSuitesSourceService,
-    private val testSuitesSourceSnapshotStorage: TestSuitesSourceSnapshotStorage,
+    private val testsSourceVersionService: TestsSourceVersionService,
     private val testSuitesService: TestSuitesService,
     private val organizationService: OrganizationService,
     private val gitService: GitService,
@@ -142,12 +147,22 @@ class TestSuitesSourceController(
         @RequestParam creationTime: Long,
         @RequestPart("content") contentAsMonoPart: Mono<Part>
     ): Mono<Unit> = findAsDtoByName(organizationName, sourceName)
-        .map { TestSuitesSourceSnapshotKey(it, version, creationTime) }
+        .map {
+            val parsedCreationTime = creationTime.millisToInstant().toLocalDateTime(TimeZone.UTC)
+            TestsSourceVersionInfo(
+                organizationName = it.organizationName,
+                sourceName = it.name,
+                version = version,
+                creationTime = parsedCreationTime,
+                commitId = version,
+                commitTime = parsedCreationTime,
+            )
+        }
         .flatMap { key ->
             contentAsMonoPart.flatMap { part ->
                 val content = part.content().map { it.asByteBuffer() }
-                testSuitesSourceSnapshotStorage.upload(key, content).map { writtenBytes ->
-                    log.info { "Saved ($writtenBytes bytes) snapshot of ${key.testSuitesSourceName} in ${key.organizationName} with version $version" }
+                testsSourceVersionService.upload(key, content).map { writtenBytes ->
+                    log.info { "Saved ($writtenBytes bytes) snapshot of ${key.sourceName} in ${key.organizationName} with version $version" }
                 }
             }
         }
@@ -214,7 +229,7 @@ class TestSuitesSourceController(
         @RequestParam version: String,
     ): Mono<Boolean> = findAsDtoByName(organizationName, sourceName)
         .flatMap {
-            testSuitesSourceSnapshotStorage.doesContain(it.organizationName, it.name, version)
+            testsSourceVersionService.doesContain(it.organizationName, it.name, version)
         }
 
     @GetMapping(
@@ -243,9 +258,9 @@ class TestSuitesSourceController(
     fun listSnapshotVersions(
         @PathVariable organizationName: String,
         @PathVariable sourceName: String,
-    ): Mono<TestSuitesSourceSnapshotKeyList> = findAsDtoByName(organizationName, sourceName)
+    ): Mono<TestsSourceVersionInfoList> = findAsDtoByName(organizationName, sourceName)
         .flatMap {
-            testSuitesSourceSnapshotStorage.list(it.organizationName, it.name)
+            testsSourceVersionService.list(it.organizationName, it.name)
                 .collectList()
         }
 
@@ -268,10 +283,9 @@ class TestSuitesSourceController(
     @ApiResponse(responseCode = "404", description = "Organization was not found by provided name.")
     fun listSnapshots(
         @PathVariable organizationName: String,
-    ): Mono<TestSuitesSourceSnapshotKeyList> = getOrganization(organizationName)
+    ): Mono<TestsSourceVersionInfoList> = getOrganization(organizationName)
         .flatMap { organization ->
-            testSuitesSourceSnapshotStorage.list()
-                .filter { it.organizationName == organization.name }
+            testsSourceVersionService.list(organization.name)
                 .collectList()
         }
 
@@ -339,12 +353,7 @@ class TestSuitesSourceController(
                 EntitySaveStatus.UPDATED -> {
                     val newName = updatedEntity.name
                     val movingSnapshots = if (originalName != newName) {
-                        testSuitesSourceSnapshotStorage.list(updatedEntity.organization.name, originalName)
-                            .map { it to it.copy(testSuitesSourceName = newName) }
-                            .flatMap { (sourceKey, targetKey) ->
-                                testSuitesSourceSnapshotStorage.move(sourceKey, targetKey)
-                            }
-                            .then()
+                        testsSourceVersionService.updateSourceName(updatedEntity.organization.name, originalName, newName)
                     } else {
                         Mono.just(Unit)
                     }
@@ -446,10 +455,7 @@ class TestSuitesSourceController(
         .map {
             testSuitesService.deleteTestSuite(it, version)
         }
-        .then(testSuitesSourceSnapshotStorage.findKey(organizationName, sourceName, version))
-        .flatMap {
-            testSuitesSourceSnapshotStorage.delete(it)
-        }
+        .then(testsSourceVersionService.delete(organizationName, sourceName, version))
 
     private fun getOrganization(organizationName: String): Mono<Organization> = blockingToMono {
         organizationService.findByNameAndCreatedStatus(organizationName)
@@ -528,7 +534,7 @@ class TestSuitesSourceController(
         authentication: Authentication,
     ): Mono<StringListResponse> = blockingToMono { testSuitesSourceService.findByName(organizationName, sourceName) }
         .flatMap { testSuitesSourceService.tagList(it.toDto()) }
-        .zipWith(testSuitesSourceSnapshotStorage.list(organizationName, sourceName)
+        .zipWith(testsSourceVersionService.list(organizationName, sourceName)
             .map { it.version }
             .collectList())
         .map { (tags, versions) ->
@@ -571,14 +577,15 @@ class TestSuitesSourceController(
 
     private fun TestSuitesSourceDto.downloadSnapshot(
         version: String
-    ): Mono<ByteBufferFluxResponse> = testSuitesSourceSnapshotStorage.findKey(organizationName, name, version)
+    ): Mono<ByteBufferFluxResponse> = testsSourceVersionService.doesContain(organizationName, name, version)
+        .filter { it }
         .switchIfEmptyToNotFound {
             "Not found a snapshot of $name in $organizationName with version=$version"
         }
         .map {
             ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(testSuitesSourceSnapshotStorage.download(it))
+                .body(testsSourceVersionService.download(organizationName, name, version))
         }
 
     companion object {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/internal/TestController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/internal/TestController.kt
@@ -1,10 +1,7 @@
 package com.saveourtool.save.backend.controllers.internal
 
 import com.saveourtool.save.backend.service.TestService
-import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
 import com.saveourtool.save.test.TestDto
-import com.saveourtool.save.test.TestFilesContent
-import com.saveourtool.save.test.TestFilesRequest
 import com.saveourtool.save.utils.debug
 import com.saveourtool.save.utils.getLogger
 import com.saveourtool.save.utils.trace
@@ -15,7 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import reactor.core.publisher.Mono
 
 /**
  *  Controller used to initialize tests
@@ -25,7 +21,6 @@ import reactor.core.publisher.Mono
 class TestController(
     private val testService: TestService,
     private val meterRegistry: MeterRegistry,
-    private val testSuitesSourceSnapshotStorage: TestSuitesSourceSnapshotStorage,
 ) {
     /**
      * @param testDtos list of [TestDto]s to save into the DB
@@ -38,14 +33,6 @@ class TestController(
             testService.saveTests(testDtos)
         }
     }
-
-    /**
-     * @param testFilesRequest
-     * @return [TestFilesContent] filled with test files
-     */
-    @PostMapping("/tests/get-content")
-    fun getContent(@RequestBody testFilesRequest: TestFilesRequest): Mono<TestFilesContent> =
-            testSuitesSourceSnapshotStorage.getTestContent(testFilesRequest)
 
     companion object {
         private val log: Logger = getLogger<TestController>()

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestsSourceVersionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestsSourceVersionService.kt
@@ -1,0 +1,191 @@
+package com.saveourtool.save.backend.service
+
+import com.saveourtool.save.backend.configs.ConfigProperties
+import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
+import com.saveourtool.save.test.TestFilesContent
+import com.saveourtool.save.test.TestFilesRequest
+import com.saveourtool.save.test.TestsSourceVersionInfo
+import com.saveourtool.save.testsuite.TestSuitesSourceSnapshotKey
+import com.saveourtool.save.utils.ARCHIVE_EXTENSION
+import com.saveourtool.save.utils.extractZipHere
+import com.saveourtool.save.utils.orNotFound
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.nio.ByteBuffer
+import kotlin.io.path.*
+
+/**
+ * Service for [TestsSourceVersionInfo]
+ */
+@Service
+class TestsSourceVersionService(
+    private val snapshotStorage: TestSuitesSourceSnapshotStorage,
+    configProperties: ConfigProperties,
+) {
+    private val tmpDir = (java.nio.file.Path.of(configProperties.fileStorage.location) / "tmp").createDirectories()
+
+    /**
+     * @param versionInfo
+     * @param content
+     * @return count of written bytes
+     */
+    fun upload(
+        versionInfo: TestsSourceVersionInfo,
+        content: Flux<ByteBuffer>,
+    ): Mono<Long> = snapshotStorage.upload(
+        key = TestSuitesSourceSnapshotKey(
+            organizationName = versionInfo.organizationName,
+            testSuitesSourceName = versionInfo.sourceName,
+            version = versionInfo.commitId,
+            creationTime = versionInfo.commitTime,
+        ),
+        content = content
+    )
+
+    /**
+     * @param organizationName
+     * @param sourceName
+     * @param version
+     * @return true if storage contains snapshot with provided values, otherwise -- false
+     */
+    fun doesContain(
+        organizationName: String,
+        sourceName: String,
+        version: String,
+    ): Mono<Boolean> = findSnapshotKey(organizationName, sourceName, version)
+        .map { true }
+        .defaultIfEmpty(false)
+
+    /**
+     * @param organizationName
+     * @param testSuitesSourceName
+     * @param version
+     * @return content of a key which contains provided values
+     */
+    fun download(
+        organizationName: String,
+        testSuitesSourceName: String,
+        version: String,
+    ): Flux<ByteBuffer> = findSnapshotKey(
+        organizationName = organizationName,
+        sourceName = testSuitesSourceName,
+        version = version,
+    ).flatMapMany { snapshotStorage.download(it) }
+
+    /**
+     * @param organizationName
+     * @param sourceName
+     * @param version
+     * @return result of deletion of a key which contains provided values
+     */
+    fun delete(
+        organizationName: String,
+        sourceName: String,
+        version: String,
+    ): Mono<Boolean> = findSnapshotKey(
+        organizationName = organizationName,
+        sourceName = sourceName,
+        version = version,
+    ).flatMap { snapshotStorage.delete(it) }
+
+    private fun findSnapshotKey(
+        organizationName: String,
+        sourceName: String,
+        version: String,
+    ): Mono<TestSuitesSourceSnapshotKey> = snapshotStorage.list()
+        .filter { it.equalsTo(organizationName, sourceName, version) }
+        .singleOrEmpty()
+
+    /**
+     * @param organizationName
+     * @return list of [TestsSourceVersionInfo] found by provided values
+     */
+    fun list(
+        organizationName: String,
+    ): Flux<TestsSourceVersionInfo> = snapshotStorage.list()
+        .filter { it.organizationName == organizationName }
+        .map { it.toVersionInfo() }
+
+    /**
+     * @param organizationName
+     * @param sourceName
+     * @return list of [TestsSourceVersionInfo] found by provided values
+     */
+    fun list(
+        organizationName: String,
+        sourceName: String,
+    ): Flux<TestsSourceVersionInfo> = snapshotStorage.list()
+        .filter { it.equalsTo(organizationName, sourceName) }
+        .map { it.toVersionInfo() }
+
+    /**
+     * @param request
+     * @return [TestFilesContent] filled with test files
+     */
+    fun getTestContent(request: TestFilesRequest): Mono<TestFilesContent> = with(request.testSuitesSource) {
+        findSnapshotKey(organizationName, name, request.version)
+            .orNotFound {
+                "There is no content for tests from $name in $organizationName with version ${request.version}"
+            }
+    }
+        .flatMap { key ->
+            val tmpSourceDir = createTempDirectory(tmpDir, "source-")
+            val tmpArchive = createTempFile(tmpSourceDir, "archive-", ARCHIVE_EXTENSION)
+            val sourceContent = snapshotStorage.download(key)
+                .map { DefaultDataBufferFactory.sharedInstance.wrap(it) }
+                .cast(DataBuffer::class.java)
+
+            DataBufferUtils.write(sourceContent, tmpArchive.outputStream())
+                .map { DataBufferUtils.release(it) }
+                .collectList()
+                .map {
+                    tmpArchive.extractZipHere()
+                    tmpArchive.deleteExisting()
+                }
+                .map {
+                    val testFilePath = request.test.filePath
+                    val additionalTestFilePath = request.test.additionalFiles.firstOrNull()
+                    val result = TestFilesContent(
+                        tmpSourceDir.resolve(testFilePath).readLines(),
+                        additionalTestFilePath?.let { tmpSourceDir.resolve(it).readLines() },
+                    )
+                    tmpSourceDir.toFile().deleteRecursively()
+                    result
+                }
+        }
+
+    /**
+     * Handle changing source name -- files are moved in snapshot storage
+     *
+     * @param organizationName
+     * @param oldSourceName
+     * @param newSourceName
+     * @return [Mono] without value
+     */
+    fun updateSourceName(
+        organizationName: String,
+        oldSourceName: String,
+        newSourceName: String,
+    ): Mono<Unit> = snapshotStorage.list()
+        .filter { it.equalsTo(organizationName, oldSourceName) }
+        .map { it to it.copy(testSuitesSourceName = newSourceName) }
+        .flatMap { (sourceKey, targetKey) ->
+            snapshotStorage.move(sourceKey, targetKey)
+        }
+        .then(Mono.just(Unit))
+
+    companion object {
+        private fun TestSuitesSourceSnapshotKey.toVersionInfo() = TestsSourceVersionInfo(
+            organizationName = organizationName,
+            sourceName = testSuitesSourceName,
+            version = version,
+            creationTime = convertAndGetCreationTime(),
+            commitId = version,
+            commitTime = convertAndGetCreationTime(),
+        )
+    }
+}

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/TestSuitesSourceSnapshotStorage.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/TestSuitesSourceSnapshotStorage.kt
@@ -2,16 +2,9 @@ package com.saveourtool.save.backend.storage
 
 import com.saveourtool.save.backend.configs.ConfigProperties
 import com.saveourtool.save.storage.AbstractFileBasedStorage
-import com.saveourtool.save.test.TestFilesContent
-import com.saveourtool.save.test.TestFilesRequest
 import com.saveourtool.save.testsuite.TestSuitesSourceSnapshotKey
 import com.saveourtool.save.utils.*
-import org.springframework.core.io.buffer.DataBuffer
-import org.springframework.core.io.buffer.DataBufferUtils
-import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.springframework.stereotype.Component
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -25,8 +18,6 @@ import kotlin.io.path.*
 class TestSuitesSourceSnapshotStorage(
     configProperties: ConfigProperties,
 ) : AbstractFileBasedStorage<TestSuitesSourceSnapshotKey>(Path.of(configProperties.fileStorage.location) / "testSuites", PATH_PARTS_COUNT) {
-    private val tmpDir = (Path.of(configProperties.fileStorage.location) / "tmp").createDirectories()
-
     /**
      * @param rootDir
      * @param pathToContent
@@ -48,81 +39,6 @@ class TestSuitesSourceSnapshotStorage(
     override fun buildPathToContent(rootDir: Path, key: TestSuitesSourceSnapshotKey): Path = with(key) {
         return rootDir / organizationName / testSuitesSourceName.encodeUrl() / creationTimeInMills.toString() / "$version$ARCHIVE_EXTENSION"
     }
-
-    /**
-     * @param organizationName
-     * @param testSuitesSourceName
-     * @param version
-     * @return true if storage contains snapshot with provided values, otherwise -- false
-     */
-    fun doesContain(
-        organizationName: String,
-        testSuitesSourceName: String,
-        version: String,
-    ): Mono<Boolean> = findKey(organizationName, testSuitesSourceName, version)
-        .map { true }
-        .defaultIfEmpty(false)
-
-    /**
-     * @param organizationName
-     * @param testSuitesSourceName
-     * @param version
-     * @return key which contains provided values
-     */
-    fun findKey(
-        organizationName: String,
-        testSuitesSourceName: String,
-        version: String,
-    ): Mono<TestSuitesSourceSnapshotKey> = list()
-        .filter { it.equalsTo(organizationName, testSuitesSourceName, version) }
-        .singleOrEmpty()
-
-    /**
-     * @param organizationName
-     * @param testSuitesSourceName
-     * @return list of [TestSuitesSourceSnapshotKey] found by provided values
-     */
-    fun list(
-        organizationName: String,
-        testSuitesSourceName: String,
-    ): Flux<TestSuitesSourceSnapshotKey> = list()
-        .filter { it.equalsTo(organizationName, testSuitesSourceName) }
-
-    /**
-     * @param request
-     * @return [TestFilesContent] filled with test files
-     */
-    fun getTestContent(request: TestFilesRequest): Mono<TestFilesContent> = with(request.testSuitesSource) {
-        findKey(organizationName, name, request.version)
-            .orNotFound {
-                "There is no content for tests from $name in $organizationName with version ${request.version}"
-            }
-    }
-        .flatMap { key ->
-            val tmpSourceDir = createTempDirectory(tmpDir, "source-")
-            val tmpArchive = createTempFile(tmpSourceDir, "archive-", ARCHIVE_EXTENSION)
-            val sourceContent = download(key)
-                .map { DefaultDataBufferFactory.sharedInstance.wrap(it) }
-                .cast(DataBuffer::class.java)
-
-            DataBufferUtils.write(sourceContent, tmpArchive.outputStream())
-                .map { DataBufferUtils.release(it) }
-                .collectList()
-                .map {
-                    tmpArchive.extractZipHere()
-                    tmpArchive.deleteExisting()
-                }
-                .map {
-                    val testFilePath = request.test.filePath
-                    val additionalTestFilePath = request.test.additionalFiles.firstOrNull()
-                    val result = TestFilesContent(
-                        tmpSourceDir.resolve(testFilePath).readLines(),
-                        additionalTestFilePath?.let { tmpSourceDir.resolve(it).readLines() },
-                    )
-                    tmpSourceDir.toFile().deleteRecursively()
-                    result
-                }
-        }
 
     private fun String.encodeUrl(): String = URLEncoder.encode(this, StandardCharsets.UTF_8)
 

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/OrganizationControllerTest.kt
@@ -7,7 +7,6 @@ import com.saveourtool.save.backend.repository.*
 import com.saveourtool.save.backend.security.OrganizationPermissionEvaluator
 import com.saveourtool.save.backend.security.ProjectPermissionEvaluator
 import com.saveourtool.save.backend.service.*
-import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
 import com.saveourtool.save.authservice.utils.AuthenticationDetails
 import com.saveourtool.save.backend.S11nTestConfig
 import com.saveourtool.save.backend.utils.mutateMockedUser
@@ -73,7 +72,7 @@ import java.util.concurrent.TimeUnit
     MockBean(TestSuiteRepository::class),
     MockBean(TestRepository::class),
     MockBean(TestExecutionRepository::class),
-    MockBean(TestSuitesSourceSnapshotStorage::class),
+    MockBean(TestsSourceVersionService::class),
     MockBean(ExecutionRepository::class),
     MockBean(AgentStatusRepository::class),
     MockBean(AgentRepository::class),

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/TestSuitesControllerTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/controller/TestSuitesControllerTest.kt
@@ -3,7 +3,7 @@ package com.saveourtool.save.backend.controller
 import com.saveourtool.save.backend.SaveApplication
 import com.saveourtool.save.backend.controllers.ProjectController
 import com.saveourtool.save.backend.repository.*
-import com.saveourtool.save.backend.storage.TestSuitesSourceSnapshotStorage
+import com.saveourtool.save.backend.service.TestsSourceVersionService
 import com.saveourtool.save.backend.utils.MySqlExtension
 import com.saveourtool.save.entities.TestSuite
 import com.saveourtool.save.testsuite.TestSuiteDto
@@ -50,7 +50,7 @@ class TestSuitesControllerTest {
     lateinit var testSuitesSourceRepository: TestSuitesSourceRepository
 
     @Autowired
-    lateinit var testSuitesSourceSnapshotStorage: TestSuitesSourceSnapshotStorage
+    lateinit var testsSourceVersionService: TestsSourceVersionService
 
     @MockBean
     lateinit var scheduler: Scheduler

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/test/TestsSourceVersionInfo.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/test/TestsSourceVersionInfo.kt
@@ -1,0 +1,24 @@
+package com.saveourtool.save.test
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.Serializable
+
+typealias TestsSourceVersionInfoList = List<TestsSourceVersionInfo>
+
+/**
+ * @property organizationName
+ * @property sourceName
+ * @property version
+ * @property creationTime
+ * @property commitId
+ * @property commitTime
+ */
+@Serializable
+data class TestsSourceVersionInfo(
+    val organizationName: String,
+    val sourceName: String,
+    val version: String,
+    val creationTime: LocalDateTime,
+    val commitId: String,
+    val commitTime: LocalDateTime,
+)

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/testsuite/TestSuitesSourceSnapshotKey.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/testsuite/TestSuitesSourceSnapshotKey.kt
@@ -3,8 +3,6 @@ package com.saveourtool.save.testsuite
 import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
 
-typealias TestSuitesSourceSnapshotKeyList = List<TestSuitesSourceSnapshotKey>
-
 /**
  * @property organizationName
  * @property testSuitesSourceName

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/DateTimeUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/DateTimeUtils.kt
@@ -17,9 +17,9 @@ fun Long.millisToInstant(): Instant = Instant.fromEpochMilliseconds(this)
 fun Long.secondsToInstant(): Instant = Instant.fromEpochSeconds(this)
 
 /**
- * @return pretty string representation of [Instant]
+ * @return pretty string representation of [LocalDateTime]
  */
-fun Instant.prettyPrint() = this.toString()
+fun LocalDateTime.prettyPrint() = this.toString()
     .replace("T", " ")
     .replace("Z", "")
     .replace("-", ".")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationTestsMenu.kt
@@ -14,6 +14,7 @@ import com.saveourtool.save.frontend.components.basic.testsuitessources.fetch.te
 import com.saveourtool.save.frontend.components.basic.testsuitessources.showTestSuiteSourceUpsertModal
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.frontend.utils.loadingHandler
+import com.saveourtool.save.test.*
 import com.saveourtool.save.testsuite.*
 
 import csstype.ClassName
@@ -72,8 +73,8 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
     )
 
     val (selectedTestSuitesSource, setSelectedTestSuitesSource) = useState<TestSuitesSourceDto>()
-    val (testSuitesSourceSnapshotKeys, setTestSuitesSourceSnapshotKeys) = useState(emptyList<TestSuitesSourceSnapshotKey>())
-    val fetchTestSuitesSourcesSnapshotKeys = useDeferredRequest {
+    val (testsSourceVersionInfoList, setTestsSourceVersionInfoList) = useState(emptyList<TestsSourceVersionInfo>())
+    val fetchTestsSourcesVersionInfoList = useDeferredRequest {
         selectedTestSuitesSource?.let { testSuitesSource ->
             val response = get(
                 url = "$apiUrl/test-suites-sources/${testSuitesSource.organizationName}/${encodeURIComponent(testSuitesSource.name)}/list-snapshot",
@@ -82,25 +83,25 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
             )
             if (response.ok) {
                 response.unsafeMap {
-                    it.decodeFromJsonString<TestSuitesSourceSnapshotKeyList>()
+                    it.decodeFromJsonString<TestsSourceVersionInfoList>()
                 }.let {
-                    setTestSuitesSourceSnapshotKeys(it)
+                    setTestsSourceVersionInfoList(it)
                 }
             } else {
-                setTestSuitesSourceSnapshotKeys(emptyList())
+                setTestsSourceVersionInfoList(emptyList())
             }
         }
     }
 
-    val (testSuitesSourceSnapshotKeyToDelete, setTestSuitesSourceSnapshotKeyToDelete) = useState<TestSuitesSourceSnapshotKey>()
+    val (testsSourceVersionInfoToDelete, setTestsSourceVersionInfoToDelete) = useState<TestsSourceVersionInfo>()
     val deleteTestSuitesSourcesSnapshotKey = useDeferredRequest {
-        testSuitesSourceSnapshotKeyToDelete?.let { key ->
+        testsSourceVersionInfoToDelete?.let { key ->
             delete(
-                url = "$apiUrl/test-suites-sources/${key.organizationName}/${encodeURIComponent(key.testSuitesSourceName)}/delete-test-suites-and-snapshot?version=${key.version}",
+                url = "$apiUrl/test-suites-sources/${key.organizationName}/${encodeURIComponent(key.sourceName)}/delete-test-suites-and-snapshot?version=${key.version}",
                 headers = jsonHeaders,
                 loadingHandler = ::loadingHandler,
             )
-            setTestSuitesSourceSnapshotKeyToDelete(null)
+            setTestsSourceVersionInfoToDelete(null)
         }
     }
     val selectHandler: (TestSuitesSourceDto) -> Unit = {
@@ -108,7 +109,7 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
             setSelectedTestSuitesSource(null)
         } else {
             setSelectedTestSuitesSource(it)
-            fetchTestSuitesSourcesSnapshotKeys()
+            fetchTestsSourcesVersionInfoList()
         }
     }
     val fetchHandler: (TestSuitesSourceDto) -> Unit = {
@@ -120,14 +121,14 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
         setTestSuiteSourceToUpsert(it)
         testSuitesSourceUpsertWindowOpenness.openWindow()
     }
-    val deleteHandler: (TestSuitesSourceSnapshotKey) -> Unit = {
-        if (window.confirm("Are you sure you want to delete snapshot ${it.version} of ${it.testSuitesSourceName}?")) {
-            setTestSuitesSourceSnapshotKeyToDelete(it)
+    val deleteHandler: (TestsSourceVersionInfo) -> Unit = {
+        if (window.confirm("Are you sure you want to delete snapshot ${it.version} of ${it.sourceName}?")) {
+            setTestsSourceVersionInfoToDelete(it)
             deleteTestSuitesSourcesSnapshotKey()
-            setTestSuitesSourceSnapshotKeys(testSuitesSourceSnapshotKeys.filterNot(it::equals))
+            setTestsSourceVersionInfoList(testsSourceVersionInfoList.filterNot(it::equals))
         }
     }
-    val refreshTestSuitesSourcesSnapshotKey = useDeferredRequest {
+    val refreshTestSuitesSources = useDeferredRequest {
         val response = getTestSuitesSourcesWithId(props.organizationName)
         if (response.ok) {
             setTestSuitesSources(response.decodeFromJsonString<TestSuitesSourceDtoList>())
@@ -136,8 +137,8 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
         }
     }
     val refreshHandler: () -> Unit = {
-        refreshTestSuitesSourcesSnapshotKey()
-        fetchTestSuitesSourcesSnapshotKeys()
+        refreshTestSuitesSources()
+        fetchTestsSourcesVersionInfoList()
     }
     val (managePermissionsMode, setManagePermissionsMode) = useState<PermissionManagerMode?>(null)
     manageTestSuitePermissionsComponent {
@@ -171,9 +172,9 @@ private fun organizationTestsMenu() = FC<OrganizationTestsMenuProps> { props ->
         className = ClassName("mb-2 d-flex justify-content-center")
         when (selectedTestSuitesSource) {
             null -> showTestSuitesSources(testSuitesSources, selectHandler, fetchHandler, editHandler, refreshHandler)
-            else -> showTestSuitesSourceSnapshotKeys(
+            else -> showTestsSourceVersionInfoList(
                 selectedTestSuitesSource,
-                testSuitesSourceSnapshotKeys,
+                testsSourceVersionInfoList,
                 selectHandler,
                 editHandler,
                 fetchHandler,

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/TestSuitesSourcesDisplayer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/TestSuitesSourcesDisplayer.kt
@@ -26,9 +26,6 @@ import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.ul
 
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
-
 /**
  * Display single TestSuiteSource as list option
  *

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/TestSuitesSourcesDisplayer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/TestSuitesSourcesDisplayer.kt
@@ -9,8 +9,9 @@ package com.saveourtool.save.frontend.components.basic.organizations
 
 import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.buttonBuilder
+import com.saveourtool.save.test.TestsSourceVersionInfo
+import com.saveourtool.save.test.TestsSourceVersionInfoList
 import com.saveourtool.save.testsuite.*
-import com.saveourtool.save.utils.millisToInstant
 import com.saveourtool.save.utils.prettyPrint
 
 import csstype.ClassName
@@ -24,6 +25,9 @@ import react.dom.html.ReactHTML.li
 import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.ul
+
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 
 /**
  * Display single TestSuiteSource as list option
@@ -135,30 +139,30 @@ fun ChildrenBuilder.showTestSuitesSources(
 }
 
 /**
- * Display list of [TestSuitesSourceSnapshotKey] of [selectedTestSuiteSource]
+ * Display list of [TestsSourceVersionInfo] of [selectedTestSuiteSource]
  *
  * @param selectedTestSuiteSource
- * @param testSuitesSourcesSnapshotKeys
+ * @param testsSourceVersionInfoList
  * @param selectHandler callback invoked on TestSuitesSource selection
  * @param editHandler callback invoked on edit TestSuitesSource button pressed
  * @param fetchHandler callback invoked on fetch button pressed
- * @param deleteHandler callback invoked on [TestSuitesSourceSnapshotKey] deletion
+ * @param deleteHandler callback invoked on [TestsSourceVersionInfo] deletion
  * @param refreshHandler
  */
 @Suppress("LongParameterList", "TOO_MANY_PARAMETERS")
-fun ChildrenBuilder.showTestSuitesSourceSnapshotKeys(
+fun ChildrenBuilder.showTestsSourceVersionInfoList(
     selectedTestSuiteSource: TestSuitesSourceDto,
-    testSuitesSourcesSnapshotKeys: TestSuitesSourceSnapshotKeyList,
+    testsSourceVersionInfoList: TestsSourceVersionInfoList,
     selectHandler: (TestSuitesSourceDto) -> Unit,
     editHandler: (TestSuitesSourceDto) -> Unit,
     fetchHandler: (TestSuitesSourceDto) -> Unit,
-    deleteHandler: (TestSuitesSourceSnapshotKey) -> Unit,
+    deleteHandler: (TestsSourceVersionInfo) -> Unit,
     refreshHandler: () -> Unit,
 ) {
     ul {
         className = ClassName("list-group col-8")
         showTestSuitesSourceAsListElement(selectedTestSuiteSource, true, selectHandler, editHandler, fetchHandler, refreshHandler)
-        if (testSuitesSourcesSnapshotKeys.isEmpty()) {
+        if (testsSourceVersionInfoList.isEmpty()) {
             li {
                 className = ClassName("list-group-item list-group-item-light")
                 +"This source is not fetched yet..."
@@ -178,21 +182,21 @@ fun ChildrenBuilder.showTestSuitesSourceSnapshotKeys(
                     }
                 }
             }
-            testSuitesSourcesSnapshotKeys.forEach { testSuitesSourceSnapshotKey ->
+            testsSourceVersionInfoList.forEach { testsSourceVersionInfo ->
                 li {
                     className = ClassName("list-group-item")
                     div {
                         className = ClassName("clearfix")
                         div {
                             className = ClassName("float-left")
-                            +testSuitesSourceSnapshotKey.version
+                            +testsSourceVersionInfo.version
                         }
                         buttonBuilder(faTimesCircle, style = null, classes = "float-right btn-sm pt-0 pb-0") {
-                            deleteHandler(testSuitesSourceSnapshotKey)
+                            deleteHandler(testsSourceVersionInfo)
                         }
                         div {
                             className = ClassName("float-right")
-                            +testSuitesSourceSnapshotKey.creationTimeInMills.millisToInstant().prettyPrint()
+                            +testsSourceVersionInfo.creationTime.toInstant(TimeZone.UTC).prettyPrint()
                         }
                     }
                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/TestSuitesSourcesDisplayer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/TestSuitesSourcesDisplayer.kt
@@ -196,7 +196,7 @@ fun ChildrenBuilder.showTestsSourceVersionInfoList(
                         }
                         div {
                             className = ClassName("float-right")
-                            +testsSourceVersionInfo.creationTime.toInstant(TimeZone.UTC).prettyPrint()
+                            +testsSourceVersionInfo.creationTime.prettyPrint()
                         }
                     }
                 }


### PR DESCRIPTION
### What's done:
- added `TestsSourceVersionInfo`
- added `TestsSourceVersionService`
- removed direct usage of `TestSuitesSourceSnapshotKey` and `TestSuitesSourceSnapshotStorage`

It's part of #1717