### PR TITLE
Make sure artifact signing is applied after Maven configurations are created (take 2)

### DIFF
--- a/.github/workflows/save-api-release.yml
+++ b/.github/workflows/save-api-release.yml
@@ -35,6 +35,7 @@ jobs:
           gradle-version: wrapper
           arguments: |
             --build-cache
+            --console=rich
             -Prelease
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
@@ -33,17 +33,37 @@ import org.gradle.plugins.signing.SigningExtension
  */
 fun Project.configureSigning() {
     if (hasProperty("signingKey")) {
-        configure<SigningExtension> {
-            useInMemoryPgpKeys(property("signingKey") as String?, property("signingPassword") as String?)
-            val publications = extensions.getByType<PublishingExtension>().publications
-            val publicationCount = publications.size
-            val message = "The following $publicationCount publication(s) are getting signed: ${publications.map(Named::getName)}"
-            val style = when (publicationCount) {
-                0 -> Failure
-                else -> Success
-            }
-            styledOut(logCategory = "signing").style(style).println(message)
-            sign(*publications.toTypedArray())
+        /*
+         * GitHub Actions.
+         */
+        configureSigningCommon {
+            useInMemoryPgpKeys(property("signingKey") as String?, findProperty("signingPassword") as String?)
+        }
+    } else if (
+        hasProperties(
+            "signing.keyId",
+            "signing.password",
+            "signing.secretKeyRingFile",
+        )
+    ) {
+        /*-
+         * Pure-Java signing mechanism via `org.bouncycastle.bcpg`.
+         *
+         * Requires an 8-digit (short form) PGP key id and a present `~/.gnupg/secring.gpg`
+         * (for gpg 2.1, run
+         * `gpg --keyring secring.gpg --export-secret-keys >~/.gnupg/secring.gpg`
+         * to generate one).
+         */
+        configureSigningCommon()
+    } else if (hasProperty("signing.gnupg.keyName")) {
+        /*-
+         * Use an external `gpg` executable.
+         *
+         * On Windows, you may need to additionally specify the path to `gpg` via
+         * `signing.gnupg.executable`.
+         */
+        configureSigningCommon {
+            useGpgCmd()
         }
     }
 }
@@ -110,5 +130,37 @@ internal fun Project.configureNexusPublishing() {
     }
 }
 
+/**
+ * @param useKeys the block which configures the PGP keys. Use either
+ *   [SigningExtension.useInMemoryPgpKeys], [SigningExtension.useGpgCmd], or an
+ *   empty lambda.
+ * @see SigningExtension.useInMemoryPgpKeys
+ * @see SigningExtension.useGpgCmd
+ */
+private fun Project.configureSigningCommon(useKeys: SigningExtension.() -> Unit = {}) {
+    configure<SigningExtension> {
+        useKeys()
+        val publications = extensions.getByType<PublishingExtension>().publications
+        val publicationCount = publications.size
+        val message = "The following $publicationCount publication(s) are getting signed: ${publications.map(Named::getName)}"
+        val style = when (publicationCount) {
+            0 -> Failure
+            else -> Success
+        }
+        styledOut(logCategory = "signing").style(style).println(message)
+        sign(*publications.toTypedArray())
+    }
+}
+
 private fun Project.styledOut(logCategory: String): StyledTextOutput =
         serviceOf<StyledTextOutputFactory>().create(logCategory)
+
+/**
+ * Determines if this project has all the given properties.
+ *
+ * @param propertyNames the names of the properties to locate.
+ * @return `true` if this project has all the given properties, `false` otherwise.
+ * @see Project.hasProperty
+ */
+private fun Project.hasProperties(vararg propertyNames: String): Boolean =
+        propertyNames.asSequence().all(this::hasProperty)

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/publishing-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/publishing-configuration.gradle.kts
@@ -34,13 +34,4 @@ run {
 
 run {
     configurePublications()
-
-    /*-
-     * This alone is not sufficient if a sub-module has a custom `publishing {}`
-     * section, because, in most cases, this function is called before any Maven
-     * configuration is created.
-     *
-     * Should be explicitly called after each custom `publishing {}` section.
-     */
-    configureSigning()
 }

--- a/save-cloud-common/build.gradle.kts
+++ b/save-cloud-common/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.saveourtool.save.buildutils.configureSigning
+
 @Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
 plugins {
     kotlin("multiplatform")
@@ -76,3 +78,5 @@ kotlin {
         }
     }
 }
+
+configureSigning()


### PR DESCRIPTION
 - The previous PR (which partially fixes the issue) is #1754.
 - Now, for Kotlin MPP, all 4 publications (`kotlinMultiplatform`, `js`, `jvm`, and `linuxx64`) get signed.
 - Added the ability to sign artifacts via either pure-Java _BCPG_ (`signing.keyId`), or via external `gpg` executable (`signing.gnupg.keyName`). Now, it's possible to run `gradle signKotlinMultiplatformPublication signMavenPublication publishToMavenLocal` to test locally whether signing works correctly.