### PR TITLE
TestSuiteSelector search mode fix

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -91,7 +91,7 @@ class TestSuitesService(
                 .withMatcher("name", ExampleMatcher.GenericPropertyMatchers.contains().ignoreCase())
                 .withMatcher("language", ExampleMatcher.GenericPropertyMatchers.contains().ignoreCase())
                 .withMatcher("tags", ExampleMatcher.GenericPropertyMatchers.contains().ignoreCase())
-                .withIgnorePaths("description", "source", "version", "dateAdded", "plugins", "sourceSnapshot")
+                .withIgnorePaths("description", "sourceSnapshot", "version", "dateAdded", "plugins")
                 .let {
                     Example.of(
                         TestSuite(

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/TestSuitesService.kt
@@ -91,7 +91,7 @@ class TestSuitesService(
                 .withMatcher("name", ExampleMatcher.GenericPropertyMatchers.contains().ignoreCase())
                 .withMatcher("language", ExampleMatcher.GenericPropertyMatchers.contains().ignoreCase())
                 .withMatcher("tags", ExampleMatcher.GenericPropertyMatchers.contains().ignoreCase())
-                .withIgnorePaths("description", "source", "version", "dateAdded", "plugins")
+                .withIgnorePaths("description", "source", "version", "dateAdded", "plugins", "sourceSnapshot")
                 .let {
                     Example.of(
                         TestSuite(

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/TestSuite.kt
@@ -15,6 +15,9 @@ import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 
 /**
+ * Keep in mind ExampleMatcher is used with this Entity in TestSuitesService
+ * Do not forget to add new fields to ignorePaths of ExampleMatcher
+ *
  * @property name name of the test suite
  * @property description description of the test suite
  * @property sourceSnapshot snapshot of source, which this test suite is created from


### PR DESCRIPTION
This PR closes #1834

### What's done:
 * Fixed `/filtered` endpoint - @nulls has broken it by adding new field to `TestSuite` forgetting about `ExampleMatcher`'s `ignorePaths`