### PR TITLE
Hotfix for demo url for backend

### DIFF
--- a/save-cloud-charts/save-cloud/templates/backend-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-configmap.yaml
@@ -6,6 +6,7 @@ data:
   application.properties: |
     backend.preprocessor-url=http://preprocessor
     backend.orchestrator-url=http://orchestrator
+    backend.demo-url=http://demo
     backend.loki.url=http://loki:3100
     backend.loki.labels.agent-container-name=pod
     backend.loki.labels.application-name=app


### PR DESCRIPTION
### What's done:
 * Added demo url to `backend-configmap.yaml` (`http://demo:5421` -> `http://demo`)