### PR TITLE
Demo Agent socket timeout exception

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoAgentConfig.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/DemoAgentConfig.kt
@@ -51,7 +51,6 @@ data class DemoConfiguration(
  * @property configFileName name of config file or null if not supported
  * @property runCommands [RunCommandMap] where key is mode name and value is run command for that mode
  * @property outputFileName name of a file that contains the output information e.g. report
- * @property logFileName name of file that contains logs
  */
 @Serializable
 data class RunConfiguration(
@@ -59,7 +58,6 @@ data class RunConfiguration(
     val configFileName: String?,
     val runCommands: RunCommandMap,
     val outputFileName: String?,
-    val logFileName: String = "logs.txt",
 )
 
 /**


### PR DESCRIPTION
nulls surely would like a new timeout-related PR

### What's done:
* Added `HttpTimeout` plugin to `save-demo` `HttpClient`
* Set timeout to match `PROCESS_BUILDER_TIMEOUT_MILLIS` of `save-demo-agent` (currently equals to `20_000L millis`)
* Cleaned `SimpleRunner` up - removed log file creating as it is useless - all the info is available without redirecting to file
* Removed `logFileName` from `RunConfiguration`