### PR TITLE
Get rid of type aliases

### DIFF
--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/common/CloneAndProcessDirectoryAction.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/common/CloneAndProcessDirectoryAction.kt
@@ -1,0 +1,25 @@
+package com.saveourtool.save.preprocessor.common
+
+import com.saveourtool.save.entities.GitDto
+import com.saveourtool.save.preprocessor.service.GitPreprocessorService
+import org.reactivestreams.Publisher
+
+/**
+ * Uses [GitPreprocessorService] to clone and process a repository.
+ */
+fun interface CloneAndProcessDirectoryAction<T : Publisher<*>> {
+    /**
+     * Clones and processes a repository identified by [gitDto].
+     *
+     * @param gitDto the _Git_ URL along with optional credentials.
+     * @param branchOrTagOrCommit either a branch name, or a tag name, or a
+     *   commit hash.
+     * @param repositoryProcessor the custom process action.
+     * @return a custom [Publisher] returned by [repositoryProcessor].
+     */
+    fun GitPreprocessorService.cloneAndProcessDirectoryAsync(
+        gitDto: GitDto,
+        branchOrTagOrCommit: String,
+        repositoryProcessor: GitRepositoryProcessor<T>,
+    ): T
+}

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/common/CloneResult.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/common/CloneResult.kt
@@ -1,0 +1,15 @@
+package com.saveourtool.save.preprocessor.common
+
+import com.saveourtool.save.preprocessor.utils.GitCommitInfo
+import java.nio.file.Path
+
+/**
+ * The result of running `git clone`.
+ *
+ * @property directory the local directory the repository has been cloned into.
+ * @property gitCommitInfo the _Git_ commit metadata.
+ */
+data class CloneResult(
+    val directory: Path,
+    val gitCommitInfo: GitCommitInfo,
+)

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/common/GitRepositoryProcessor.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/common/GitRepositoryProcessor.kt
@@ -1,0 +1,16 @@
+package com.saveourtool.save.preprocessor.common
+
+import org.reactivestreams.Publisher
+
+/**
+ * Asynchronously processes a local _Git_ repository.
+ */
+fun interface GitRepositoryProcessor<T : Publisher<*>> {
+    /**
+     * Processes the cloned _Git_ repository, returning a `Mono` or a `Flux`.
+     *
+     * @param cloneResult the local directory along with _Git_ metadata.
+     * @return the result of the processing as a custom [Publisher].
+     */
+    fun processAsync(cloneResult: CloneResult): T
+}

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/AwesomeBenchmarksDownloadController.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/controllers/AwesomeBenchmarksDownloadController.kt
@@ -58,7 +58,7 @@ class AwesomeBenchmarksDownloadController(
                             gitPreprocessorService.cloneBranchAndProcessDirectory(
                                 gitDto,
                                 branch
-                            ) { repositoryDir: Path, _ ->
+                            ) { (repositoryDir: Path) ->
                                 log.info("Awesome-benchmarks were downloaded to ${repositoryDir.absolutePathString()}")
                                 processDirectoryAndCleanUp(repositoryDir)
                             }

--- a/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/service/GitPreprocessorService.kt
+++ b/save-preprocessor/src/main/kotlin/com/saveourtool/save/preprocessor/service/GitPreprocessorService.kt
@@ -1,6 +1,8 @@
 package com.saveourtool.save.preprocessor.service
 
 import com.saveourtool.save.entities.GitDto
+import com.saveourtool.save.preprocessor.common.CloneResult
+import com.saveourtool.save.preprocessor.common.GitRepositoryProcessor
 import com.saveourtool.save.preprocessor.config.ConfigProperties
 import com.saveourtool.save.preprocessor.utils.GitCommitInfo
 import com.saveourtool.save.preprocessor.utils.cloneBranchToDirectory
@@ -11,6 +13,7 @@ import org.eclipse.jgit.util.FileUtils
 import org.jetbrains.annotations.NonBlocking
 import org.slf4j.Logger
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.io.IOException
 import java.nio.file.Files
@@ -19,8 +22,6 @@ import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
 
-typealias CloneResult = Pair<Path, GitCommitInfo>
-typealias GitRepositoryProcessor<T> = (Path, GitCommitInfo) -> Mono<T>
 typealias ArchiveProcessor<T> = (Path) -> Mono<T>
 
 /**
@@ -45,81 +46,189 @@ class GitPreprocessorService(
     )
 
     /**
-     * @param gitDto
-     * @param tagName
-     * @param repositoryProcessor operation on folder should be finished here -- folder will be removed after it
-     * @return result of [repositoryProcessor]
+     * @param gitDto the Git URL with optional credentials.
+     * @param tagName the Git tag.
+     * @param repositoryProcessor folder processing should be finished here
+     *   &mdash; the folder will be removed afterwards.
+     * @return the result returned by [GitRepositoryProcessor.processAsync].
      * @throws IllegalStateException
      * @throws Exception
+     * @see cloneTagAndProcessDirectoryMany
+     * @see cloneBranchAndProcessDirectory
+     * @see cloneBranchAndProcessDirectoryMany
+     * @see cloneCommitAndProcessDirectory
+     * @see cloneCommitAndProcessDirectoryMany
      */
-    fun <T> cloneTagAndProcessDirectory(
+    @Suppress("TYPE_ALIAS")
+    fun <T : Any> cloneTagAndProcessDirectory(
         gitDto: GitDto,
         tagName: String,
-        repositoryProcessor: GitRepositoryProcessor<T>,
+        repositoryProcessor: GitRepositoryProcessor<Mono<T>>,
     ): Mono<T> = doCloneAndProcessDirectory(gitDto, repositoryProcessor) {
         cloneTagToDirectory(tagName, it)
     }
 
     /**
-     * @param gitDto
-     * @param branchName
-     * @param repositoryProcessor operation on folder should be finished here -- folder will be removed after it
-     * @return result of [repositoryProcessor]
+     * @param gitDto the Git URL with optional credentials.
+     * @param branchName the Git branch.
+     * @param repositoryProcessor folder processing should be finished here
+     *   &mdash; the folder will be removed afterwards.
+     * @return the result returned by [GitRepositoryProcessor.processAsync].
      * @throws IllegalStateException
      * @throws Exception
+     * @see cloneTagAndProcessDirectory
+     * @see cloneTagAndProcessDirectoryMany
+     * @see cloneBranchAndProcessDirectoryMany
+     * @see cloneCommitAndProcessDirectory
+     * @see cloneCommitAndProcessDirectoryMany
      */
-    fun <T> cloneBranchAndProcessDirectory(
+    @Suppress("TYPE_ALIAS")
+    fun <T : Any> cloneBranchAndProcessDirectory(
         gitDto: GitDto,
         branchName: String,
-        repositoryProcessor: GitRepositoryProcessor<T>,
+        repositoryProcessor: GitRepositoryProcessor<Mono<T>>,
     ): Mono<T> = doCloneAndProcessDirectory(gitDto, repositoryProcessor) {
         cloneBranchToDirectory(branchName, it)
     }
 
     /**
-     * @param gitDto
-     * @param commitId
-     * @param repositoryProcessor operation on folder should be finished here -- folder will be removed after it
-     * @return result of [repositoryProcessor]
+     * @param gitDto the Git URL with optional credentials.
+     * @param commitId the Git commit hash.
+     * @param repositoryProcessor folder processing should be finished here
+     *   &mdash; the folder will be removed afterwards.
+     * @return the result returned by [GitRepositoryProcessor.processAsync].
      * @throws IllegalStateException
      * @throws Exception
+     * @see cloneTagAndProcessDirectory
+     * @see cloneTagAndProcessDirectoryMany
+     * @see cloneBranchAndProcessDirectory
+     * @see cloneBranchAndProcessDirectoryMany
+     * @see cloneCommitAndProcessDirectoryMany
      */
-    fun <T> cloneCommitAndProcessDirectory(
+    @Suppress("TYPE_ALIAS")
+    fun <T : Any> cloneCommitAndProcessDirectory(
         gitDto: GitDto,
         commitId: String,
-        repositoryProcessor: GitRepositoryProcessor<T>,
+        repositoryProcessor: GitRepositoryProcessor<Mono<T>>,
     ): Mono<T> = doCloneAndProcessDirectory(gitDto, repositoryProcessor) {
         cloneCommitToDirectory(commitId, it)
     }
 
     /**
+     * @param gitDto the Git URL with optional credentials.
+     * @param tagName the Git tag.
+     * @param repositoryProcessor folder processing should be finished here
+     *   &mdash; the folder will be removed afterwards.
+     * @return the result returned by [GitRepositoryProcessor.processAsync].
+     * @see cloneTagAndProcessDirectory
+     * @see cloneBranchAndProcessDirectory
+     * @see cloneBranchAndProcessDirectoryMany
+     * @see cloneCommitAndProcessDirectory
+     * @see cloneCommitAndProcessDirectoryMany
+     */
+    @Suppress("TYPE_ALIAS")
+    fun <T : Any> cloneTagAndProcessDirectoryMany(
+        gitDto: GitDto,
+        tagName: String,
+        repositoryProcessor: GitRepositoryProcessor<Flux<T>>,
+    ): Flux<T> = doCloneAndProcessDirectoryMany(gitDto, repositoryProcessor) {
+        cloneTagToDirectory(tagName, it)
+    }
+
+    /**
+     * @param gitDto the Git URL with optional credentials.
+     * @param branchName the Git branch.
+     * @param repositoryProcessor folder processing should be finished here
+     *   &mdash; the folder will be removed afterwards.
+     * @return the result returned by [GitRepositoryProcessor.processAsync].
+     * @see cloneTagAndProcessDirectory
+     * @see cloneTagAndProcessDirectoryMany
+     * @see cloneBranchAndProcessDirectory
+     * @see cloneCommitAndProcessDirectory
+     * @see cloneCommitAndProcessDirectoryMany
+     */
+    @Suppress("TYPE_ALIAS")
+    fun <T : Any> cloneBranchAndProcessDirectoryMany(
+        gitDto: GitDto,
+        branchName: String,
+        repositoryProcessor: GitRepositoryProcessor<Flux<T>>,
+    ): Flux<T> = doCloneAndProcessDirectoryMany(gitDto, repositoryProcessor) {
+        cloneBranchToDirectory(branchName, it)
+    }
+
+    /**
+     * @param gitDto
+     * @param commitId the Git commit hash.
+     * @param repositoryProcessor folder processing should be finished here
+     *   &mdash; the folder will be removed afterwards.
+     * @return result of [GitRepositoryProcessor.processAsync]
+     * @see cloneTagAndProcessDirectory
+     * @see cloneTagAndProcessDirectoryMany
+     * @see cloneBranchAndProcessDirectory
+     * @see cloneBranchAndProcessDirectoryMany
+     * @see cloneCommitAndProcessDirectory
+     */
+    @Suppress("TYPE_ALIAS")
+    fun <T : Any> cloneCommitAndProcessDirectoryMany(
+        gitDto: GitDto,
+        commitId: String,
+        repositoryProcessor: GitRepositoryProcessor<Flux<T>>,
+    ): Flux<T> = doCloneAndProcessDirectoryMany(gitDto, repositoryProcessor) {
+        cloneCommitToDirectory(commitId, it)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    @NonBlocking
+    private fun GitDto.cloneAsync(doCloneToDirectory: GitDto.(Path) -> GitCommitInfo): Mono<CloneResult> =
+            blockingToMono {
+                val tmpDir = createTempDirectoryForRepository()
+                val gitCommitInfo = try {
+                    doCloneToDirectory(tmpDir)
+                } catch (ex: Exception) {
+                    log.error(ex) { "Failed to clone git repository $url" }
+                    tmpDir.deleteRecursivelySafely()
+                    throw ex
+                }
+                CloneResult(tmpDir, gitCommitInfo)
+            }
+
+    @NonBlocking
+    private fun CloneResult.cleanupAsync(): Mono<Unit> =
+            directory.deleteRecursivelySafelyAsync()
+
+    /**
      * @param doCloneToDirectory a blocking `git-clone` action (will be wrapped
-     * with [blockingToMono]).
+     *   with [blockingToMono]).
+     * @see doCloneAndProcessDirectoryMany
      */
     @NonBlocking
-    @Suppress("TooGenericExceptionCaught")
-    private fun <T> doCloneAndProcessDirectory(
+    @Suppress("TYPE_ALIAS")
+    private fun <T : Any> doCloneAndProcessDirectory(
         gitDto: GitDto,
-        repositoryProcessor: GitRepositoryProcessor<T>,
+        repositoryProcessor: GitRepositoryProcessor<Mono<T>>,
         doCloneToDirectory: GitDto.(Path) -> GitCommitInfo,
-    ): Mono<T> {
-        val cloneAction: () -> CloneResult = {
-            val tmpDir = createTempDirectoryForRepository()
-            val gitCommitInfo = try {
-                gitDto.doCloneToDirectory(tmpDir)
-            } catch (ex: Exception) {
-                log.error(ex) { "Failed to clone git repository ${gitDto.url}" }
-                tmpDir.deleteRecursivelySafely()
-                throw ex
-            }
-            tmpDir to gitCommitInfo
-        }
-        return Mono.usingWhen(
-            blockingToMono(cloneAction),
-            { (directory, gitCommitInfo) -> repositoryProcessor(directory, gitCommitInfo) },
-            { (directory, _) -> directory.deleteRecursivelySafelyAsync() }
-        )
-    }
+    ): Mono<T> =
+            Mono.usingWhen(
+                gitDto.cloneAsync(doCloneToDirectory),
+                repositoryProcessor::processAsync,
+            ) { cloneResult -> cloneResult.cleanupAsync() }
+
+    /**
+     * @param doCloneToDirectory a blocking `git-clone` action (will be wrapped
+     *   with [blockingToMono]).
+     * @see doCloneAndProcessDirectory
+     */
+    @NonBlocking
+    @Suppress("TYPE_ALIAS")
+    private fun <T : Any> doCloneAndProcessDirectoryMany(
+        gitDto: GitDto,
+        repositoryProcessor: GitRepositoryProcessor<Flux<T>>,
+        doCloneToDirectory: GitDto.(Path) -> GitCommitInfo,
+    ): Flux<T> =
+            Flux.usingWhen(
+                gitDto.cloneAsync(doCloneToDirectory),
+                repositoryProcessor::processAsync,
+            ) { cloneResult -> cloneResult.cleanupAsync() }
 
     /**
      * @param pathToRepository


### PR DESCRIPTION
 - This converts `CloneAndProcessDirectoryAction`, `GitRepositoryProcessor`, and `CloneResult` into classes/interfaces.
 - Additionally, `fetch()` now returns a `Flux<TestSuiteValidationResult>` instead of `Mono<Unit>`.
 - Related: #1096