### PR TITLE
Introduced `StorageInitializer`

### DIFF
--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/DebugInfoStorage.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/DebugInfoStorage.kt
@@ -40,18 +40,14 @@ class DebugInfoStorage(
      * Init method to delete unexpected ids which are not associated to [com.saveourtool.save.entities.TestExecution]
      */
     @PostConstruct
-    fun deleteUnexpectedIds() {
-        Mono.fromFuture {
-            s3Operations.deleteUnexpectedKeys(
-                storageName = "${this::class.simpleName}",
-                commonPrefix = s3KeyManager.commonPrefix,
-            ) { s3Key ->
-                testExecutionRepository.findById(s3Key.removePrefix(s3KeyManager.commonPrefix).toLong()).isEmpty
-            }
+    override fun doInit(): Mono<Unit> = Mono.fromFuture {
+        s3Operations.deleteUnexpectedKeys(
+            storageName = "${this::class.simpleName}",
+            commonPrefix = s3KeyManager.commonPrefix,
+        ) { s3Key ->
+            testExecutionRepository.findById(s3Key.removePrefix(s3KeyManager.commonPrefix).toLong()).isEmpty
         }
-            .publishOn(s3Operations.scheduler)
-            .subscribe()
-    }
+    }.publishOn(s3Operations.scheduler)
 
     /**
      * Store provided [testResultDebugInfo] associated with [TestExecution.id]

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/ExecutionInfoStorage.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/ExecutionInfoStorage.kt
@@ -35,19 +35,14 @@ class ExecutionInfoStorage(
     /**
      * Init method to delete unexpected ids which are not associated to [com.saveourtool.save.entities.Execution]
      */
-    @PostConstruct
-    fun deleteUnexpectedIds() {
-        Mono.fromFuture {
+    override fun doInit(): Mono<Unit> = Mono.fromFuture {
             s3Operations.deleteUnexpectedKeys(
                 storageName = "${this::class.simpleName}",
                 commonPrefix = s3KeyManager.commonPrefix,
             ) { s3Key ->
                 executionRepository.findById(s3Key.removePrefix(s3KeyManager.commonPrefix).toLong()).isEmpty
             }
-        }
-            .publishOn(s3Operations.scheduler)
-            .subscribe()
-    }
+        }.publishOn(s3Operations.scheduler)
 
     /**
      * Update ExecutionInfo if it's required ([ExecutionUpdateDto.failReason] not null)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/ExecutionInfoStorage.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/storage/ExecutionInfoStorage.kt
@@ -17,8 +17,6 @@ import org.slf4j.Logger
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 
-import javax.annotation.PostConstruct
-
 /**
  * A storage for storing additional data (ExecutionInfo) associated with test results
  */
@@ -36,13 +34,13 @@ class ExecutionInfoStorage(
      * Init method to delete unexpected ids which are not associated to [com.saveourtool.save.entities.Execution]
      */
     override fun doInit(): Mono<Unit> = Mono.fromFuture {
-            s3Operations.deleteUnexpectedKeys(
-                storageName = "${this::class.simpleName}",
-                commonPrefix = s3KeyManager.commonPrefix,
-            ) { s3Key ->
-                executionRepository.findById(s3Key.removePrefix(s3KeyManager.commonPrefix).toLong()).isEmpty
-            }
-        }.publishOn(s3Operations.scheduler)
+        s3Operations.deleteUnexpectedKeys(
+            storageName = "${this::class.simpleName}",
+            commonPrefix = s3KeyManager.commonPrefix,
+        ) { s3Key ->
+            executionRepository.findById(s3Key.removePrefix(s3KeyManager.commonPrefix).toLong()).isEmpty
+        }
+    }.publishOn(s3Operations.scheduler)
 
     /**
      * Update ExecutionInfo if it's required ([ExecutionUpdateDto.failReason] not null)

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/s3/DefaultS3Operations.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/s3/DefaultS3Operations.kt
@@ -199,7 +199,7 @@ class DefaultS3Operations(
         private val stubRegion = Region.AWS_ISO_GLOBAL
 
         private fun <T : Any> CompletableFuture<T>.handleNoSuchKeyException(): CompletableFuture<T?> = exceptionally { ex ->
-            when (ex) {
+            when (ex.cause) {
                 is NoSuchKeyException -> null
                 else -> throw ex
             }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractMigrationStorage.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractMigrationStorage.kt
@@ -22,42 +22,19 @@ abstract class AbstractMigrationStorage<O : Any, N : Any>(
 ) : Storage<O> {
     private val log: Logger = getLogger(this.javaClass)
 
-    @SuppressWarnings("NonBooleanPropertyPrefixedWithIs")
-    private val isMigrationStarted = AtomicBoolean(false)
-
-    @SuppressWarnings("NonBooleanPropertyPrefixedWithIs")
-    private val isMigrationFinished = AtomicBoolean(false)
+    private val initializer: StorageInitializer = StorageInitializer(this::class)
 
     /**
      * Init method which copies file from one storage to another
      */
     @PostConstruct
     fun migrate() {
-        migrateAsync().subscribe()
-    }
-
-    /**
-     * Async method which copies file from one storage to another
-     *
-     * @return [Mono] without value
-     */
-    fun migrateAsync(): Mono<Unit> {
-        require(!isMigrationStarted.compareAndExchange(false, true)) {
-            "Migration cannot be called more than 1 time, migration is in progress"
+        initializer.init {
+            oldStorage.list()
+                .flatMap { migrateKey(it) }
+                .thenJust(Unit)
+                .defaultIfEmpty(Unit)
         }
-        return oldStorage.list()
-            .flatMap { migrateKey(it) }
-            .switchIfEmpty(true.toMono())
-            .then(
-                Mono.fromCallable {
-                    require(!isMigrationFinished.compareAndExchange(false, true)) {
-                        "Migration cannot be called more than 1 time. Migration already finished by another project"
-                    }
-                    log.info {
-                        "Migration of ${javaClass.simpleName} is done"
-                    }
-                }
-            )
     }
 
     private fun migrateKey(oldKey: O): Mono<Boolean> = blockingToMono { oldKey.toNewKey() }
@@ -105,31 +82,24 @@ abstract class AbstractMigrationStorage<O : Any, N : Any>(
      */
     protected abstract fun N.toOldKey(): O
 
-    private fun <R> validateAndRun(action: () -> R): R {
-        require(isMigrationFinished.get()) {
-            "Any method of ${javaClass.simpleName} should be called after migration is finished"
-        }
-        return action()
-    }
+    override fun list(): Flux<O> = initializer.validateAndRun { newStorage.list().map { key -> key.toOldKey() } }
 
-    override fun list(): Flux<O> = validateAndRun { newStorage.list().map { key -> key.toOldKey() } }
+    override fun download(key: O): Flux<ByteBuffer> = initializer.validateAndRun { newStorage.download(key.toNewKey()) }
 
-    override fun download(key: O): Flux<ByteBuffer> = validateAndRun { newStorage.download(key.toNewKey()) }
-
-    override fun upload(key: O, content: Flux<ByteBuffer>): Mono<O> = validateAndRun { newStorage.upload(key.toNewKey(), content).map { it.toOldKey() } }
+    override fun upload(key: O, content: Flux<ByteBuffer>): Mono<O> = initializer.validateAndRun { newStorage.upload(key.toNewKey(), content).map { it.toOldKey() } }
 
     override fun upload(key: O, contentLength: Long, content: Flux<ByteBuffer>): Mono<O> =
-            validateAndRun { newStorage.upload(key.toNewKey(), contentLength, content).map { it.toOldKey() } }
+        initializer.validateAndRun { newStorage.upload(key.toNewKey(), contentLength, content).map { it.toOldKey() } }
 
-    override fun delete(key: O): Mono<Boolean> = validateAndRun { newStorage.delete(key.toNewKey()) }
+    override fun delete(key: O): Mono<Boolean> = initializer.validateAndRun { newStorage.delete(key.toNewKey()) }
 
-    override fun lastModified(key: O): Mono<Instant> = validateAndRun { newStorage.lastModified(key.toNewKey()) }
+    override fun lastModified(key: O): Mono<Instant> = initializer.validateAndRun { newStorage.lastModified(key.toNewKey()) }
 
-    override fun contentLength(key: O): Mono<Long> = validateAndRun { newStorage.contentLength(key.toNewKey()) }
+    override fun contentLength(key: O): Mono<Long> = initializer.validateAndRun { newStorage.contentLength(key.toNewKey()) }
 
-    override fun doesExist(key: O): Mono<Boolean> = validateAndRun { newStorage.doesExist(key.toNewKey()) }
+    override fun doesExist(key: O): Mono<Boolean> = initializer.validateAndRun { newStorage.doesExist(key.toNewKey()) }
 
-    override fun move(source: O, target: O): Mono<Boolean> = validateAndRun { newStorage.move(source.toNewKey(), target.toNewKey()) }
+    override fun move(source: O, target: O): Mono<Boolean> = initializer.validateAndRun { newStorage.move(source.toNewKey(), target.toNewKey()) }
 
-    override fun generateUrlToDownload(key: O): URL = validateAndRun { newStorage.generateUrlToDownload(key.toNewKey()) }
+    override fun generateUrlToDownload(key: O): URL = initializer.validateAndRun { newStorage.generateUrlToDownload(key.toNewKey()) }
 }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractMigrationStorage.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractMigrationStorage.kt
@@ -4,13 +4,11 @@ import com.saveourtool.save.utils.*
 import org.slf4j.Logger
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.core.util.function.component1
 import reactor.kotlin.core.util.function.component2
 import java.net.URL
 import java.nio.ByteBuffer
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.annotation.PostConstruct
 
 /**
@@ -21,7 +19,6 @@ abstract class AbstractMigrationStorage<O : Any, N : Any>(
     private val newStorage: Storage<N>,
 ) : Storage<O> {
     private val log: Logger = getLogger(this.javaClass)
-
     private val initializer: StorageInitializer = StorageInitializer(this::class)
 
     /**
@@ -89,7 +86,7 @@ abstract class AbstractMigrationStorage<O : Any, N : Any>(
     override fun upload(key: O, content: Flux<ByteBuffer>): Mono<O> = initializer.validateAndRun { newStorage.upload(key.toNewKey(), content).map { it.toOldKey() } }
 
     override fun upload(key: O, contentLength: Long, content: Flux<ByteBuffer>): Mono<O> =
-        initializer.validateAndRun { newStorage.upload(key.toNewKey(), contentLength, content).map { it.toOldKey() } }
+            initializer.validateAndRun { newStorage.upload(key.toNewKey(), contentLength, content).map { it.toOldKey() } }
 
     override fun delete(key: O): Mono<Boolean> = initializer.validateAndRun { newStorage.delete(key.toNewKey()) }
 

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractS3Storage.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractS3Storage.kt
@@ -106,7 +106,6 @@ abstract class AbstractS3Storage<K : Any>(
                             }
                         }
                 }
-                .thenReturn(key)
 
     override fun upload(key: K, contentLength: Long, content: Flux<ByteBuffer>): Mono<K> =
             createNewS3Key(key)

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractSimpleStorage.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractSimpleStorage.kt
@@ -20,7 +20,6 @@ abstract class AbstractSimpleStorage<K : Any>(
     s3Operations,
 ) {
     private val initializer: StorageInitializer = StorageInitializer(this::class)
-
     override val s3KeyManager: S3KeyManager<K> = object : AbstractS3KeyManager<K>(prefix) {
         override fun buildKeyFromSuffix(s3KeySuffix: String): K = doBuildKeyFromSuffix(s3KeySuffix)
         override fun buildS3KeySuffix(key: K): String = doBuildS3KeySuffix(key)
@@ -38,6 +37,9 @@ abstract class AbstractSimpleStorage<K : Any>(
      */
     abstract fun doBuildS3KeySuffix(key: K): String
 
+    /**
+     * Init method to call [initializer]
+     */
     @PostConstruct
     fun init() {
         initializer.init {
@@ -45,6 +47,9 @@ abstract class AbstractSimpleStorage<K : Any>(
         }
     }
 
+    /**
+     * @return result of init method as [Mono] without body, it's [Mono.empty] by default
+     */
     protected open fun doInit(): Mono<Unit> = Mono.empty()
 
     override fun list(): Flux<K> = initializer.validateAndRun { super.list() }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractSimpleStorage.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/AbstractSimpleStorage.kt
@@ -3,6 +3,12 @@ package com.saveourtool.save.storage
 import com.saveourtool.save.s3.S3Operations
 import com.saveourtool.save.storage.key.AbstractS3KeyManager
 import com.saveourtool.save.storage.key.S3KeyManager
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.net.URL
+import java.nio.ByteBuffer
+import java.time.Instant
+import javax.annotation.PostConstruct
 
 /**
  * A simple implementation of [Storage]
@@ -13,6 +19,8 @@ abstract class AbstractSimpleStorage<K : Any>(
 ) : AbstractS3Storage<K>(
     s3Operations,
 ) {
+    private val initializer: StorageInitializer = StorageInitializer(this::class)
+
     override val s3KeyManager: S3KeyManager<K> = object : AbstractS3KeyManager<K>(prefix) {
         override fun buildKeyFromSuffix(s3KeySuffix: String): K = doBuildKeyFromSuffix(s3KeySuffix)
         override fun buildS3KeySuffix(key: K): String = doBuildS3KeySuffix(key)
@@ -29,4 +37,33 @@ abstract class AbstractSimpleStorage<K : Any>(
      * @return suffix for s3 key, cannot start with [PATH_DELIMITER]
      */
     abstract fun doBuildS3KeySuffix(key: K): String
+
+    @PostConstruct
+    fun init() {
+        initializer.init {
+            doInit()
+        }
+    }
+
+    protected open fun doInit(): Mono<Unit> = Mono.empty()
+
+    override fun list(): Flux<K> = initializer.validateAndRun { super.list() }
+
+    override fun download(key: K): Flux<ByteBuffer> = initializer.validateAndRun { super.download(key) }
+
+    override fun upload(key: K, content: Flux<ByteBuffer>): Mono<K> = initializer.validateAndRun { super.upload(key, content) }
+
+    override fun upload(key: K, contentLength: Long, content: Flux<ByteBuffer>): Mono<K> = initializer.validateAndRun { super.upload(key, contentLength, content) }
+
+    override fun delete(key: K): Mono<Boolean> = initializer.validateAndRun { super.delete(key) }
+
+    override fun lastModified(key: K): Mono<Instant> = initializer.validateAndRun { super.lastModified(key) }
+
+    override fun contentLength(key: K): Mono<Long> = initializer.validateAndRun { super.contentLength(key) }
+
+    override fun doesExist(key: K): Mono<Boolean> = initializer.validateAndRun { super.doesExist(key) }
+
+    override fun move(source: K, target: K): Mono<Boolean> = initializer.validateAndRun { super.move(source, target) }
+
+    override fun generateUrlToDownload(key: K): URL = initializer.validateAndRun { super.generateUrlToDownload(key) }
 }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageInitializer.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageInitializer.kt
@@ -1,0 +1,72 @@
+package com.saveourtool.save.storage
+
+import com.saveourtool.save.utils.getLogger
+import com.saveourtool.save.utils.info
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.reflect.KClass
+
+/**
+ * Initializer for [Storage]
+ *
+ * @property storageName
+ */
+class StorageInitializer(
+    private val storageName: String,
+) {
+    /**
+     * @param clazz [storageName] will be calculated from class name
+     */
+    constructor(clazz: KClass<*>) : this(clazz.simpleName ?: clazz.java.simpleName)
+
+    @SuppressWarnings("NonBooleanPropertyPrefixedWithIs")
+    private val isInitStarted = AtomicBoolean(false)
+
+    @SuppressWarnings("NonBooleanPropertyPrefixedWithIs")
+    private val isInitFinished = AtomicBoolean(false)
+
+    /**
+     * Init method using method that returns [Mono]
+     * It can be empty
+     */
+    fun init(doInitByPublisher: () -> Mono<Unit>) {
+        require(!isInitStarted.compareAndExchange(false, true)) {
+            "Init method cannot be called more than 1 time, initialization is in progress"
+        }
+        doInitByPublisher()
+            .thenReturn(true)  // doInit worked
+            .defaultIfEmpty(false)  // doInit is emtpy
+            .doOnNext { wasDoInitCalled ->
+                require(!isInitFinished.compareAndExchange(false, true)) {
+                    "Init method cannot be called more than 1 time. Initialization $storageName already finished by another run"
+                }
+                if (wasDoInitCalled) {
+                    log.info {
+                        "Initialization $storageName is done"
+                    }
+                }
+            }
+            .subscribeOn(initScheduler)
+            .subscribe()
+    }
+
+    /**
+     * @param action
+     * @return result of [action] if initialization is finished, otherwise -- exception
+     */
+    fun <R> validateAndRun(action: () -> R): R {
+        require(isInitFinished.get()) {
+            "Any method of $storageName should be called after init method is finished"
+        }
+        return action()
+    }
+
+    companion object {
+        private val log: Logger = getLogger<StorageInitializer>()
+        private val initScheduler: Scheduler = Schedulers.boundedElastic()
+    }
+}

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageInitializer.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageInitializer.kt
@@ -32,14 +32,14 @@ class StorageInitializer(
      * Init method using method that returns [Mono]
      * It can be empty
      *
-     * @param doInitByPublisher
+     * @param doInit
      */
-    fun init(doInitByPublisher: () -> Mono<Unit>) {
+    fun init(doInit: () -> Mono<Unit>) {
         require(!isInitStarted.compareAndExchange(false, true)) {
             "Init method cannot be called more than 1 time, initialization is in progress"
         }
-        doInitByPublisher()
-            .thenReturn(true)  // doInit worked
+        doInit()
+            .map { true }  // doInit worked
             .defaultIfEmpty(false)  // doInit is emtpy
             .doOnNext { wasDoInitCalled ->
                 require(!isInitFinished.compareAndExchange(false, true)) {

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageInitializer.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageInitializer.kt
@@ -2,7 +2,6 @@ package com.saveourtool.save.storage
 
 import com.saveourtool.save.utils.getLogger
 import com.saveourtool.save.utils.info
-import org.reactivestreams.Publisher
 import org.slf4j.Logger
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Scheduler
@@ -18,11 +17,6 @@ import kotlin.reflect.KClass
 class StorageInitializer(
     private val storageName: String,
 ) {
-    /**
-     * @param clazz [storageName] will be calculated from class name
-     */
-    constructor(clazz: KClass<*>) : this(clazz.simpleName ?: clazz.java.simpleName)
-
     @SuppressWarnings("NonBooleanPropertyPrefixedWithIs")
     private val isInitStarted = AtomicBoolean(false)
 
@@ -30,8 +24,15 @@ class StorageInitializer(
     private val isInitFinished = AtomicBoolean(false)
 
     /**
+     * @param clazz [storageName] will be calculated from class name
+     */
+    constructor(clazz: KClass<*>) : this(clazz.simpleName ?: clazz.java.simpleName)
+
+    /**
      * Init method using method that returns [Mono]
      * It can be empty
+     *
+     * @param doInitByPublisher
      */
     fun init(doInitByPublisher: () -> Mono<Unit>) {
         require(!isInitStarted.compareAndExchange(false, true)) {

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageWithDatabase.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/storage/StorageWithDatabase.kt
@@ -10,13 +10,10 @@ import com.saveourtool.save.utils.*
 import org.slf4j.Logger
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.core.scheduler.Scheduler
-import reactor.core.scheduler.Schedulers
 
 import java.net.URL
 import java.nio.ByteBuffer
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.annotation.PostConstruct
 
 /**
@@ -35,7 +32,6 @@ open class StorageWithDatabase<K : Any, E : BaseEntity, R : BaseEntityRepository
     private val underlyingStorage = object : AbstractS3Storage<K>(s3Operations) {
         override val s3KeyManager: S3KeyManager<K> = this@StorageWithDatabase.s3KeyManager
     }
-
     private val initializer = StorageInitializer(this::class)
 
     /**


### PR DESCRIPTION
### What's done:
* added `StorageInitializer`
* reused it in AbstractMigrationStorage, AbstractSimpleStorage and StorageWithDatabase

It was extracted from #1867

It was done to encapsulate logic of storage initialization to a dedicated class with further reusing in different implementations of Storage: `StorageCoroutines` and `StorageProjectReactor`