### PR TITLE
When fetching test suites, use the overloaded `post()` version and `jso {}` to construct request parameters

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuitessources/fetch/TestSuitesSourceFetcher.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuitessources/fetch/TestSuitesSourceFetcher.kt
@@ -17,6 +17,7 @@ import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.testsuite.TestSuitesSourceDto
 import com.saveourtool.save.testsuite.TestSuitesSourceFetchMode
 import csstype.ClassName
+import js.core.jso
 import react.*
 import react.dom.html.ButtonType
 import react.dom.html.ReactHTML.button
@@ -73,7 +74,11 @@ fun ChildrenBuilder.testSuitesSourceFetcher(
     val triggerFetchTestSuiteSource = useDeferredRequest {
         post(
             url = with(testSuitesSource) {
-                "$apiUrl/test-suites-sources/$organizationName/${encodeURIComponent(name)}/fetch?mode=$selectedFetchMode&version=$selectedValue"
+                "$apiUrl/test-suites-sources/$organizationName/${encodeURIComponent(name)}/fetch"
+            },
+            params = jso<dynamic> {
+                mode = selectedFetchMode
+                version = selectedValue
             },
             headers = jsonHeaders,
             loadingHandler = ::loadingHandler,


### PR DESCRIPTION
Related: #1716