### PR TITLE
On the "test sources selector view" change the behaviour of "apply" button

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestSuitesDisplayer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestSuitesDisplayer.kt
@@ -39,7 +39,7 @@ fun ChildrenBuilder.showAvailableTestSuites(
                 ""
             }
             a {
-                className = ClassName("list-group-item list-group-item-action $active")
+                className = ClassName("btn list-group-item list-group-item-action $active")
                 onClick = {
                     onTestSuiteClick(testSuite)
                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelector.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelector.kt
@@ -159,7 +159,8 @@ private fun ChildrenBuilder.showTestSuitesSelectorModal(
         currentlySelectedTestSuites = initTestSuites
         windowOpenness.closeWindow()
     }
-    showTestSuitesSelectorModal(windowOpenness.isOpen(), currentOrganizationName, selectorPurpose, initTestSuites, onSubmit, onTestSuiteIdUpdate, onCancel)
+    showTestSuitesSelectorModal(windowOpenness.isOpen(), currentOrganizationName, selectorPurpose, initTestSuites, currentlySelectedTestSuites, onSubmit, onTestSuiteIdUpdate,
+        onCancel)
 }
 
 @Suppress(
@@ -173,6 +174,7 @@ private fun ChildrenBuilder.showTestSuitesSelectorModal(
     currentOrganizationName: String,
     selectorPurpose: TestSuiteSelectorPurpose,
     preselectedTestSuites: List<TestSuiteVersioned>,
+    currentlySelectedTestSuites: List<TestSuiteVersioned>,
     onSubmit: () -> Unit,
     onTestSuitesUpdate: (List<TestSuiteVersioned>) -> Unit,
     onCancel: () -> Unit,
@@ -220,6 +222,7 @@ private fun ChildrenBuilder.showTestSuitesSelectorModal(
                             type = ButtonType.button
                             className = ClassName("btn btn-primary mt-4")
                             +"Apply"
+                            disabled = currentlySelectedTestSuites.isEmpty()
                             onClick = {
                                 onSubmit()
                             }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelectorBrowserMode.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/testsuiteselector/TestSuiteSelectorBrowserMode.kt
@@ -141,7 +141,7 @@ private fun ChildrenBuilder.showBreadcrumb(
     }
 }
 
-private fun ChildrenBuilder.showAvaliableOptions(
+private fun ChildrenBuilder.showAvailableOptions(
     options: List<String>,
     onOptionClick: (String) -> Unit,
 ) {
@@ -154,8 +154,8 @@ private fun ChildrenBuilder.showAvaliableOptions(
             }
         } else {
             options.forEach { option ->
-                li {
-                    className = ClassName("list-group-item")
+                a {
+                    className = ClassName("btn text-center list-group-item list-group-item-action")
                     onClick = {
                         onOptionClick(option)
                     }
@@ -305,19 +305,19 @@ private fun testSuiteSelectorBrowserMode() = FC<TestSuiteSelectorBrowserModeProp
         div {
             className = ClassName("")
             when {
-                selectedOrganization == null -> showAvaliableOptions(
+                selectedOrganization == null -> showAvailableOptions(
                     availableOrganizations.filter { it.contains(namePrefix, true) }
                 ) { organization ->
                     setSelectedOrganization(organization)
                     setNamePrefix("")
                 }
-                selectedTestSuiteSource == null -> showAvaliableOptions(
+                selectedTestSuiteSource == null -> showAvailableOptions(
                     availableTestSuiteSources.filter { it.contains(namePrefix, true) }
                 ) { testSuiteSource ->
                     setSelectedTestSuiteSource(testSuiteSource)
                     setNamePrefix("")
                 }
-                selectedTestSuiteVersion == null -> showAvaliableOptions(
+                selectedTestSuiteVersion == null -> showAvailableOptions(
                     availableTestSuitesVersions.filter { it.contains(namePrefix, true) }
                 ) { testSuiteVersion ->
                     setSelectedTestSuiteVersion(testSuiteVersion)


### PR DESCRIPTION

* Now you can't press on Apply button if you don't selected testSuites
* Made all pointers to in the run tab or selector view as clickable

Closes #1832