### PR TITLE
Move marking execution as `OBSOLETE` on deletion of test suites to ExecutionService

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/LnkExecutionTestSuiteRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/LnkExecutionTestSuiteRepository.kt
@@ -2,6 +2,7 @@ package com.saveourtool.save.backend.repository
 
 import com.saveourtool.save.entities.Execution
 import com.saveourtool.save.entities.LnkExecutionTestSuite
+import com.saveourtool.save.entities.TestSuite
 import com.saveourtool.save.spring.repository.BaseEntityRepository
 import org.springframework.stereotype.Repository
 
@@ -33,4 +34,10 @@ interface LnkExecutionTestSuiteRepository : BaseEntityRepository<LnkExecutionTes
      * @return [LnkExecutionTestSuite] by [testSuiteId]
      */
     fun findByTestSuiteId(testSuiteId: Long): List<LnkExecutionTestSuite>
+
+    /**
+     * @param testSuites list of manageable test suites
+     * @return [LnkExecutionTestSuite] by [testSuites]
+     */
+    fun findAllByTestSuiteIn(testSuites: List<TestSuite>): List<LnkExecutionTestSuite>
 }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ExecutionService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ExecutionService.kt
@@ -41,6 +41,7 @@ class ExecutionService(
     private val lnkExecutionTestSuiteService: LnkExecutionTestSuiteService,
     private val fileRepository: FileRepository,
     private val lnkExecutionFileRepository: LnkExecutionFileRepository,
+    private val lnkExecutionTestSuiteRepository: LnkExecutionTestSuiteRepository,
     @Lazy private val agentService: AgentService,
     private val agentStatusService: AgentStatusService,
     private val testAnalysisService: TestAnalysisService,
@@ -176,15 +177,6 @@ class ExecutionService(
             .map { it.requiredId() }
             .let { deleteByIds(it) }
     }
-
-    /**
-     * Get all executions, which contains provided test suite id
-     *
-     * @param testSuiteId
-     * @return list of [Execution]'s
-     */
-    fun getExecutionsByTestSuiteId(testSuiteId: Long): List<Execution> =
-            lnkExecutionTestSuiteService.getAllExecutionsByTestSuiteId(testSuiteId)
 
     /**
      * @param projectCoordinates
@@ -327,6 +319,29 @@ class ExecutionService(
         lnkExecutionFileRepository.findAllByFile(file)
             .also {
                 lnkExecutionFileRepository.deleteAll(it)
+            }
+            .map { it.execution }
+            .forEach {
+                updateExecutionStatus(it, ExecutionStatus.OBSOLETE)
+            }
+    }
+
+    /**
+     * Unlink provided list of [TestSuite]s from all [Execution]s
+     *
+     * @param testSuites
+     */
+    @Transactional
+    fun unlinkTestSuiteFromAllExecution(testSuites: List<TestSuite>) {
+        lnkExecutionTestSuiteRepository.findAllByTestSuiteIn(testSuites)
+            .also { links ->
+                val linksByExecutions = lnkExecutionTestSuiteRepository.findByExecutionIdIn(links.map { it.execution.requiredId() })
+                require(
+                    linksByExecutions.isEmpty() || linksByExecutions.size == links.size
+                ) {
+                    "Expected that we remove all test suites related to a single execution at once"
+                }
+                lnkExecutionTestSuiteRepository.deleteAll(links)
             }
             .map { it.execution }
             .forEach {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkExecutionTestSuiteService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkExecutionTestSuiteService.kt
@@ -34,25 +34,11 @@ class LnkExecutionTestSuiteService(
                 }
 
     /**
-     * @param testSuiteId manageable test suite
-     * @return all [Execution]s with [testSuiteId]
-     */
-    fun getAllExecutionsByTestSuiteId(testSuiteId: Long) = lnkExecutionTestSuiteRepository.findByTestSuiteId(testSuiteId)
-        .map {
-            it.execution
-        }
-
-    /**
      * @param executionIds IDs of manageable executions
      */
     fun deleteByExecutionIds(executionIds: Collection<Long>) {
         lnkExecutionTestSuiteRepository.deleteAll(lnkExecutionTestSuiteRepository.findByExecutionIdIn(executionIds))
     }
-
-    /**
-     * @param [lnkExecutionTestSuite] link execution to testSuites
-     */
-    fun save(lnkExecutionTestSuite: LnkExecutionTestSuite): LnkExecutionTestSuite = lnkExecutionTestSuiteRepository.save(lnkExecutionTestSuite)
 
     /**
      * @param [lnkExecutionTestSuites] link execution to testSuites


### PR DESCRIPTION
It's part of #1717