### PR TITLE
Add pull cmd to open api action

### DIFF
--- a/.github/workflows/backend-api-spec-update.yml
+++ b/.github/workflows/backend-api-spec-update.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Commit and push if api spec is changed
         id: commit-and-push
         run: |
+          git pull origin master --no-edit
           git add save-backend/backend-api-docs.json
           if git diff --staged --quiet; then
             echo Everything is UP-TO-DATE


### PR DESCRIPTION
### What's done:
* Add pull cmd to open api action - will be useful, if branch is stale, which could be when no PR were created for some time