### PR TITLE
Hotfix for demo url for s3

### DIFF
--- a/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
@@ -21,4 +21,3 @@ data:
 
     demo.backend-url=http://backend/internal
     demo.agent-config.demo-url=http://demo
-    demo.s3-storage.endpoint=http://s3


### PR DESCRIPTION
### What's done:
 * Removed `demo.s3-storage.endpoint` configuration from `demo-configmap.yaml` as on prod the endpoint is not `http://s3`