### PR TITLE
Avoid calling `block()` on a `MonoMapFuseable` within a non-blocking …

### DIFF
--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/DownloadFilesTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/DownloadFilesTest.kt
@@ -19,6 +19,7 @@ import com.saveourtool.save.entities.*
 import com.saveourtool.save.permission.Permission
 import com.saveourtool.save.utils.mapToInputStream
 import com.saveourtool.save.v1
+import org.jetbrains.annotations.Blocking
 
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -298,6 +299,7 @@ class DownloadFilesTest {
 
         private fun FileDto.candidateTo(file: File) = name == file.name && projectCoordinates == file.project.toProjectCoordinates()
 
+        @Blocking
         private fun Flux<ByteBuffer>.collectToString(): String? = mapToInputStream()
             .map { it.bufferedReader().readText() }
             .block()

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/DownloadFilesTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/DownloadFilesTest.kt
@@ -46,12 +46,14 @@ import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.reactive.function.BodyInserters
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 import java.nio.ByteBuffer
 
 import java.nio.file.Path
 import java.time.LocalDateTime
 import java.util.*
+import java.util.concurrent.Future
 import kotlin.io.path.*
 
 @ActiveProfiles("test")
@@ -299,9 +301,25 @@ class DownloadFilesTest {
 
         private fun FileDto.candidateTo(file: File) = name == file.name && projectCoordinates == file.project.toProjectCoordinates()
 
+        /**
+         * Sometimes, the [block][Mono.block] operation of the resulting [Mono]
+         * may get executed using a non-blocking scheduler, such as
+         * [Schedulers.single] or [Schedulers.parallel], resulting in a failure
+         * at [reactor.core.publisher.BlockingSingleSubscriber.blockingGet].
+         *
+         * As a workaround, we first convert the [Mono] to a [Future].
+         *
+         * See [#1787](https://github.com/saveourtool/save-cloud/pull/1787) for details.
+         *
+         * @see Mono.block
+         * @see Schedulers.single
+         * @see Schedulers.parallel
+         * @see reactor.core.publisher.BlockingSingleSubscriber.blockingGet
+         */
         @Blocking
         private fun Flux<ByteBuffer>.collectToString(): String? = mapToInputStream()
             .map { it.bufferedReader().readText() }
-            .block()
+            .toFuture()
+            .get()
     }
 }


### PR DESCRIPTION
Apparently, _Mockito_'s `argThat()` is agnostic of reactive types such as `Mono` and `Flux`, meaning there's no way to compare reactive values directly, w/o evaluation. This leads to failures like [this one](https://scans.gradle.com/s/pnxk5cjsn2y5y/tests/:save-backend:test/com.saveourtool.save.backend.DownloadFilesTest/checkUpload()?top-execution=1):

```
11:27:19.219 [parallel-2] ERROR o.s.b.a.w.r.e.AbstractErrorWebExceptionHandler - [690a325d]  500 Server Error for HTTP POST "/api/v1/files/Huawei/huaweiName/upload" java.lang.IllegalStateException: block()/blockFirst()/blockLast() are blocking, which is not supported in thread parallel-2	
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:83)	
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 	
Error has been observed at the following site(s):	
	*__checkpoint ⇢ Handler com.saveourtool.save.backend.controllers.FileController#upload(Mono, String, String, Authentication) [DispatcherHandler]	
	*__checkpoint ⇢ com.saveourtool.save.backend.configs.UserLoggingFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.authorization.AuthorizationWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.authorization.ExceptionTranslationWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.authentication.logout.LogoutWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.savedrequest.ServerRequestCacheWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.context.SecurityContextServerWebExchangeWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.context.ReactorContextWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.header.HttpHeaderWriterWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.config.web.server.ServerHttpSecurity$ServerWebExchangeReactorContextWebFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.web.server.WebFilterChainProxy [DefaultWebFilterChain]	
	*__checkpoint ⇢ org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers$MutatorFilter [DefaultWebFilterChain]	
	*__checkpoint ⇢ HTTP POST "/api/v1/files/Huawei/huaweiName/upload" [ExceptionHandlingWebHandler]	
Original Stack Trace:	
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:83)	
		at reactor.core.publisher.Mono.block(Mono.java:1742)	
		at com.saveourtool.save.backend.DownloadFilesTest$Companion.collectToString(DownloadFilesTest.kt:303)	
		at com.saveourtool.save.backend.DownloadFilesTest$Companion.access$collectToString(DownloadFilesTest.kt:288)	
		at com.saveourtool.save.backend.DownloadFilesTest$checkUpload$4.invoke(DownloadFilesTest.kt:188)
```

&mdash; when the body of `argThat()` is itself executed within a non-blocking `Scheduler` like `Schedulers.single()` or `Schedulers.parallel()`.


So far, this has only been observed for instances of `reactor.core.publisher.MonoMapFuseable` (other `Mono` implementations have their `block()` implemented differently). Here's the minimal repro (w/o _Mockito_, but prone to the same kind of failure):

```kotlin
    @Test
    fun f() {
        val result = Mono.fromCallable {
            val mono = Flux.fromIterable(listOf(1, 2)).reduce { t, u -> t + u }.map { it + 1 }
            assertEquals("reactor.core.publisher.MonoMapFuseable", mono.javaClass.name)

            mono.block()
        }.subscribeOn(Schedulers.parallel())
            .block()
        assertEquals(4, result)
    }
```

The only workaround found so far is calling 

```kotlin
mono.toFuture().get()
```

instead of

```kotlin
mono.block()
```