### PR TITLE
Agent Jobs should be deleted on completion

### DIFF
--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -6,8 +6,7 @@ package com.saveourtool.save.orchestrator.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import java.time.Duration
 
 /**
  * Class for properties
@@ -82,7 +81,7 @@ data class ConfigProperties(
         val agentCpuLimits: String = "500m",
         val agentMemoryRequests: String = "300Mi",
         val agentMemoryLimits: String = "500Mi",
-        val ttlAfterFinished: Duration = 180.seconds,
+        val ttlAfterFinished: Duration = Duration.ofMinutes(3),
     )
 
     /**

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -6,6 +6,8 @@ package com.saveourtool.save.orchestrator.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Class for properties
@@ -69,6 +71,7 @@ data class ConfigProperties(
      * @property agentCpuLimits configures `resources.limits.cpu` for agent pods
      * @property agentMemoryRequests configures `resources.requests.memory` for agent pods
      * @property agentMemoryLimits configures `resources.requests.memory` for agent pods
+     * @property ttlAfterFinished agent job time to live after it is marked as completed
      */
     data class KubernetesSettings(
         val apiServerUrl: String,
@@ -79,6 +82,7 @@ data class ConfigProperties(
         val agentCpuLimits: String = "500m",
         val agentMemoryRequests: String = "300Mi",
         val agentMemoryLimits: String = "500Mi",
+        val ttlAfterFinished: Duration = 180.seconds,
     )
 
     /**

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -72,6 +72,7 @@ data class ConfigProperties(
      * @property agentMemoryLimits configures `resources.requests.memory` for agent pods
      * @property ttlAfterFinished agent job time to live after it is marked as completed
      */
+    @Suppress("MagicNumber")
     data class KubernetesSettings(
         val apiServerUrl: String,
         val serviceAccount: String,

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -54,7 +54,7 @@ class KubernetesManager(
             }
             spec = JobSpec().apply {
                 parallelism = replicas
-                ttlSecondsAfterFinished = TTL_AFTER_COMPLETED
+                ttlSecondsAfterFinished = kubernetesSettings.ttlAfterFinished.toInt(DurationUnit.SECONDS)
                 // do not attempt to restart failed pods, because if we manually stop pods by deleting them,
                 // job controller would think that they need to be restarted
                 backoffLimit = 0

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
+import kotlin.time.DurationUnit
 
 /**
  * A component that manages save-agents running in Kubernetes.
@@ -181,7 +182,6 @@ class KubernetesManager(
     companion object {
         private val logger = LoggerFactory.getLogger(KubernetesManager::class.java)
         private const val EXECUTION_ID_LABEL = "executionId"
-        private const val TTL_AFTER_COMPLETED = 1800
         private val containerIdEnv = setOf(AgentEnvName.CONTAINER_ID, AgentEnvName.CONTAINER_NAME)
             .map { it.name }
             .map { envName ->

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -16,7 +16,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
-import kotlin.time.DurationUnit
 
 /**
  * A component that manages save-agents running in Kubernetes.
@@ -55,7 +54,7 @@ class KubernetesManager(
             }
             spec = JobSpec().apply {
                 parallelism = replicas
-                ttlSecondsAfterFinished = kubernetesSettings.ttlAfterFinished.toInt(DurationUnit.SECONDS)
+                ttlSecondsAfterFinished = kubernetesSettings.ttlAfterFinished.toSeconds().toInt()
                 // do not attempt to restart failed pods, because if we manually stop pods by deleting them,
                 // job controller would think that they need to be restarted
                 backoffLimit = 0

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -54,6 +54,7 @@ class KubernetesManager(
             }
             spec = JobSpec().apply {
                 parallelism = replicas
+                ttlSecondsAfterFinished = TTL_AFTER_COMPLETED
                 // do not attempt to restart failed pods, because if we manually stop pods by deleting them,
                 // job controller would think that they need to be restarted
                 backoffLimit = 0
@@ -179,6 +180,7 @@ class KubernetesManager(
 
     companion object {
         private val logger = LoggerFactory.getLogger(KubernetesManager::class.java)
+        private const val TTL_AFTER_COMPLETED = 1800
         private const val EXECUTION_ID_LABEL = "executionId"
         private val containerIdEnv = setOf(AgentEnvName.CONTAINER_ID, AgentEnvName.CONTAINER_NAME)
             .map { it.name }

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -180,8 +180,8 @@ class KubernetesManager(
 
     companion object {
         private val logger = LoggerFactory.getLogger(KubernetesManager::class.java)
-        private const val TTL_AFTER_COMPLETED = 1800
         private const val EXECUTION_ID_LABEL = "executionId"
+        private const val TTL_AFTER_COMPLETED = 1800
         private val containerIdEnv = setOf(AgentEnvName.CONTAINER_ID, AgentEnvName.CONTAINER_NAME)
             .map { it.name }
             .map { envName ->


### PR DESCRIPTION
### What's done:
 * Added `ttlSecondsAfterFinished` to job spec (for now hardcoded to be 3 mins = `180`)
 * Added `ttlAfterFinished` to `KubernetesSettings`