### PR TITLE
Remove host port from save-demo-agent container spec

### DIFF
--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
@@ -130,7 +130,6 @@ fun KubernetesClient.getJobPods(demo: Demo): List<Pod> = pods()
 private fun ContainerPort.default(port: Int) = apply {
     protocol = "TCP"
     containerPort = port
-    hostPort = port
     name = "agent-server"
 }
 


### PR DESCRIPTION
### What's done:
* Removed `hostPort` specification - it seems to use node's port which cased `node(s) didn't have free ports for the requested pod ports` error