### PR TITLE
Make sure artifact signing is applied *after* Maven configurations are created

### DIFF
--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/publishing-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/publishing-configuration.gradle.kts
@@ -35,7 +35,12 @@ run {
 run {
     configurePublications()
 
-    if (hasProperty("signingKey")) {
-        configureSigning()
-    }
+    /*-
+     * This alone is not sufficient if a sub-module has a custom `publishing {}`
+     * section, because, in most cases, this function is called before any Maven
+     * configuration is created.
+     *
+     * Should be explicitly called after each custom `publishing {}` section.
+     */
+    configureSigning()
 }

--- a/save-api/build.gradle.kts
+++ b/save-api/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.saveourtool.save.buildutils.configureSigning
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
 @Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
@@ -59,3 +60,5 @@ publishing {
         }
     }
 }
+
+configureSigning()

--- a/test-analysis-core/build.gradle.kts
+++ b/test-analysis-core/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.saveourtool.save.buildutils.configureSigning
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
 plugins {
@@ -51,3 +52,5 @@ publishing {
         }
     }
 }
+
+configureSigning()


### PR DESCRIPTION
This fixes an issue when only artifacts (w/o *.asc digital signatures) get uploaded to Sonatype when a new release is created.