### PR TITLE
save-demo-agent wrong exception catching

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -49,7 +49,7 @@ inline fun <reified C : Any> parseConfig(configName: String = "agent.toml"): C =
  * Parse config file or apply default if none was found
  * Notice that [C] should be serializable
  *
- * @param defaultConfig config that should be set if no config was found ([FileNotFoundException])
+ * @param defaultConfig config that should be set if no config was found
  * @param configName name of a toml config file, agent.toml by default
  * @return [C] filled with configuration information
  */

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -58,7 +58,7 @@ inline fun <reified C : Any> parseConfigOrDefault(
     configName: String = "agent.toml",
 ): C = try {
     parseConfig(configName)
-} catch (e: Exception) {
+} catch (e: FileNotFoundException) {
     logInfo("Config file $configName not found, falling back to default config.")
     defaultConfig
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -49,7 +49,7 @@ inline fun <reified C : Any> parseConfig(configName: String = "agent.toml"): C =
  * Parse config file or apply default if none was found
  * Notice that [C] should be serializable
  *
- * @param defaultConfig config that should be set if no config was found
+ * @param defaultConfig config that should be set if no config was found ([FileNotFoundException])
  * @param configName name of a toml config file, agent.toml by default
  * @return [C] filled with configuration information
  */

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -58,7 +58,7 @@ inline fun <reified C : Any> parseConfigOrDefault(
     configName: String = "agent.toml",
 ): C = try {
     parseConfig(configName)
-} catch (e: FileNotFoundException) {
+} catch (e: Exception) {
     logInfo("Config file $configName not found, falling back to default config.")
     defaultConfig
 }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -133,10 +133,10 @@ actual fun ByteArray.writeToFile(file: okio.Path, mustCreate: Boolean) {
     }
 }
 
-actual inline fun <reified C : Any> parseConfig(configPath: okio.Path): C {
-    require(fs.exists(configPath)) { "Could not find $configPath file." }
-    return TomlFileReader.decodeFromFile(serializer(), configPath.toString())
-}
+actual inline fun <reified C : Any> parseConfig(configPath: okio.Path): C = TomlFileReader.decodeFromFile(
+    serializer(),
+    configPath.toString(),
+)
 
 /**
  * Move [source] into [destinationDir], while also copying original file attributes

--- a/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -46,7 +46,7 @@ fun FileSystem.createAndWriteIfNeeded(fileName: String?, lines: List<String>?) =
     write(path, true) { lines?.forEach { codeLine -> writeUtf8(codeLine) } }
 }
 
-actual inline fun <reified C : Any> parseConfig(configPath: Path): C {
-    require(fs.exists(configPath)) { "Could not find $configPath file." }
-    return TomlFileReader.decodeFromFile(serializer(), configPath.toString())
-}
+actual inline fun <reified C : Any> parseConfig(configPath: Path): C = TomlFileReader.decodeFromFile(
+    serializer(),
+    configPath.toString(),
+)

--- a/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/Main.kt
+++ b/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/Main.kt
@@ -11,7 +11,7 @@ import com.saveourtool.save.utils.parseConfigOrDefault
 private val defaultServerConfiguration = ServerConfiguration()
 
 fun main() {
-    logInfo("Launching server on port ${defaultServerConfiguration.port}")
     val serverConfiguration: ServerConfiguration = parseConfigOrDefault(defaultServerConfiguration)
+    logInfo("Launching server on port ${serverConfiguration.port}")
     server(serverConfiguration).start(wait = true)
 }


### PR DESCRIPTION
The root of the problem is that we have `require` call in native implementation of `parseConfig` that checks the file presence (`require` throws `IllegalArgumentException`) while processing `FileNotFoundException`.

### What's done:
* Removed `require` check in `parseConfig`
* Fixed logging in `save-demo-agent`'s entry point