### PR TITLE
Several run commands for single demo

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoAgentConfig.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoAgentConfig.kt
@@ -49,7 +49,7 @@ data class DemoConfiguration(
  *
  * @property inputFileName name of input file name
  * @property configFileName name of config file or null if not supported
- * @property runCommand command that should be executed in order to launch demo run
+ * @property runCommands [RunCommandMap] where key is mode name and value is run command for that mode
  * @property outputFileName name of a file that contains the output information e.g. report
  * @property logFileName name of file that contains logs
  */
@@ -57,7 +57,7 @@ data class DemoConfiguration(
 data class RunConfiguration(
     val inputFileName: String,
     val configFileName: String?,
-    val runCommand: String,
+    val runCommands: RunCommandMap,
     val outputFileName: String?,
     val logFileName: String = "logs.txt",
 )

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoDto.kt
@@ -4,10 +4,13 @@ import com.saveourtool.save.domain.ProjectCoordinates
 import com.saveourtool.save.domain.Sdk
 import kotlinx.serialization.Serializable
 
+typealias RunCommandMap = Map<String, String>
+typealias RunCommandPair = Pair<String, String>
+
 /**
  * @property projectCoordinates saveourtool project coordinates
  * @property vcsTagName release tag that defines the version to be fetched
- * @property runCommand command that is used to run demo on test file [fileName]
+ * @property runCommands [RunCommandMap] where key is mode name and value is run command for that mode
  * @property fileName name of an input file
  * @property sdk required sdk for tool run
  * @property configName name of config file or null if no config file is consumed
@@ -18,7 +21,7 @@ import kotlinx.serialization.Serializable
 data class DemoDto(
     val projectCoordinates: ProjectCoordinates,
     val vcsTagName: String,
-    val runCommand: String,
+    val runCommands: RunCommandMap,
     val fileName: String,
     val sdk: Sdk = Sdk.Default,
     val configName: String? = null,
@@ -29,7 +32,21 @@ data class DemoDto(
      * @return true of [DemoDto] is valid, false otherwise
      */
     @Suppress("FUNCTION_BOOLEAN_PREFIX")
-    fun validate(): Boolean = !projectCoordinates.consideredBlank() && runCommand.isNotBlank() && fileName.isNotBlank()
+    fun validate(): Boolean = !projectCoordinates.consideredBlank() && fileName.isNotBlank() && validateRunCommands()
+
+    @Suppress("FUNCTION_BOOLEAN_PREFIX")
+    private fun validateRunCommands(): Boolean = with(runCommands) {
+        isNotEmpty() && keys.all { key -> key.isNotBlank() } && values.all { value -> value.isNotBlank() }
+    }
+
+    /**
+     * @param mode name of mode that demo should be run on
+     * @return run command for [mode]
+     */
+    fun getRunCommand(mode: String): String {
+        require(mode.isNotBlank()) { "Demo mode should not be blank." }
+        return requireNotNull(runCommands[mode]) { "Could not find run command for mode $mode." }
+    }
 
     companion object {
         val empty = emptyForProject("", "")
@@ -42,7 +59,7 @@ data class DemoDto(
         fun emptyForProject(organizationName: String, projectName: String) = DemoDto(
             ProjectCoordinates(organizationName, projectName),
             "",
-            "",
+            emptyMap(),
             "",
             Sdk.Default,
             null,

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoRunRequest.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoRunRequest.kt
@@ -5,17 +5,17 @@ import kotlinx.serialization.Serializable
 
 /**
  * @property codeLines file as String that contains code requested for demo run
- * @property mode mode to tell if the analysis should be performed in [DemoMode.WARN] or in [DemoMode.FIX]
+ * @property mode mode to determine the mode that the tool should be run in
  * @property config additional configuration file for demo
  */
 @Serializable
 data class DemoRunRequest(
     val codeLines: List<String>,
-    val mode: DemoMode? = null,
+    val mode: String,
     val config: List<String>? = null,
 ) {
     companion object {
-        val empty = DemoRunRequest(emptyList(), null, null)
+        val empty = DemoRunRequest(emptyList(), "", null)
 
         /**
          * Default config for [DiktatDemoTool.DIKTAT]
@@ -121,6 +121,6 @@ data class DemoRunRequest(
             |- name: COMPLEX_EXPRESSION
             |  enabled: true
         """.trimMargin().split("\n")
-        val diktatDemoRunRequest = DemoRunRequest(emptyList(), DemoMode.WARN, defaultDiktatConfig)
+        val diktatDemoRunRequest = DemoRunRequest(emptyList(), "Warn", defaultDiktatConfig)
     }
 }

--- a/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/SimpleRunner.kt
+++ b/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/SimpleRunner.kt
@@ -32,14 +32,21 @@ fun runDemo(
     demoRunRequest: DemoRunRequest,
     deferredConfig: CompletableDeferred<DemoAgentConfig>,
 ): DemoResult {
+    require(demoRunRequest.mode.isNotBlank()) {
+        "Demo mode should not be blank."
+    }
     val config = deferredConfig.getCompleted().runConfiguration
-    val (inputFile, configFile) = createRequiredFiles(demoRunRequest, config)
 
+    val runCommand = requireNotNull(config.runCommands[demoRunRequest.mode]) {
+        "Could not find run command for mode ${demoRunRequest.mode}."
+    }
+
+    val (inputFile, configFile) = createRequiredFiles(demoRunRequest, config)
     val logFile = config.logFileName.toPath()
     val outputFile = config.outputFileName?.toPath()
 
     return try {
-        run(config.runCommand, inputFile, logFile, outputFile)
+        run(runCommand, inputFile, logFile, outputFile)
     } finally {
         cleanUp(inputFile, configFile, logFile, outputFile)
     }

--- a/save-demo/db/tables/db.changelog-tables.xml
+++ b/save-demo/db/tables/db.changelog-tables.xml
@@ -10,6 +10,7 @@
     <include file="tool.xml" relativeToChangelogFile="true"/>
     <include file="demo.xml" relativeToChangelogFile="true"/>
     <include file="dependency.xml" relativeToChangelogFile="true"/>
+    <include file="run-command.xml" relativeToChangelogFile="true"/>
 
     <changeSet id="demo-tag" author="sanyavertolet">
         <tagDatabase tag="demo-tables"/>

--- a/save-demo/db/tables/demo.xml
+++ b/save-demo/db/tables/demo.xml
@@ -47,4 +47,8 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="demo-drop_run_command" author="sanyavertolet" context="dev or prod">
+        <dropColumn tableName="demo" columnName="run_command"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/save-demo/db/tables/run-command.xml
+++ b/save-demo/db/tables/run-command.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="run-command-1" author="sanyavertolet" context="dev or prod">
+        <createTable tableName="run_command">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="demo_id" type="bigint">
+                <constraints nullable="false"
+                             foreignKeyName="fk_run_command_demo"
+                             referencedColumnNames="id"
+                             referencedTableName="demo"
+                             deleteCascade="true"/>
+            </column>
+            <column name="mode_name" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="command" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint tableName="run_command" columnNames="demo_id, mode_name" constraintName="run_command_demo_id_mode_name_constraint"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/ManagementController.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/ManagementController.kt
@@ -33,7 +33,7 @@ class ManagementController(
         }
         .asyncEffect { downloadToolService.initializeGithubDownload(it.githubProjectCoordinates, it.vcsTagName) }
         .flatMap {
-            blockingToMono { demoService.saveIfNotPresent(it.toDemo()).toDto() }
+            blockingToMono { demoService.saveIfNotPresent(it.toDemo(), it.runCommands).toDto() }
         }
 
     /**

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/entity/Demo.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/entity/Demo.kt
@@ -6,8 +6,7 @@ import com.saveourtool.save.demo.RunConfiguration
 import com.saveourtool.save.domain.ProjectCoordinates
 import com.saveourtool.save.domain.toSdk
 import com.saveourtool.save.spring.entity.BaseEntityWithDto
-import javax.persistence.Column
-import javax.persistence.Entity
+import javax.persistence.*
 
 /**
  * Entity that encapsulates all the information required for tool download and run
@@ -15,7 +14,7 @@ import javax.persistence.Entity
  * @property organizationName name of organization from saveourtool
  * @property projectName name of project from saveourtool
  * @property sdk sdk required for demo run
- * @property runCommand command that runs the tool on test file with name [fileName]
+ * @property runCommands list of [RunCommand] entities
  * @property fileName name that the tested input file should have
  * @property configName name of tool config file (or null if no config is needed)
  * @property outputFileName name of output file (or null if [outputFileName] is [fileName])
@@ -28,7 +27,6 @@ class Demo(
     var organizationName: String,
     var projectName: String,
     var sdk: String,
-    var runCommand: String,
     var fileName: String,
     var configName: String?,
     var outputFileName: String?,
@@ -36,6 +34,8 @@ class Demo(
     var githubOrganizationName: String?,
     @Column(name = "github_project")
     var githubProjectName: String?,
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "demo", targetEntity = RunCommand::class)
+    var runCommands: List<RunCommand> = emptyList(),
 ) : BaseEntityWithDto<DemoDto>() {
     private fun githubProjectCoordinates() = githubOrganizationName?.let { organization ->
         githubProjectName?.let { project ->
@@ -57,7 +57,7 @@ class Demo(
     override fun toDto(): DemoDto = DemoDto(
         projectCoordinates(),
         "",
-        runCommand,
+        runCommands.toRunCommandsMap(),
         fileName,
         sdk.toSdk(),
         configName,
@@ -71,7 +71,7 @@ class Demo(
     fun toRunConfiguration() = RunConfiguration(
         fileName,
         configName,
-        runCommand,
+        runCommands.toRunCommandsMap(),
         outputFileName,
     )
 
@@ -84,19 +84,31 @@ class Demo(
         projectName,
         version,
     )
+
+    /**
+     * @param mode name of mode that demo should be run on
+     * @return run command for [mode]
+     */
+    fun getRunCommand(mode: String): String {
+        require(mode.isNotBlank()) { "Demo mode should not be blank." }
+        return requireNotNull(runCommands.find { it.modeName == mode }) {
+            "Could not find run command for mode $mode."
+        }.command
+    }
 }
 
 /**
+ * @param runCommands [MutableList] of [RunCommand]
  * @return [Demo] entity filled with [DemoDto] data
  */
-fun DemoDto.toDemo() = Demo(
+fun DemoDto.toDemo(runCommands: List<RunCommand> = mutableListOf()) = Demo(
     projectCoordinates.organizationName,
     projectCoordinates.projectName,
     sdk.toString(),
-    runCommand,
     fileName,
     configName,
     outputFileName,
     githubProjectCoordinates?.organizationName,
     githubProjectCoordinates?.projectName,
+    runCommands,
 )

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/entity/RunCommand.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/entity/RunCommand.kt
@@ -1,0 +1,31 @@
+package com.saveourtool.save.demo.entity
+
+import com.saveourtool.save.demo.RunCommandMap
+import com.saveourtool.save.spring.entity.BaseEntity
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+
+/**
+ * Entity that encapsulates the run command that should be used to run specific [demo] mode
+ *
+ * @property demo [Demo] entity
+ * @property modeName name of a mode, e.g. Fix or Warn
+ * @property command command that runs the [demo] with mode with name [modeName]
+ */
+@Entity
+class RunCommand(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "demo_id")
+    var demo: Demo,
+    var modeName: String,
+    var command: String,
+) : BaseEntity()
+
+/**
+ * @return [RunCommandMap] where key is mode name and value is run command for that mode
+ */
+fun List<RunCommand>.toRunCommandsMap(): RunCommandMap = associate { mode ->
+    mode.modeName to mode.command
+}

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/repository/RunCommandRepository.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/repository/RunCommandRepository.kt
@@ -1,0 +1,11 @@
+package com.saveourtool.save.demo.repository
+
+import com.saveourtool.save.demo.entity.RunCommand
+import com.saveourtool.save.spring.repository.BaseEntityRepository
+import org.springframework.stereotype.Repository
+
+/**
+ * JPA repository for [RunCommand] entity.
+ */
+@Repository
+interface RunCommandRepository : BaseEntityRepository<RunCommand>

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/cli/DemoCliRunner.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/cli/DemoCliRunner.kt
@@ -38,12 +38,11 @@ class DemoCliRunner(
                 dependency.fileName to getExecutable(workingDir, dependency.toToolKey())
             }
         return commandBuilder.build(
-            demo.runCommand,
+            demo.getRunCommand(demoRunRequest.mode),
             CommandContext(
                 testPath,
                 tools,
                 outputPath,
-                demoRunRequest.mode,
                 configPath,
             )
         )

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/cli/DiktatCliRunner.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/cli/DiktatCliRunner.kt
@@ -47,7 +47,7 @@ class DiktatCliRunner(
         append(" --disabled_rules=diktat-ruleset:package-naming,standard")
 
         append(" --reporter=plain,output=$outputPath ")
-        if (demoRunRequest.mode == DemoMode.FIX) {
+        if (demoRunRequest.mode == DemoMode.FIX.name) {
             append(" --format ")
         }
         append(testPath)

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/command/CommandBuilder.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/command/CommandBuilder.kt
@@ -1,6 +1,5 @@
 package com.saveourtool.save.demo.runners.command
 
-import com.saveourtool.save.demo.DemoMode
 import org.apache.commons.text.StringSubstitutor
 import org.springframework.stereotype.Component
 
@@ -20,12 +19,6 @@ class CommandBuilder {
     private fun CommandContext.toMap(): Map<String, String> = buildMap {
         put("testPath", testPath.toString())
         put("outputPath", outputPath.toString())
-        mode?.let {
-            when (it) {
-                DemoMode.FIX -> put("isWarn", "")
-                DemoMode.WARN -> put("isFix", "")
-            }
-        }
         tools.map { (key, value) ->
             put("tools.$key", value.toString())
         }

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/command/CommandContext.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/runners/command/CommandContext.kt
@@ -1,20 +1,18 @@
 package com.saveourtool.save.demo.runners.command
 
-import com.saveourtool.save.demo.DemoMode
 import java.nio.file.Path
 
 /**
  * Context for command
+ *
  * @property testPath
  * @property tools
  * @property outputPath
- * @property mode
  * @property configPath
  */
 data class CommandContext(
     val testPath: Path,
     val tools: Map<String, Path>,
     val outputPath: Path,
-    val mode: DemoMode?,
     val configPath: Path?,
 )

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/service/DemoService.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/service/DemoService.kt
@@ -104,9 +104,9 @@ class DemoService(
     fun saveIfNotPresent(demo: Demo, runCommands: RunCommandMap): Demo = demoRepository.findByOrganizationNameAndProjectName(demo.organizationName, demo.projectName)?.let {
         throw IllegalStateException("Demo for project ${demo.organizationName}/${demo.projectName} is already added.")
     } ?: run {
-        save(demo).also { savedDemo ->
-            runCommands.map { (mode, command) ->
-                RunCommand(savedDemo, mode, command)
+        save(demo).apply {
+            this.runCommands = runCommands.map { (mode, command) ->
+                RunCommand(this, mode, command)
             }.let { runCommandList ->
                 runCommandRepository.saveAll(runCommandList)
             }

--- a/save-demo/src/test/kotlin/com/saveourtool/save/demo/runners/cli/CommandBuilderTest.kt
+++ b/save-demo/src/test/kotlin/com/saveourtool/save/demo/runners/cli/CommandBuilderTest.kt
@@ -19,13 +19,12 @@ class CommandBuilderTest {
                 "diktat" to "diktat-1.2.3.jar".toPath().toNioPath(),
             ),
             "./output.txt".toPath().toNioPath(),
-            DemoMode.FIX,
             null,
         )
         @Suppress("MaxLineLength")
         Assertions.assertEquals(
-            "ktlint -R diktat-1.2.3.jar --disabled_rules=diktat-ruleset:package-naming,standard --reporter=plain,output=output.txt --format",
-            builder.build("\${tools.ktlint} -R \${tools.diktat} --disabled_rules=diktat-ruleset:package-naming,standard --reporter=plain,output=\${outputPath} \${isFix:---format}", commandContext)
+            "ktlint -R diktat-1.2.3.jar --disabled_rules=diktat-ruleset:package-naming,standard --reporter=plain,output=output.txt",
+            builder.build("\${tools.ktlint} -R \${tools.diktat} --disabled_rules=diktat-ruleset:package-naming,standard --reporter=plain,output=\${outputPath}", commandContext)
         )
     }
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/SdkSelection.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/SdkSelection.kt
@@ -9,20 +9,63 @@ package com.saveourtool.save.frontend.components.basic
 import com.saveourtool.save.domain.*
 
 import csstype.ClassName
-import react.ChildrenBuilder
-import react.FC
-import react.PropsWithChildren
+import react.*
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.option
 import react.dom.html.ReactHTML.select
-import react.useState
 import web.html.HTMLSelectElement
 
 /**
  * Component for sdk selection
  */
-val sdkSelection = sdkSelection()
+val sdkSelection: FC<SdkProps> = FC { props ->
+    val (sdkName, setSdkName) = useState(props.selectedSdk.name)
+    val (sdkVersion, setSdkVersion) = useState(props.selectedSdk.version)
+
+    if (props.title.isNotBlank()) {
+        label {
+            className =
+                    ClassName("control-label col-auto justify-content-between font-weight-bold text-gray-800 mb-1 pl-0")
+            +props.title
+        }
+    }
+    div {
+        className = ClassName("card align-items-left mb-3 pt-0 pb-0")
+        div {
+            className = ClassName("card-body align-items-left pb-1 pt-3")
+            div {
+                className = ClassName("row no-gutters align-items-left")
+                selection(
+                    "SDK",
+                    sdkName,
+                    sdks,
+                    isDisabled = props.isDisabled,
+                ) { element ->
+                    val newSdkName = element.value
+                    val newSdkVersion = newSdkName.getSdkVersions().first()
+                    setSdkName(newSdkName)
+                    setSdkVersion(newSdkVersion)
+                    props.onSdkChange("$newSdkName:$newSdkVersion".toSdk())
+                }
+            }
+            div {
+                className = ClassName("row no-gutters align-items-left")
+                className = ClassName("d-inline")
+                selection(
+                    "Version",
+                    sdkVersion,
+                    sdkName.getSdkVersions(),
+                    isDisabled = props.isDisabled,
+                ) { element ->
+                    val newSdkVersion = element.value
+                    setSdkVersion(newSdkVersion)
+                    props.onSdkChange("$sdkName:$newSdkVersion".toSdk())
+                }
+            }
+        }
+    }
+}
 
 /**
  * Props for SdkSelection component
@@ -81,51 +124,3 @@ private fun ChildrenBuilder.selection(
         }
     }
 }
-
-private fun sdkSelection() =
-        FC<SdkProps> { props ->
-            val (sdkName, setSdkName) = useState(props.selectedSdk.name)
-            val (sdkVersion, setSdkVersion) = useState(props.selectedSdk.version)
-            if (props.title.isNotBlank()) {
-                label {
-                    className =
-                            ClassName("control-label col-auto justify-content-between font-weight-bold text-gray-800 mb-1 pl-0")
-                    +props.title
-                }
-            }
-            div {
-                className = ClassName("card align-items-left mb-3 pt-0 pb-0")
-                div {
-                    className = ClassName("card-body align-items-left pb-1 pt-3")
-                    div {
-                        className = ClassName("row no-gutters align-items-left")
-                        selection(
-                            "SDK",
-                            sdkName,
-                            sdks,
-                            isDisabled = props.isDisabled,
-                        ) { element ->
-                            val newSdkName = element.value
-                            val newSdkVersion = newSdkName.getSdkVersions().first()
-                            setSdkName(newSdkName)
-                            setSdkVersion(newSdkVersion)
-                            props.onSdkChange("$newSdkName:$newSdkVersion".toSdk())
-                        }
-                    }
-                    div {
-                        className = ClassName("row no-gutters align-items-left")
-                        className = ClassName("d-inline")
-                        selection(
-                            "Version",
-                            sdkVersion,
-                            sdkName.getSdkVersions(),
-                            isDisabled = props.isDisabled,
-                        ) { element ->
-                            val newSdkVersion = element.value
-                            setSdkVersion(newSdkVersion)
-                            props.onSdkChange("$sdkName:$newSdkVersion".toSdk())
-                        }
-                    }
-                }
-            }
-        }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoButtons.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoButtons.kt
@@ -1,0 +1,90 @@
+/**
+ * Buttons of demo management card
+ */
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoStatus
+import com.saveourtool.save.domain.Role
+import com.saveourtool.save.frontend.utils.buttonBuilder
+import csstype.ClassName
+import react.ChildrenBuilder
+import react.dom.html.ReactHTML.div
+
+/**
+ * Display buttons of demo management card
+ *
+ * @param demoStatus [DemoStatus] of this demo
+ * @param userRole current user role, required for button disabling
+ * @param sendDemoCreationRequest callback that sends creation request to backend
+ * @param getDemoStatus callback that fetches [DemoStatus] of this demo
+ * @param startDemo callback that sends request to start demo pod
+ * @param stopDemo callback that sends request to stop demo pod
+ * @param deleteDemo callback that sends request to delete created demo
+ */
+@Suppress("TOO_MANY_PARAMETERS", "LongParameterList")
+internal fun ChildrenBuilder.renderButtons(
+    demoStatus: DemoStatus,
+    userRole: Role,
+    sendDemoCreationRequest: () -> Unit,
+    getDemoStatus: () -> Unit,
+    startDemo: () -> Unit,
+    stopDemo: () -> Unit,
+    deleteDemo: () -> Unit,
+) {
+    div {
+        className = ClassName("flex-wrap d-flex justify-content-around")
+        when (demoStatus) {
+            DemoStatus.NOT_CREATED -> buttonBuilder("Create", isDisabled = userRole.isLowerThan(Role.OWNER)) {
+                sendDemoCreationRequest()
+            }
+
+            DemoStatus.STARTING -> {
+                buttonBuilder("Stop", style = "warning", isDisabled = userRole.isLowerThan(Role.ADMIN)) {
+                    stopDemo()
+                }
+                buttonBuilder("Reload", style = "secondary", isDisabled = userRole.isLowerThan(Role.VIEWER)) {
+                    getDemoStatus()
+                }
+            }
+
+            DemoStatus.RUNNING -> {
+                buttonBuilder("Stop", style = "warning", isDisabled = userRole.isLowerThan(Role.ADMIN)) {
+                    stopDemo()
+                }
+                buttonBuilder("Delete", style = "danger", isDisabled = userRole.isLowerThan(Role.OWNER)) {
+                    deleteDemo()
+                }
+            }
+
+            DemoStatus.ERROR -> {
+                buttonBuilder("Run", isDisabled = userRole.isLowerThan(Role.ADMIN)) {
+                    startDemo()
+                }
+                buttonBuilder("Delete", style = "danger", isDisabled = userRole.isLowerThan(Role.OWNER)) {
+                    deleteDemo()
+                }
+            }
+
+            DemoStatus.STOPPED -> {
+                buttonBuilder("Run", isDisabled = userRole.isLowerThan(Role.ADMIN)) {
+                    startDemo()
+                }
+                buttonBuilder("Update configuration", style = "info", isDisabled = userRole.isLowerThan(Role.ADMIN)) {
+                    // update request here
+                }
+                buttonBuilder("Delete", style = "danger", isDisabled = userRole.isLowerThan(Role.OWNER)) {
+                    deleteDemo()
+                }
+            }
+
+            DemoStatus.STOPPING -> buttonBuilder(
+                "Reload",
+                style = "secondary",
+                isDisabled = userRole.isLowerThan(Role.VIEWER)
+            ) {
+                getDemoStatus()
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoFileUploader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoFileUploader.kt
@@ -1,0 +1,120 @@
+/**
+ * File uploader of demo management card
+ */
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoDto
+import com.saveourtool.save.demo.DemoStatus
+import com.saveourtool.save.domain.ProjectCoordinates
+import com.saveourtool.save.entities.FileDto
+import com.saveourtool.save.frontend.components.basic.fileuploader.simpleFileUploader
+import com.saveourtool.save.frontend.utils.apiUrl
+import csstype.ClassName
+import react.ChildrenBuilder
+import react.StateSetter
+import react.dom.html.AutoComplete
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+
+/**
+ * Display file uploader of demo management card
+ *
+ * @param demoStatus [DemoStatus] of this demo
+ * @param demoDto currently configured [DemoDto]
+ * @param setDemoDto callback to update state of [demoDto]
+ * @param githubProjectCoordinates GitHub's organization and project name wrapped into [ProjectCoordinates]
+ * @param setGithubProjectCoordinates callback that updates [githubProjectCoordinates] state
+ * @param setSelectedFileDtos update state of list of [FileDto] that should be connected with this demo
+ */
+@Suppress(
+    "TOO_LONG_FUNCTION",
+    "LongMethod",
+    "TOO_MANY_PARAMETERS",
+    "TYPE_ALIAS",
+    "LongParameterList"
+)
+internal fun ChildrenBuilder.renderFileUploading(
+    demoStatus: DemoStatus,
+    demoDto: DemoDto,
+    setDemoDto: StateSetter<DemoDto>,
+    githubProjectCoordinates: ProjectCoordinates,
+    setGithubProjectCoordinates: StateSetter<ProjectCoordinates>,
+    setSelectedFileDtos: StateSetter<List<FileDto>>,
+) {
+    div {
+        className = ClassName("d-flex justify-content-between align-items-center")
+        div {
+            className = ClassName("col pl-0")
+            input {
+                className = ClassName("form-control col mb-2")
+                autoComplete = AutoComplete.off
+                placeholder = "GitHub organization name"
+                value = githubProjectCoordinates.organizationName
+                disabled = true
+                onChange = { event ->
+                    setGithubProjectCoordinates {
+                        it.copy(organizationName = event.target.value)
+                    }
+                }
+            }
+            input {
+                className = ClassName("form-control col mb-2")
+                autoComplete = AutoComplete.off
+                placeholder = "GitHub project name"
+                value = githubProjectCoordinates.projectName
+                disabled = true
+                onChange = { event ->
+                    setGithubProjectCoordinates {
+                        it.copy(projectName = event.target.value)
+                    }
+                }
+            }
+            input {
+                className = ClassName("form-control col")
+                autoComplete = AutoComplete.off
+                placeholder = "Release tag"
+                value = demoDto.vcsTagName
+                disabled = true
+                onChange = { event ->
+                    setDemoDto { request ->
+                        request.copy(vcsTagName = event.target.value)
+                    }
+                }
+            }
+        }
+        div {
+            +" or "
+        }
+        div {
+            className = ClassName("col pr-0")
+            div {
+                simpleFileUploader {
+                    buttonLabel = " Upload files"
+                    getUrlForAvailableFilesFetch = {
+                        with(demoDto) {
+                            "$apiUrl/files/$projectCoordinates/list"
+                        }
+                    }
+                    getUrlForDemoFilesFetch = {
+                        with(demoDto) {
+                            "$apiUrl/demo/$projectCoordinates/list-file"
+                        }
+                    }
+                    getUrlForFileDeletion = {
+                        with(demoDto) {
+                            "$apiUrl/demo/$projectCoordinates/delete?fileId=${it.id}"
+                        }
+                    }
+                    getUrlForFileUpload = {
+                        with(demoDto) {
+                            "$apiUrl/files/$projectCoordinates/upload"
+                        }
+                    }
+                    updateFileDtos = { setSelectedFileDtos(it) }
+                    isDisabled = demoStatus == DemoStatus.STARTING || demoStatus == DemoStatus.RUNNING
+                }
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoModeDisplayer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoModeDisplayer.kt
@@ -1,0 +1,64 @@
+/**
+ * Modal for better run command management
+ */
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoDto
+import com.saveourtool.save.demo.RunCommandPair
+import com.saveourtool.save.frontend.components.modal.mediumTransparentModalStyle
+import com.saveourtool.save.frontend.components.modal.modal
+import com.saveourtool.save.frontend.components.modal.modalBuilder
+import com.saveourtool.save.frontend.utils.buttonBuilder
+import com.saveourtool.save.utils.isNotNull
+import csstype.ClassName
+import react.*
+import react.dom.html.ReactHTML.div
+
+/**
+ * Display modal for better run command management
+ *
+ * @param selectedOption currently selected [RunCommandPair]
+ * @param setSelectedOption callback to update state of [selectedOption]
+ * @param disabled flag that defines whether forms should be disabled or not
+ * @param setDemoDto callback to update currently configured [DemoDto]
+ */
+internal fun ChildrenBuilder.demoModeModal(
+    selectedOption: RunCommandPair?,
+    setSelectedOption: StateSetter<RunCommandPair?>,
+    disabled: Boolean,
+    setDemoDto: StateSetter<DemoDto>,
+) {
+    val selectedDemoMode = selectedOption?.first
+    val selectedRunCommand = selectedOption?.second
+    modal { props ->
+        props.isOpen = selectedOption.isNotNull()
+        props.style = mediumTransparentModalStyle
+        modalBuilder(
+            "Demo Mode",
+            onCloseButtonPressed = { setSelectedOption(null) },
+            bodyBuilder = {
+                div {
+                    className = ClassName("d-flex justify-content-center")
+                    demoRunCommandEditor {
+                        this.setDemoDto = setDemoDto
+                        this.disabled = disabled
+                        this.defaultModeName = selectedDemoMode
+                        this.defaultRunCommand = selectedRunCommand
+                        this.isEdit = true
+                        this.setSelectedOption = setSelectedOption
+                    }
+                }
+            },
+        ) {
+            buttonBuilder("Delete", "danger") {
+                setDemoDto { demoDto ->
+                    demoDto.copy(runCommands = demoDto.runCommands.filter { (mode, _) ->
+                        mode != selectedDemoMode
+                    })
+                }
+                setSelectedOption(null)
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoModeLabel.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoModeLabel.kt
@@ -1,0 +1,51 @@
+/**
+ * Clickable demo mode label
+ */
+
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.RunCommandPair
+import com.saveourtool.save.frontend.utils.buttonBuilder
+import csstype.ClassName
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+
+/**
+ * Clickable demo mode label
+ */
+val demoModeLabel: FC<DemoModeLabelProps> = FC { props ->
+    div {
+        className = ClassName(props.classes)
+        buttonBuilder(props.modeName, "secondary", classes = "badge badge-pill badge-secondary") {
+            props.onClickCallback(props.modeName to props.runCommand)
+        }
+    }
+}
+
+/**
+ * [Props] of [demoModeLabel]
+ */
+external interface DemoModeLabelProps : Props {
+    /**
+     * Name of possible mode that the demo can be run with
+     */
+    var modeName: String
+
+    /**
+     * Run command that should be executed in order to run demo with mode with name [modeName]
+     */
+    var runCommand: String
+
+    /**
+     * [ClassName] that should be applied to outer [div] block
+     */
+    var classes: String
+
+    /**
+     * Callback that is invoked when label is clicked
+     */
+    var onClickCallback: (RunCommandPair) -> Unit
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoRunCommands.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoRunCommands.kt
@@ -1,0 +1,144 @@
+/**
+ * Run command editor section of projectDemoMenu
+ */
+
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoDto
+import com.saveourtool.save.demo.RunCommandPair
+import com.saveourtool.save.frontend.externals.fontawesome.faEdit
+import com.saveourtool.save.frontend.externals.fontawesome.faPlus
+import com.saveourtool.save.frontend.utils.buttonBuilder
+import com.saveourtool.save.frontend.utils.useTooltip
+import csstype.ClassName
+import react.*
+import react.dom.html.AutoComplete
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+
+/**
+ * A pair of input forms for Mode name and run command with "Apply" button
+ */
+@Suppress("TOO_LONG_FUNCTION")
+val demoRunCommandEditor: FC<DemoSettingsAdder> = FC { props ->
+    useTooltip()
+    val (modeName, setModeName) = useState(props.defaultModeName.orEmpty())
+    val (runCommand, setRunCommand) = useState(props.defaultRunCommand.orEmpty())
+    div {
+        className = ClassName("input-group mb-2")
+        input {
+            className = ClassName("form-control col-3")
+            autoComplete = AutoComplete.off
+            placeholder = "Mode name"
+            value = modeName
+            disabled = props.disabled
+            onChange = { event -> setModeName(event.target.value) }
+        }
+        input {
+            className = ClassName("form-control col")
+            autoComplete = AutoComplete.off
+            placeholder = "Run command"
+            value = runCommand
+            this.disabled = disabled
+            onChange = { event -> setRunCommand(event.target.value) }
+        }
+        div {
+            className = ClassName("input-group-append")
+            val icon = if (props.isEdit) faEdit else faPlus
+            buttonBuilder(
+                icon,
+                isDisabled = props.disabled || modeName.isBlank() || runCommand.isBlank(),
+                isOutline = true,
+            ) {
+                props.setDemoDto { demoDto ->
+                    val newRunCommands = if (props.isEdit) {
+                        demoDto.runCommands.minus(props.defaultModeName.orEmpty()).plus(modeName to runCommand)
+                    } else {
+                        demoDto.runCommands.plus(modeName to runCommand)
+                    }
+                    demoDto.copy(
+                        runCommands = newRunCommands
+                    )
+                }
+                props.setSelectedOption?.invoke(null)
+                setRunCommand("")
+                setModeName("")
+            }
+        }
+    }
+}
+
+/**
+ * [Props] of [demoRunCommandEditor]
+ */
+external interface DemoSettingsAdder : Props {
+    /**
+     * Callback to update [DemoDto] state
+     */
+    var setDemoDto: StateSetter<DemoDto>
+
+    /**
+     * Flag that defines whether in forms should be disabled or not
+     */
+    var disabled: Boolean
+
+    /**
+     * Default value of modeName input form, if null, empty string is used
+     */
+    var defaultModeName: String?
+
+    /**
+     * Default value of runCommand input form, if null, empty string is used
+     */
+    var defaultRunCommand: String?
+
+    /**
+     * Flag that defined if [demoRunCommandEditor] run in edit mode or not
+     */
+    var isEdit: Boolean
+
+    /**
+     * Callback to update currently selected [RunCommandPair]
+     */
+    var setSelectedOption: StateSetter<RunCommandPair?>?
+}
+
+/**
+ * Display run command editor section of projectDemoMenu
+ *
+ * @param demoDto currently configured [DemoDto]
+ * @param setDemoDto callback to update [demoDto] state
+ * @param isDisabled flag that defines if input forms are disabled or not
+ * @param onOptionClickCallback callback that selects [RunCommandPair] and opens extended run command editor
+ */
+internal fun ChildrenBuilder.renderRunCommand(
+    demoDto: DemoDto,
+    setDemoDto: StateSetter<DemoDto>,
+    isDisabled: Boolean,
+    onOptionClickCallback: StateSetter<RunCommandPair?>,
+) {
+    div {
+        div {
+            demoRunCommandEditor {
+                this.setDemoDto = setDemoDto
+                this.disabled = isDisabled
+                this.defaultModeName = ""
+                this.defaultRunCommand = ""
+                this.isEdit = false
+            }
+            div {
+                className = ClassName("d-flex justify-content-start")
+                demoDto.runCommands.map { (mode, command) ->
+                    demoModeLabel {
+                        this.modeName = mode
+                        this.runCommand = command
+                        this.classes = "m-2"
+                        this.onClickCallback = { runCommandPair -> onOptionClickCallback(runCommandPair) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoSdkSelector.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoSdkSelector.kt
@@ -1,0 +1,33 @@
+/**
+ * Sdk selector of projectDemoMenu
+ */
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoDto
+import com.saveourtool.save.frontend.components.basic.sdkSelection
+import react.ChildrenBuilder
+import react.StateSetter
+import react.dom.html.ReactHTML.div
+
+/**
+ * Display [sdkSelection] of projectDemoMenu
+ *
+ * @param demoDto currently configured [DemoDto]
+ * @param setDemoDto callback to update [demoDto] state
+ * @param isDisabled flag that defines if sdk selectors should be disabled or not
+ */
+internal fun ChildrenBuilder.renderSdkSelector(demoDto: DemoDto, setDemoDto: StateSetter<DemoDto>, isDisabled: Boolean) {
+    div {
+        sdkSelection {
+            title = ""
+            this.isDisabled = isDisabled
+            selectedSdk = demoDto.sdk
+            onSdkChange = { newSdk ->
+                setDemoDto { oldDemoDto ->
+                    oldDemoDto.copy(sdk = newSdk)
+                }
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoSettingsComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoSettingsComponent.kt
@@ -1,0 +1,64 @@
+/**
+ * Demo file names input forms
+ */
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoDto
+import csstype.ClassName
+import react.*
+import react.dom.html.AutoComplete
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+
+/**
+ * Display demo file names input forms such as config filename form, input filename form etc
+ *
+ * @param demoDto currently configured [DemoDto]
+ * @param setDemoDto callback to update [demoDto] state
+ */
+internal fun ChildrenBuilder.renderDemoSettings(demoDto: DemoDto, setDemoDto: StateSetter<DemoDto>) {
+    div {
+        div {
+            input {
+                className = ClassName("form-control col mb-2")
+                autoComplete = AutoComplete.off
+                placeholder = "Test file name"
+                value = demoDto.fileName
+                this.disabled = disabled
+                onChange = { event ->
+                    setDemoDto { request ->
+                        request.copy(fileName = event.target.value)
+                    }
+                }
+            }
+        }
+        div {
+            className = ClassName("d-flex justify-content-between")
+            input {
+                className = ClassName("form-control col mr-1")
+                autoComplete = AutoComplete.off
+                placeholder = "Output file name"
+                value = demoDto.outputFileName
+                this.disabled = disabled
+                onChange = { event ->
+                    setDemoDto { request ->
+                        request.copy(outputFileName = event.target.value.ifBlank { null })
+                    }
+                }
+            }
+            input {
+                className = ClassName("form-control col ml-1")
+                autoComplete = AutoComplete.off
+                placeholder = "Config name"
+                value = demoDto.configName
+                this.disabled = disabled
+                onChange = { event ->
+                    setDemoDto { request ->
+                        request.copy(configName = event.target.value.ifBlank { null })
+                    }
+                }
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoStatusLabel.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/management/DemoStatusLabel.kt
@@ -1,0 +1,47 @@
+/**
+ * Current demo status
+ */
+
+package com.saveourtool.save.frontend.components.basic.demo.management
+
+import com.saveourtool.save.demo.DemoStatus
+import csstype.ClassName
+import react.ChildrenBuilder
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.label
+
+/**
+ * Display current demo status wrapped into bordered colorful pill
+ *
+ * @param demoStatus current status of demo e.g. [DemoStatus.STOPPED], [DemoStatus.RUNNING] etc.
+ */
+internal fun ChildrenBuilder.renderStatusLabel(demoStatus: DemoStatus) {
+    div {
+        className = ClassName("col-6 d-flex justify-content-center")
+        div {
+            val borderStyle = when (demoStatus) {
+                DemoStatus.NOT_CREATED -> "border-dark"
+                DemoStatus.STARTING, DemoStatus.STOPPING -> "border-warning"
+                DemoStatus.RUNNING -> "border-success"
+                DemoStatus.STOPPED -> "border-secondary"
+                DemoStatus.ERROR -> "border-danger"
+            }
+            className =
+                    ClassName("border $borderStyle d-flex align-items-center justify-content-between rounded-pill m-3")
+            div {
+                className = ClassName("col m-3 flex-wrap")
+                label {
+                    className = ClassName("m-0")
+                    +"Status"
+                }
+            }
+            div {
+                className = ClassName("col m-3 flex-wrap")
+                label {
+                    className = ClassName("m-0")
+                    +demoStatus.name
+                }
+            }
+        }
+    }
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/demo/DemoView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/demo/DemoView.kt
@@ -1,5 +1,5 @@
 /**
- * View with demo for diktat and ktlint
+ * View with demo
  */
 
 @file:Suppress("FILE_NAME_MATCH_CLASS")
@@ -7,59 +7,37 @@
 package com.saveourtool.save.frontend.components.views.demo
 
 import com.saveourtool.save.demo.DemoDto
-import com.saveourtool.save.demo.DemoRunRequest
+import com.saveourtool.save.domain.ProjectCoordinates
 import com.saveourtool.save.frontend.components.basic.cardComponent
-import com.saveourtool.save.frontend.components.basic.demoRunComponent
+import com.saveourtool.save.frontend.components.basic.demo.demoRunComponent
 import com.saveourtool.save.frontend.externals.reactace.AceThemes
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.utils.Languages
 
 import csstype.*
-import js.core.get
 import react.*
 import react.dom.html.ReactHTML.div
-import react.router.useParams
 
 private val backgroundCard = cardComponent(hasBg = true, isPaddingBottomNull = true)
 
 /**
- * [VFC] for demo view
+ * Demo View
  */
-val demoView: VFC = VFC {
-    val params = useParams()
-    val projectCoordinates = "${params["organizationName"]}/${params["projectName"]}"
-    var configName by useState<String>()
-    useRequest(arrayOf(params)) {
-        configName = get(
-            url = "$demoApiUrl/manager/$projectCoordinates",
+val demoView: FC<DemoViewProps> = FC { props ->
+    useBackground(Style.WHITE)
+    val (demoDto, setDemoDto) = useState(DemoDto.empty)
+    useRequest {
+        get(
+            url = "$demoApiUrl/manager/${props.projectCoordinates}",
             headers = jsonHeaders,
             loadingHandler = ::loadingHandler,
         )
             .unsafeMap {
-                it.decodeFromJsonString<DemoDto>().configName
+                it.decodeFromJsonString<DemoDto>()
             }
+            .let { setDemoDto(it) }
     }
 
-    commonDemoView {
-        emptyDemoRunRequest = DemoRunRequest.empty
-        demoRunEndpoint = "/$projectCoordinates/run"
-        this.configName = configName
-    }
-}
-
-/**
- * [VFC] for demo view (a temporary workaround for diktat)
- */
-val diktatDemoView: VFC = VFC {
-    commonDemoView {
-        emptyDemoRunRequest = DemoRunRequest.diktatDemoRunRequest
-        demoRunEndpoint = "/diktat/run"
-        configName = "diktat-analysis.xml"
-    }
-}
-
-private val commonDemoView: FC<DemoViewProps> = FC { props ->
-    useBackground(Style.WHITE)
     val (selectedTheme, setSelectedTheme) = useState(AceThemes.preferredTheme)
     div {
         className = ClassName("d-flex justify-content-center mb-2")
@@ -81,9 +59,9 @@ private val commonDemoView: FC<DemoViewProps> = FC { props ->
                     // todo: add editor mode selector
                     this.selectedMode = Languages.KOTLIN
                     this.selectedTheme = selectedTheme
-                    this.emptyDemoRunRequest = props.emptyDemoRunRequest
-                    this.demoRunEndpoint = props.demoRunEndpoint
-                    this.configName = props.configName
+                    this.projectCoordinates = props.projectCoordinates
+                    this.configName = demoDto.configName
+                    this.availableModes = demoDto.runCommands.keys.toList()
                 }
             }
         }
@@ -91,21 +69,11 @@ private val commonDemoView: FC<DemoViewProps> = FC { props ->
 }
 
 /**
- * [Props] for DemoView
+ * [Props] for [demoView]
  */
 external interface DemoViewProps : Props {
     /**
-     * An initial value of [DemoRunRequest]
+     * saveourtool [ProjectCoordinates]
      */
-    var emptyDemoRunRequest: DemoRunRequest
-
-    /**
-     * Endpoint to run this demo
-     */
-    var demoRunEndpoint: String
-
-    /**
-     * Optional config name for this demo
-     */
-    var configName: String?
+    var projectCoordinates: ProjectCoordinates
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/routing/BasicRouting.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/routing/BasicRouting.kt
@@ -6,6 +6,7 @@
 
 package com.saveourtool.save.frontend.routing
 
+import com.saveourtool.save.domain.ProjectCoordinates
 import com.saveourtool.save.domain.TestResultStatus
 import com.saveourtool.save.entities.benchmarks.BenchmarkCategoryEnum
 import com.saveourtool.save.filters.TestExecutionFilter
@@ -15,7 +16,6 @@ import com.saveourtool.save.frontend.components.views.contests.ContestListView
 import com.saveourtool.save.frontend.components.views.contests.UserRatingTab
 import com.saveourtool.save.frontend.components.views.demo.cpgView
 import com.saveourtool.save.frontend.components.views.demo.demoView
-import com.saveourtool.save.frontend.components.views.demo.diktatDemoView
 import com.saveourtool.save.frontend.components.views.fossgraph.createVulnerabilityView
 import com.saveourtool.save.frontend.components.views.fossgraph.fossGraphCollectionView
 import com.saveourtool.save.frontend.components.views.fossgraph.fossGraphView
@@ -44,7 +44,7 @@ val testExecutionDetailsView = testExecutionDetailsView()
  * Just put a map: View -> Route URL to this list
  */
 val basicRouting: FC<AppProps> = FC { props ->
-    val contestView: FC<Props> = withRouter { location, params ->
+    val contestView: VFC = withRouter { location, params ->
         ContestView::class.react {
             currentUserInfo = props.userInfo
             currentContestName = params["contestName"]
@@ -52,7 +52,7 @@ val basicRouting: FC<AppProps> = FC { props ->
         }
     }
 
-    val contestExecutionView: FC<Props> = withRouter { _, params ->
+    val contestExecutionView: VFC = withRouter { _, params ->
         ContestExecutionView::class.react {
             currentUserInfo = props.userInfo
             contestName = params["contestName"]!!
@@ -61,7 +61,7 @@ val basicRouting: FC<AppProps> = FC { props ->
         }
     }
 
-    val projectView: FC<Props> = withRouter { location, params ->
+    val projectView: VFC = withRouter { location, params ->
         ProjectView::class.react {
             name = params["name"]!!
             owner = params["owner"]!!
@@ -70,14 +70,14 @@ val basicRouting: FC<AppProps> = FC { props ->
         }
     }
 
-    val historyView: FC<Props> = withRouter { _, params ->
+    val historyView: VFC = withRouter { _, params ->
         HistoryView::class.react {
             name = params["name"]!!
             organizationName = params["owner"]!!
         }
     }
 
-    val executionView: FC<Props> = withRouter { location, params ->
+    val executionView: VFC = withRouter { location, params ->
         ExecutionView::class.react {
             executionId = params["executionId"]!!
             filters = web.url.URLSearchParams(location.search).let { params ->
@@ -92,13 +92,13 @@ val basicRouting: FC<AppProps> = FC { props ->
         }
     }
 
-    val creationView: FC<Props> = withRouter { _, params ->
+    val creationView: VFC = withRouter { _, params ->
         CreationView::class.react {
             organizationName = params["owner"]
         }
     }
 
-    val organizationView: FC<Props> = withRouter { location, params ->
+    val organizationView: VFC = withRouter { location, params ->
         OrganizationView::class.react {
             organizationName = params["owner"]!!
             currentUserInfo = props.userInfo
@@ -106,17 +106,26 @@ val basicRouting: FC<AppProps> = FC { props ->
         }
     }
 
-    val awesomeBenchmarksView: FC<Props> = withRouter { location, _ ->
+    val awesomeBenchmarksView: VFC = withRouter { location, _ ->
         AwesomeBenchmarksView::class.react {
             this.location = location
         }
     }
 
-    val contestGlobalRatingView: FC<Props> = withRouter { location, _ ->
+    val contestGlobalRatingView: VFC = withRouter { location, _ ->
         ContestGlobalRatingView::class.react {
             organizationName = URLSearchParams(location.search).get("organizationName")
             projectName = URLSearchParams(location.search).get("projectName")
             this.location = location
+        }
+    }
+
+    val demoView: FC<Props> = withRouter { _, params ->
+        demoView {
+            projectCoordinates = ProjectCoordinates(
+                requireNotNull(params["organizationName"]),
+                requireNotNull(params["projectName"]),
+            )
         }
     }
 
@@ -142,7 +151,6 @@ val basicRouting: FC<AppProps> = FC { props ->
             projectView.create() to "/:owner/:name",
             executionView.create() to "/:owner/:name/history/execution/:executionId",
             demoView.create() to "/$DEMO/:organizationName/:projectName",
-            diktatDemoView.create() to "/$DEMO/diktat",
             cpgView.create() to "/$DEMO/cpg",
             testExecutionDetailsView.create() to "/:owner/:name/history/execution/:executionId/details/:testSuiteName/:pluginName/*",
             fossGraphCollectionView.create() to "/$FOSS_GRAPH",


### PR DESCRIPTION
This PR closes #2000

### What's done:
 * Added `RunCommand` entity for storing run commands in database
 * Added `RunCommandRepository`
 * Replaces `runCommand` field of `Demo` entity with list of `RunCommand` entities
 * Split `ProjectDemoMenu.kt` file into several files with few functions/components per file
 * Supported several run commands on frontend
 * Removed hardcoded diktat demo from frontend
 * Refactored `demoView`
 * Updated the logic of `Demo` entity save
 * Removed default demo code lines

### How it looks:
https://user-images.githubusercontent.com/35039155/226077751-3c08e053-7b0e-4fb0-8232-7bdac94d0334.mov

### What's next:
 * Remove hardcoded diktat demo
 * Implement `Demo` update
 * Fix frontend issues - wrong SDK and File displaying (Seem to be set to defaults which is not true)
 * Improve stability
 * Add demos for popular static analysis tools