### PR TITLE
Fix for diktat download to tool storage

### DIFF
--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/service/DownloadToolService.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/service/DownloadToolService.kt
@@ -1,9 +1,11 @@
 package com.saveourtool.save.demo.service
 
 import com.saveourtool.save.demo.config.ConfigProperties
+import com.saveourtool.save.demo.diktat.DiktatDemoTool
 import com.saveourtool.save.demo.entity.*
 import com.saveourtool.save.demo.storage.ToolKey
 import com.saveourtool.save.demo.storage.ToolStorage
+import com.saveourtool.save.demo.storage.toToolKey
 import com.saveourtool.save.demo.utils.toByteBufferFlux
 import com.saveourtool.save.domain.ProjectCoordinates
 import com.saveourtool.save.utils.asyncEffectIf
@@ -122,6 +124,8 @@ class DownloadToolService(
         .zipWith(toolService.getSupportedTools().toMono())
         .flatMapIterable { (availableFiles, supportedTools) ->
             supportedTools.map { it.toToolKey() }
+                .plus(DiktatDemoTool.DIKTAT.toToolKey("diktat-1.2.3.jar"))
+                .plus(DiktatDemoTool.KTLINT.toToolKey("ktlint"))
                 .filter { it !in availableFiles }
                 .also { tools ->
                     if (tools.isEmpty()) {


### PR DESCRIPTION
### What's done:
 * Fixed an issue with diktat download - not it is hardcoded to be downloaded to storage (will be removed after #1770)