### PR TITLE
Demo frontend follow-ups

### DIFF
--- a/save-backend/backend-api-docs.json
+++ b/save-backend/backend-api-docs.json
@@ -2107,6 +2107,74 @@
         ]
       }
     },
+    "/api/v1/demo/{organizationName}/{projectName}/start": {
+      "post": {
+        "description": "Start demo container if possible, do nothing otherwise.",
+        "operationId": "startDemo",
+        "parameters": [
+          {
+            "description": "name of saveourtool organization",
+            "in": "path",
+            "name": "organizationName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of saveourtool project",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "example": "basic",
+            "in": "header",
+            "name": "X-Authorization-Source",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successfully started demo."
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not enough permission for demo management."
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Could not find saveourtool project or demo of a project."
+          }
+        },
+        "summary": "Start demo container.",
+        "tags": [
+          "demo-manager-controller"
+        ]
+      }
+    },
     "/api/v1/demo/{organizationName}/{projectName}/status": {
       "get": {
         "description": "Get demo status.",
@@ -2148,7 +2216,8 @@
                     "NOT_CREATED",
                     "RUNNING",
                     "STARTING",
-                    "STOPPED"
+                    "STOPPED",
+                    "STOPPING"
                   ]
                 }
               }
@@ -2165,7 +2234,8 @@
                     "NOT_CREATED",
                     "RUNNING",
                     "STARTING",
-                    "STOPPED"
+                    "STOPPED",
+                    "STOPPING"
                   ]
                 }
               }
@@ -2182,7 +2252,8 @@
                     "NOT_CREATED",
                     "RUNNING",
                     "STARTING",
-                    "STOPPED"
+                    "STOPPED",
+                    "STOPPING"
                   ]
                 }
               }
@@ -2191,6 +2262,74 @@
           }
         },
         "summary": "Get demo status.",
+        "tags": [
+          "demo-manager-controller"
+        ]
+      }
+    },
+    "/api/v1/demo/{organizationName}/{projectName}/stop": {
+      "post": {
+        "description": "Delete demo container if possible, do nothing otherwise.",
+        "operationId": "stopDemo",
+        "parameters": [
+          {
+            "description": "name of saveourtool organization",
+            "in": "path",
+            "name": "organizationName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of saveourtool project",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "example": "basic",
+            "in": "header",
+            "name": "X-Authorization-Source",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successfully stopped demo."
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not enough permission for demo management."
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Could not find saveourtool project or demo of a project."
+          }
+        },
+        "summary": "Stop demo.",
         "tags": [
           "demo-manager-controller"
         ]
@@ -8379,7 +8518,8 @@
               "NOT_CREATED",
               "RUNNING",
               "STARTING",
-              "STOPPED"
+              "STOPPED",
+              "STOPPING"
             ]
           }
         }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DemoManagerController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DemoManagerController.kt
@@ -10,6 +10,7 @@ import com.saveourtool.save.demo.DemoDto
 import com.saveourtool.save.demo.DemoInfo
 import com.saveourtool.save.demo.DemoStatus
 import com.saveourtool.save.entities.FileDto
+import com.saveourtool.save.entities.Project
 import com.saveourtool.save.permission.Permission
 import com.saveourtool.save.spring.utils.applyAll
 import com.saveourtool.save.utils.*
@@ -139,28 +140,15 @@ class DemoManagerController(
         @RequestParam(required = false, defaultValue = "manual") version: String,
         @RequestPart file: FilePart,
         authentication: Authentication,
-    ): Mono<FileDto> = projectService.projectByCoordinatesOrNotFound(projectName, organizationName) {
-        "Could not find project $projectName in organization $organizationName."
+    ): Mono<FileDto> = forwardRequestCheckingPermission(Permission.DELETE, organizationName, projectName, authentication) {
+        webClientDemo.post()
+            .uri("/demo/internal/files/$organizationName/$projectName/upload?version=$version")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(BodyInserters.fromMultipartData("file", file))
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .bodyToMono()
     }
-        .requireOrSwitchToResponseException({ projectPermissionEvaluator.hasPermission(authentication, this, Permission.DELETE) }, HttpStatus.FORBIDDEN) {
-            "Not enough permission for accessing given project."
-        }
-        .flatMap {
-            webClientDemo.post()
-                .uri("/demo/internal/files/$organizationName/$projectName/upload?version=$version")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData("file", file))
-                .retrieve()
-                .onStatus({ it == HttpStatus.NOT_FOUND }) {
-                    Mono.error(
-                        ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            "Demo for $organizationName/$projectName is not found.",
-                        )
-                    )
-                }
-                .bodyToMono()
-        }
 
     @GetMapping("/{organizationName}/{projectName}/list-file")
     @RequiresAuthorizationSourceHeader
@@ -193,14 +181,7 @@ class DemoManagerController(
             webClientDemo.get()
                 .uri("/demo/internal/files/$organizationName/$projectName/list?version=$version")
                 .retrieve()
-                .onStatus({ it == HttpStatus.NOT_FOUND }) {
-                    Mono.error(
-                        ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            "Demo for $organizationName/$projectName is not found.",
-                        )
-                    )
-                }
+                .defaultNotFoundProcessing(organizationName, projectName)
                 .bodyToFlux()
         }
 
@@ -227,26 +208,13 @@ class DemoManagerController(
         @RequestParam(required = false, defaultValue = "manual") version: String,
         @RequestParam fileName: String,
         authentication: Authentication,
-    ): Mono<Boolean> = projectService.projectByCoordinatesOrNotFound(projectName, organizationName) {
-        "Could not find project $projectName in organization $organizationName."
+    ): Mono<Boolean> = forwardRequestCheckingPermission(Permission.DELETE, organizationName, projectName, authentication) {
+        webClientDemo.delete()
+            .uri("/demo/internal/files/$organizationName/$projectName/delete?version=$version&fileName=$fileName")
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .bodyToMono()
     }
-        .requireOrSwitchToResponseException({ projectPermissionEvaluator.hasPermission(authentication, this, Permission.DELETE) }, HttpStatus.FORBIDDEN) {
-            "Not enough permission for accessing given project."
-        }
-        .flatMap {
-            webClientDemo.delete()
-                .uri("/demo/internal/files/$organizationName/$projectName/delete?version=$version&fileName=$fileName")
-                .retrieve()
-                .onStatus({ it == HttpStatus.NOT_FOUND }) {
-                    Mono.error(
-                        ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            "Demo for $organizationName/$projectName is not found.",
-                        )
-                    )
-                }
-                .bodyToMono()
-        }
 
     @GetMapping("/{organizationName}/{projectName}/status")
     @RequiresAuthorizationSourceHeader
@@ -266,27 +234,14 @@ class DemoManagerController(
         @PathVariable organizationName: String,
         @PathVariable projectName: String,
         authentication: Authentication,
-    ): Mono<DemoStatus> = projectService.projectByCoordinatesOrNotFound(projectName, organizationName) {
-        "Could not find project $projectName in organization $organizationName."
+    ): Mono<DemoStatus> = forwardRequestCheckingPermission(Permission.READ, organizationName, projectName, authentication) {
+        webClientDemo.get()
+            .uri("/demo/api/manager/$organizationName/$projectName/status")
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .bodyToMono<DemoStatus>()
+            .defaultIfEmpty(DemoStatus.NOT_CREATED)
     }
-        .requireOrSwitchToResponseException({ projectPermissionEvaluator.hasPermission(authentication, this, Permission.READ) }, HttpStatus.FORBIDDEN) {
-            "Not enough permission for accessing given project."
-        }
-        .flatMap {
-            webClientDemo.get()
-                .uri("/demo/api/manager/$organizationName/$projectName/status")
-                .retrieve()
-                .onStatus({ it == HttpStatus.NOT_FOUND }) {
-                    Mono.error(
-                        ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            "Demo for $organizationName/$projectName is not found.",
-                        )
-                    )
-                }
-                .bodyToMono<DemoStatus>()
-                .defaultIfEmpty(DemoStatus.NOT_CREATED)
-        }
 
     @GetMapping("/{organizationName}/{projectName}")
     @RequiresAuthorizationSourceHeader
@@ -307,32 +262,19 @@ class DemoManagerController(
         @PathVariable organizationName: String,
         @PathVariable projectName: String,
         authentication: Authentication,
-    ): Mono<DemoInfo> = projectService.projectByCoordinatesOrNotFound(projectName, organizationName) {
-        "Could not find project $projectName in organization $organizationName."
-    }
-        .requireOrSwitchToResponseException({ projectPermissionEvaluator.hasPermission(authentication, this, Permission.WRITE) }, HttpStatus.FORBIDDEN) {
-            "Not enough permission for accessing given project."
-        }
-        .flatMap {
-            webClientDemo.get()
-                .uri("/demo/api/manager/$organizationName/$projectName")
-                .retrieve()
-                .onStatus({ it == HttpStatus.NOT_FOUND }) {
-                    Mono.error(
-                        ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            "Demo for $organizationName/$projectName is not found.",
-                        )
-                    )
-                }
-                .bodyToMono<DemoInfo>()
-                .defaultIfEmpty(
-                    DemoInfo(
-                        DemoDto.emptyForProject(organizationName, projectName),
-                        DemoStatus.NOT_CREATED,
-                    )
+    ): Mono<DemoInfo> = forwardRequestCheckingPermission(Permission.READ, organizationName, projectName, authentication) {
+        webClientDemo.get()
+            .uri("/demo/api/manager/$organizationName/$projectName")
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .bodyToMono<DemoInfo>()
+            .defaultIfEmpty(
+                DemoInfo(
+                    DemoDto.emptyForProject(organizationName, projectName),
+                    DemoStatus.NOT_CREATED,
                 )
-        }
+            )
+    }
 
     @PostMapping("/{organizationName}/{projectName}/delete")
     @RequiresAuthorizationSourceHeader
@@ -353,24 +295,86 @@ class DemoManagerController(
         @PathVariable organizationName: String,
         @PathVariable projectName: String,
         authentication: Authentication,
-    ): Mono<StringResponse> = projectService.projectByCoordinatesOrNotFound(projectName, organizationName) {
+    ): Mono<StringResponse> = forwardRequestCheckingPermission(Permission.DELETE, organizationName, projectName, authentication) { project ->
+        webClientDemo.post()
+            .uri("/demo/internal/manager/${project.toProjectCoordinates()}/delete")
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .toEntity()
+    }
+
+    @PostMapping("/{organizationName}/{projectName}/start")
+    @RequiresAuthorizationSourceHeader
+    @Parameters(
+        Parameter(name = "organizationName", `in` = ParameterIn.PATH, description = "name of saveourtool organization", required = true),
+        Parameter(name = "projectName", `in` = ParameterIn.PATH, description = "name of saveourtool project", required = true),
+    )
+    @Operation(
+        method = "POST",
+        summary = "Start demo container.",
+        description = "Start demo container if possible, do nothing otherwise.",
+    )
+    @ApiResponse(responseCode = "200", description = "Successfully started demo.")
+    @ApiResponse(responseCode = "403", description = "Not enough permission for demo management.")
+    @ApiResponse(responseCode = "404", description = "Could not find saveourtool project or demo of a project.")
+    fun startDemo(
+        @PathVariable organizationName: String,
+        @PathVariable projectName: String,
+        authentication: Authentication,
+    ): Mono<StringResponse> = forwardRequestCheckingPermission(Permission.WRITE, organizationName, projectName, authentication) { project ->
+        webClientDemo.post()
+            .uri("/demo/internal/manager/${project.toProjectCoordinates()}/start")
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .toEntity()
+    }
+
+    @PostMapping("/{organizationName}/{projectName}/stop")
+    @RequiresAuthorizationSourceHeader
+    @Parameters(
+        Parameter(name = "organizationName", `in` = ParameterIn.PATH, description = "name of saveourtool organization", required = true),
+        Parameter(name = "projectName", `in` = ParameterIn.PATH, description = "name of saveourtool project", required = true),
+    )
+    @Operation(
+        method = "POST",
+        summary = "Stop demo.",
+        description = "Delete demo container if possible, do nothing otherwise.",
+    )
+    @ApiResponse(responseCode = "200", description = "Successfully stopped demo.")
+    @ApiResponse(responseCode = "403", description = "Not enough permission for demo management.")
+    @ApiResponse(responseCode = "404", description = "Could not find saveourtool project or demo of a project.")
+    fun stopDemo(
+        @PathVariable organizationName: String,
+        @PathVariable projectName: String,
+        authentication: Authentication,
+    ): Mono<StringResponse> = forwardRequestCheckingPermission(Permission.WRITE, organizationName, projectName, authentication) { project ->
+        webClientDemo.post()
+            .uri("/demo/internal/manager/${project.toProjectCoordinates()}/stop")
+            .retrieve()
+            .defaultNotFoundProcessing(organizationName, projectName)
+            .toEntity()
+    }
+
+    private inline fun <reified T : Any> forwardRequestCheckingPermission(
+        requiredPermission: Permission,
+        organizationName: String,
+        projectName: String,
+        authentication: Authentication,
+        crossinline requestBuilder: (Project) -> Mono<T>,
+    ): Mono<T> = projectService.projectByCoordinatesOrNotFound(projectName, organizationName) {
         "Could not find $organizationName/$projectName."
     }
-        .requireOrSwitchToResponseException({ projectPermissionEvaluator.hasPermission(authentication, this, Permission.DELETE) }, HttpStatus.FORBIDDEN) {
+        .requireOrSwitchToForbidden({ projectPermissionEvaluator.hasPermission(authentication, this, requiredPermission) }) {
             "Not enough permission for accessing $organizationName/$projectName."
         }
         .flatMap { project ->
-            webClientDemo.post()
-                .uri("/demo/internal/manager/${project.toProjectCoordinates()}/delete")
-                .retrieve()
-                .onStatus({ it == HttpStatus.NOT_FOUND }) {
-                    Mono.error(
-                        ResponseStatusException(
-                            HttpStatus.NOT_FOUND,
-                            "Could not find demo for $organizationName/$projectName.",
-                        )
-                    )
-                }
-                .toEntity()
+            requestBuilder(project)
         }
+
+    private fun WebClient.ResponseSpec.defaultNotFoundProcessing(
+        organizationName: String,
+        projectName: String,
+    ) = onStatus({ it == HttpStatus.NOT_FOUND }) {
+        Mono.error(ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find demo for $organizationName/$projectName."))
+    }
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoStatus.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoStatus.kt
@@ -31,5 +31,10 @@ enum class DemoStatus {
      * Demo is created but stopped by owner
      */
     STOPPED,
+
+    /**
+     * Demo stop request is already sent, but container is not stopped yet.
+     */
+    STOPPING,
     ;
 }

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/ReactorUtils.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/ReactorUtils.kt
@@ -65,6 +65,7 @@ fun <T> Flux<T>.switchIfEmptyToNotFound(messageCreator: (() -> String?) = { null
  * @param status
  * @param messageCreator
  * @return original [Mono] or [Mono.error] with [status] if [predicate] is true for value in [Mono]
+ * @see requireOrSwitchToForbidden
  */
 @Suppress("LAMBDA_IS_NOT_LAST_PARAMETER")
 fun <T> Mono<T>.requireOrSwitchToResponseException(
@@ -72,6 +73,18 @@ fun <T> Mono<T>.requireOrSwitchToResponseException(
     status: HttpStatus,
     messageCreator: (() -> String?) = { null }
 ) = filter(predicate).switchIfEmptyToResponseException(status, messageCreator)
+
+/**
+ * @param predicate
+ * @param messageCreator
+ * @return original [Mono] or [Mono.error] with [HttpStatus.FORBIDDEN] if [predicate] is true for value in [Mono]
+ * @see [requireOrSwitchToResponseException]
+ */
+@Suppress("LAMBDA_IS_NOT_LAST_PARAMETER")
+fun <T> Mono<T>.requireOrSwitchToForbidden(
+    predicate: T.() -> Boolean,
+    messageCreator: (() -> String?) = { null }
+) = requireOrSwitchToResponseException(predicate, HttpStatus.FORBIDDEN, messageCreator)
 
 /**
  * @param lazyValue default value creator


### PR DESCRIPTION
This PR closes #1925

### What's done:
 * Added `backend` endpoints that check permissions and forward them to `save-demo` (for `/start` and `/stop`)
 * Finished frontend menu
 * Tested locally on `!kubernetes` profile
 * Slightly refactored `DemoManagerController`