### PR TITLE
Unified setupShTimeoutMillis

### DIFF
--- a/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -91,7 +91,11 @@ class SaveAgent(private val config: AgentConfiguration,
     }
 
     // a temporary workaround for python integration
-    private fun executeAdditionallySetup(targetDirectory: Path, additionalFileNames: Collection<String>) = runCatching {
+    private fun executeAdditionallySetup(
+        targetDirectory: Path,
+        additionalFileNames: Collection<String>,
+        setupShTimeoutMillis: Long,
+    ) = runCatching {
         logDebugCustom("Will execute additionally setup of evaluated tool if it's required")
         additionalFileNames
             .singleOrNull { it == "setup.sh" }
@@ -103,7 +107,7 @@ class SaveAgent(private val config: AgentConfiguration,
                         "./$targetFile",
                         "",
                         null,
-                        SETUP_SH_TIMEOUT
+                        setupShTimeoutMillis,
                     )
                 if (setupResult.code != 0) {
                     throw IllegalStateException("$fileName} is failed with error: ${setupResult.stderr}")
@@ -208,7 +212,7 @@ class SaveAgent(private val config: AgentConfiguration,
             }
 
         // a temporary workaround for python integration
-        executeAdditionallySetup(targetDirectory, agentInitConfig.additionalFileNameToUrl.keys)
+        executeAdditionallySetup(targetDirectory, agentInitConfig.additionalFileNameToUrl.keys, agentInitConfig.setupShTimeoutMillis)
             .runIf(
                 failureResultPredicate
             ) {
@@ -411,7 +415,6 @@ class SaveAgent(private val config: AgentConfiguration,
 
     companion object {
         private const val SAVE_CLI_TIMEOUT = 1_000_000L
-        private const val SETUP_SH_TIMEOUT = 60_000L
         private val failureResultPredicate: Result<*>.() -> Boolean = { isFailure }
     }
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/agent/AgentInitConfig.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/agent/AgentInitConfig.kt
@@ -1,5 +1,6 @@
 package com.saveourtool.save.agent
 
+import com.saveourtool.save.utils.DEFAULT_SETUP_SH_TIMEOUT_MILLIS
 import kotlinx.serialization.Serializable
 
 /**
@@ -7,6 +8,7 @@ import kotlinx.serialization.Serializable
  * @property testSuitesSourceSnapshotUrl an url to download snapshot of test suites source with tests
  * @property additionalFileNameToUrl a map of file name to url to download additional file
  * @property saveCliOverrides overrides for save-cli
+ * @property setupShTimeoutMillis amount of milliseconds to run setup.sh if it is present, [DEFAULT_SETUP_SH_TIMEOUT_MILLIS] by default
  */
 @Serializable
 data class AgentInitConfig(
@@ -14,4 +16,5 @@ data class AgentInitConfig(
     val testSuitesSourceSnapshotUrl: String,
     val additionalFileNameToUrl: Map<String, String>,
     val saveCliOverrides: SaveCliOverrides,
+    val setupShTimeoutMillis: Long = DEFAULT_SETUP_SH_TIMEOUT_MILLIS,
 )

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoAgentConfig.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoAgentConfig.kt
@@ -4,6 +4,7 @@
 
 package com.saveourtool.save.demo
 
+import com.saveourtool.save.utils.DEFAULT_SETUP_SH_TIMEOUT_MILLIS
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,12 +13,14 @@ import kotlinx.serialization.Serializable
  * @property demoConfiguration all the information about current demo e.g. maintainer and version
  * @property runConfiguration all the required information to run demo
  * @property demoUrl url of save-demo
+ * @property setupShTimeoutMillis amount of milliseconds to run setup.sh if it is present, [DEFAULT_SETUP_SH_TIMEOUT_MILLIS] by default
  */
 @Serializable
 data class DemoAgentConfig(
     val demoUrl: String,
     val demoConfiguration: DemoConfiguration,
     val runConfiguration: RunConfiguration,
+    val setupShTimeoutMillis: Long = DEFAULT_SETUP_SH_TIMEOUT_MILLIS,
 ) {
     companion object {
         const val DEMO_CONFIGURE_ME_URL_ENV = "SAVE_DEMO_CONFIGURE_ME_URL"

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
@@ -48,3 +48,8 @@ const val FILE_PART_NAME = "file"
  * A custom header for `Content-Length`
  */
 const val CONTENT_LENGTH_CUSTOM = "Content-Length-Custom"
+
+/**
+ * Default time to execute setup.sh
+ */
+const val DEFAULT_SETUP_SH_TIMEOUT_MILLIS = 60_000L

--- a/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/Server.kt
+++ b/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/Server.kt
@@ -51,7 +51,7 @@ private fun Application.getConfigurationOnStartup(
             ?.also(updateConfig)
             ?.let { config ->
                 logTrace("Configuration successfully updated.")
-                setupEnvironment(config.demoUrl, config.demoConfiguration)
+                setupEnvironment(config.demoUrl, config.setupShTimeoutMillis, config.demoConfiguration)
             }
             ?: run { logWarn("Could not prepare save-demo-agent, expecting /setup call.") }
     }
@@ -69,7 +69,7 @@ private fun Routing.configure(updateConfig: (DemoAgentConfig) -> Unit) = post("/
     val config = call.receive<DemoAgentConfig>().also(updateConfig)
     logInfo("Agent has received configuration.")
     try {
-        setupEnvironment(config.demoUrl, config.demoConfiguration)
+        setupEnvironment(config.demoUrl, config.setupShTimeoutMillis, config.demoConfiguration)
         call.respondText(
             "Agent is set up.",
             status = HttpStatusCode.OK,

--- a/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/utils/SetupUtils.kt
+++ b/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/utils/SetupUtils.kt
@@ -11,12 +11,8 @@ import com.saveourtool.save.core.utils.ExecutionResult
 import com.saveourtool.save.core.utils.ProcessBuilder
 import com.saveourtool.save.demo.DemoConfiguration
 import com.saveourtool.save.utils.*
-import io.ktor.http.*
 
-import io.ktor.server.application.*
 import okio.Path.Companion.toPath
-
-import kotlinx.coroutines.*
 
 private const val SETUP_SH_TIMEOUT_MILLIS = 5000L
 private const val SETUP_SH_LOGS_FILENAME = "setup.logs"
@@ -26,10 +22,11 @@ private const val CWD = "."
  * Download all the required files from save-demo
  *
  * @param demoUrl url to save-demo
+ * @param setupShTimeoutMillis amount of milliseconds to run setup.sh if it is present
  * @param demoConfiguration all the information required for tool download
  * @throws IllegalStateException when it was caught from [downloadDemoFiles]
  */
-suspend fun setupEnvironment(demoUrl: String, demoConfiguration: DemoConfiguration) {
+suspend fun setupEnvironment(demoUrl: String, setupShTimeoutMillis: Long, demoConfiguration: DemoConfiguration) {
     logInfo("Setting up the environment...")
 
     try {
@@ -41,7 +38,7 @@ suspend fun setupEnvironment(demoUrl: String, demoConfiguration: DemoConfigurati
 
     logDebug("All files successfully downloaded.")
 
-    val executionResult = executeSetupSh()
+    val executionResult = executeSetupSh(setupShTimeoutMillis)
     executionResult?.let {
         if (executionResult.code != 0) {
             logError("Setup script has finished with ${executionResult.code} code.")
@@ -53,7 +50,7 @@ suspend fun setupEnvironment(demoUrl: String, demoConfiguration: DemoConfigurati
     logInfo("The environment is successfully set up.")
 }
 
-private fun executeSetupSh(setupShName: String = "setup.sh"): ExecutionResult? = setupShName.takeIf {
+private fun executeSetupSh(setupShTimeoutMillis: Long, setupShName: String = "setup.sh"): ExecutionResult? = setupShName.takeIf {
     fs.exists(it.toPath())
 }
     ?.let { setupSh ->
@@ -62,7 +59,7 @@ private fun executeSetupSh(setupShName: String = "setup.sh"): ExecutionResult? =
             "./$setupSh",
             CWD,
             SETUP_SH_LOGS_FILENAME.toPath(),
-            SETUP_SH_TIMEOUT_MILLIS,
+            setupShTimeoutMillis,
         )
     }
 


### PR DESCRIPTION
This PR is a part of #1952

### What's done:
 * Made `setup.sh` timeout configurable
 * Unified default value for `setup.sh` timeout for both `save-agent` and `save-demo-agent`