### PR TITLE
Correct the path/URL manupulation when `saveDemoAgentDistroFileUrl` is unset

### DIFF
--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/DownloadConfiguration.kt
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/DownloadConfiguration.kt
@@ -1,0 +1,42 @@
+@file:JvmName("DownloadConfiguration")
+@file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package com.saveourtool.save.buildutils
+
+import de.undercouch.gradle.tasks.download.Download
+import org.gradle.api.Project
+import java.net.URL
+import java.nio.file.Path
+
+/**
+ * @param urlPropertyName the name of the property that holds the file URL.
+ * @param targetDirectory the name of the target directory (relative to
+ *   [Project.getBuildDir]).
+ * @return the configuration for the [Download] task.
+ */
+fun Project.downloadTaskConfiguration(
+    urlPropertyName: String,
+    targetDirectory: String,
+): Download.() -> Unit = {
+    /*-
+     * `hasProperty()` is not enough here, as it may return `false` even if the
+     * property is set (e.g.: globally).
+     */
+    val fileUrlOrNull = findProperty(urlPropertyName)
+    enabled = fileUrlOrNull != null
+    if (!enabled) {
+        logger.warn("To enable the `$name` task, set the `$urlPropertyName` property.")
+    }
+
+    val fileUrl = URL(fileUrlOrNull?.toString() ?: "file:not-found")
+
+    src { fileUrl }
+    dest {
+        /*
+         * Take only the last segment of potentially multi-segment server-side path.
+         */
+        val fileName = Path.of(fileUrl.file).fileName.toString()
+        buildDir.resolve(targetDirectory).resolve(fileName).normalize()
+    }
+    overwrite(false)
+}

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/save-agent-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/save-agent-configuration.gradle.kts
@@ -6,24 +6,20 @@ package com.saveourtool.save.buildutils
 
 import de.undercouch.gradle.tasks.download.Download
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.*
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
-import java.io.File
+
 plugins {
     kotlin("jvm")
     id("de.undercouch.download")
 }
 
-@Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
-val downloadSaveAgentDistroTaskProvider: TaskProvider<Download> = tasks.register<Download>("downloadSaveAgentDistro") {
-    enabled = findProperty("saveAgentDistroFilepath") != null
-
-    val saveAgentDistroFilepath = findProperty("saveAgentDistroFilepath")?.toString() ?: "file:\\\\not-found"
-    src { saveAgentDistroFilepath }
-    dest { "$buildDir/agentDistro/${File(saveAgentDistroFilepath).name}" }
-
-    overwrite(false)
-}
+val downloadSaveAgentDistroTaskProvider: TaskProvider<Download> = tasks.register(
+    name = "downloadSaveAgentDistro",
+    configuration = downloadTaskConfiguration(
+        urlPropertyName = "saveAgentDistroFilepath",
+        targetDirectory = "agentDistro",
+    ),
+)
 
 dependencies {
     if (!DefaultNativePlatform.getCurrentOperatingSystem().isLinux) {

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/save-demo-agent-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/save-demo-agent-configuration.gradle.kts
@@ -5,25 +5,20 @@
 package com.saveourtool.save.buildutils
 
 import de.undercouch.gradle.tasks.download.Download
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.*
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
-import java.nio.file.Path
 
 plugins {
     kotlin("jvm")
     id("de.undercouch.download")
 }
 
-@Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
-val downloadSaveDemoAgentDistroTaskProvider: TaskProvider<Download> = tasks.register<Download>("downloadSaveDemoAgentDistro") {
-    enabled = findProperty("saveDemoAgentDistroFilepath") != null
-
-    val saveDemoAgentDistroFilepath = findProperty("saveDemoAgentDistroFilepath")?.toString() ?: "file://not-found"
-    src { saveDemoAgentDistroFilepath }
-    dest { "$buildDir/demoAgentDistro/${Path.of(saveDemoAgentDistroFilepath).fileName}" }
-    overwrite(false)
-}
+val downloadSaveDemoAgentDistroTaskProvider: TaskProvider<Download> = tasks.register(
+    name = "downloadSaveDemoAgentDistro",
+    configuration = downloadTaskConfiguration(
+        urlPropertyName = "saveDemoAgentDistroFileUrl",
+        targetDirectory = "demoAgentDistro",
+    ),
+)
 
 dependencies {
     if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {


### PR DESCRIPTION
This change also renames the property from `saveDemoAgentDistroFilepath` to `saveDemoAgentDistroFileUrl`.