### PR TITLE
save-demo-agents isolation pt I

### DIFF
--- a/save-cloud-charts/save-cloud/templates/agent-namespace.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-namespace.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.demo.agentNamespace }}
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.demo.agentNamespace }}
+
+{{ end }}

--- a/save-cloud-charts/save-cloud/templates/agent-service.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-service.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.demo.agentNamespace }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.demo.name }}
+  namespace: {{ .Values.demo.agentNamespace }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.demo.name }}.save-cloud.svc.cluster.local
+
+{{ end }}

--- a/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
@@ -6,7 +6,8 @@ data:
   application.properties: |
     demo.kubernetes.apiServerUrl=http://kubernetes.default.svc
     demo.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
-    demo.kubernetes.namespace=${POD_NAMESPACE}
+    demo.kubernetes.current-namespace=${POD_NAMESPACE}
+    demo.kubernetes.agent-namespace={{ .Values.demo.agentNamespace }}
     demo.kubernetes.agentPort={{ .Values.demo.agentPort }}
     demo.kubernetes.agentSubdomainName={{ .Values.demo.agentSubdomainName }}
 

--- a/save-cloud-charts/save-cloud/templates/demo-service-account.yaml
+++ b/save-cloud-charts/save-cloud/templates/demo-service-account.yaml
@@ -10,6 +10,9 @@ kind: Role
 metadata:
   name: jobs-demo-executor
 rules:
+  - apiGroups: [""]
+    resources: [services]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [batch]
     resources: [jobs]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/save-cloud-charts/save-cloud/values.yaml
+++ b/save-cloud-charts/save-cloud/values.yaml
@@ -219,3 +219,4 @@ demo:
   clusterIP: null
   agentSubdomainName: demo-agent-service
   agentPort: 23456
+  agentNamespace: save-agent

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/Beans.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/Beans.kt
@@ -25,7 +25,7 @@ class Beans {
         }
         return KubernetesClientBuilder()
             .withConfig(ConfigBuilder()
-                .withNamespace(kubernetesSettings.namespace)
+                .withNamespace(kubernetesSettings.currentNamespace)
                 .build())
             .build()
     }

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/ConfigProperties.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/ConfigProperties.kt
@@ -38,10 +38,11 @@ data class ConfigProperties(
  *
  * @property apiServerUrl
  * @property serviceAccount
- * @property namespace
+ * @property currentNamespace namespace that demo works in
  * @property useGvisor
  * @property agentSubdomainName name of service that is created in order to access agents
  * @property agentPort port of agent that should be used to access it
+ * @property agentNamespace namespace that demo-agents should work in, [currentNamespace] by default
  * @property agentCpuRequests
  * @property agentCpuLimits
  * @property agentMemoryRequests
@@ -52,10 +53,11 @@ data class ConfigProperties(
 data class KubernetesConfig(
     val apiServerUrl: String,
     val serviceAccount: String,
-    val namespace: String,
+    val currentNamespace: String,
     val useGvisor: Boolean,
     val agentSubdomainName: String,
     val agentPort: Int,
+    val agentNamespace: String = currentNamespace,
     val agentCpuRequests: String = "100m",
     val agentCpuLimits: String = "500m",
     val agentMemoryRequests: String = "300Mi",

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.JobSpec
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
 import io.fabric8.kubernetes.client.dsl.ScalableResource
+import org.apache.commons.codec.digest.DigestUtils
 import org.slf4j.LoggerFactory
 
 private const val DEMO_ORG_NAME = "organizationName"
@@ -33,66 +34,109 @@ private val logger = LoggerFactory.getLogger("KubernetesUtils")
  * @param agentDownloadUrl url to download save-demo-agent.kexe, will be used to get pod start command
  * @param kubernetesSettings kubernetes configuration
  * @param agentConfig configuration that is required to be present on save-demo-agent on startup
- * @throws KubernetesRunnerException on failed job creation
+ * @return [Job], filled with all the required info, but not created yet
+ * @see createResourceOrThrow
  */
 @Suppress("NestedBlockDepth")
-fun KubernetesClient.startJob(
+fun getJobObjectForDemo(
     demo: Demo,
     agentDownloadUrl: String,
     kubernetesSettings: KubernetesConfig,
     agentConfig: ConfigProperties.AgentConfig,
-) {
-    val job = Job().apply {
-        metadata = ObjectMeta().apply {
-            name = jobNameForDemo(demo)
-        }
-        spec = JobSpec().apply {
-            parallelism = REPLICAS_PER_DEMO
-            ttlSecondsAfterFinished = TTL_AFTER_COMPLETED
-            backoffLimit = 0
-            template = PodTemplateSpec().apply {
-                spec = PodSpec().apply {
-                    subdomain = kubernetesSettings.agentSubdomainName
-                    if (kubernetesSettings.useGvisor) {
-                        nodeSelector = mapOf(
-                            "gvisor" to "enabled"
-                        )
-                        runtimeClassName = "gvisor"
-                    }
-                    metadata = ObjectMeta().apply {
-                        labels = mapOf(
-                            DEMO_ORG_NAME to demo.organizationName,
-                            DEMO_PROJ_NAME to demo.projectName,
-                            DEMO_VERSION to "manual",
-                            // "baseImageName" to baseImageName
-                            "io.kompose.service" to "save-demo-agent",
-                        )
-                    }
-                    restartPolicy = "Never"
-                    containers = listOf(
-                        demoAgentContainerSpec(
-                            demo.sdk.toSdk().baseImageName(),
-                            agentDownloadUrl,
-                            demo,
-                            kubernetesSettings,
-                            agentConfig,
-                        )
+) = Job().apply {
+    metadata = ObjectMeta().apply {
+        name = jobNameForDemo(demo)
+        namespace = kubernetesSettings.agentNamespace
+    }
+    spec = JobSpec().apply {
+        parallelism = REPLICAS_PER_DEMO
+        ttlSecondsAfterFinished = TTL_AFTER_COMPLETED
+        backoffLimit = 0
+        template = PodTemplateSpec().apply {
+            spec = PodSpec().apply {
+                subdomain = kubernetesSettings.agentSubdomainName
+                if (kubernetesSettings.useGvisor) {
+                    nodeSelector = mapOf(
+                        "gvisor" to "enabled"
+                    )
+                    runtimeClassName = "gvisor"
+                }
+                metadata = ObjectMeta().apply {
+                    labels = mapOf(
+                        DEMO_ORG_NAME to demo.organizationName,
+                        DEMO_PROJ_NAME to demo.projectName,
+                        DEMO_VERSION to "manual",
+                        // "baseImageName" to baseImageName
+                        "io.kompose.service" to "save-demo-agent",
                     )
                 }
+                restartPolicy = "Never"
+                containers = listOf(
+                    demoAgentContainerSpec(
+                        demo.sdk.toSdk().baseImageName(),
+                        agentDownloadUrl,
+                        demo,
+                        kubernetesSettings,
+                        agentConfig,
+                    )
+                )
             }
         }
     }
-    logger.debug { "Attempt to create Job from the following spec: $job" }
-    try {
-        resource(job).create()
-        with(demo) {
-            logger.info("Created Job for demo $organizationName/$projectName")
-        }
-    } catch (kex: KubernetesClientException) {
-        with(demo) {
-            throw KubernetesRunnerException("Unable to create a job for demo $organizationName/$projectName", kex)
-        }
+}
+
+/**
+ * @param demo [Demo] entity
+ * @param job already created job for ownerResource setting
+ * @param kubernetesSettings kubernetes configuration
+ * @return [ServicePort], filled with all the required info, but not created yet
+ * @see createResourceOrThrow
+ */
+@Suppress("NestedBlockDepth")
+fun getServiceObjectForDemo(
+    demo: Demo,
+    job: HasMetadata,
+    kubernetesSettings: KubernetesConfig,
+) = Service().apply {
+    metadata = ObjectMeta().apply {
+        name = serviceNameForDemo(demo)
+        namespace = kubernetesSettings.agentNamespace
     }
+
+    addOwnerReference(job)
+
+    spec = ServiceSpec().apply {
+        type = "ClusterIP"
+        ports = listOf(
+            ServicePort().apply {
+                protocol = "TCP"
+                port = kubernetesSettings.agentPort
+                targetPort = IntOrString(kubernetesSettings.agentPort)
+                name = "web-server"
+            }
+        )
+        selector = mapOf(
+            DEMO_ORG_NAME to demo.organizationName,
+            DEMO_PROJ_NAME to demo.projectName,
+            "io.kompose.service" to "save-demo-agent",
+        )
+    }
+}
+
+/**
+ * Create kubernetes resource and process possible exceptions
+ *
+ * @param resourceToCreate resource (e.g. [Job], [Service] etc) that should be created by [KubernetesClient]
+ * @return created [HasMetadata] resource
+ * @throws KubernetesRunnerException on failed job creation
+ */
+fun <T : HasMetadata> KubernetesClient.createResourceOrThrow(resourceToCreate: T): T = try {
+logger.debug { "Attempt to create ${resourceToCreate.kind} with the following name: ${resourceToCreate.fullResourceName}" }
+    resource(resourceToCreate).create().also {
+        logger.info("Created ${resourceToCreate.kind} with the following name: ${resourceToCreate.fullResourceName}")
+    }
+} catch (kex: KubernetesClientException) {
+    throw KubernetesRunnerException("Unable to create ${resourceToCreate.kind} with the following name: ${resourceToCreate.fullResourceName}", kex)
 }
 
 /**
@@ -137,7 +181,19 @@ private fun ContainerPort.default(port: Int) = apply {
  * @param demo demo entity
  * @return name of job that is/should be assigned to [demo]
  */
-fun jobNameForDemo(demo: Demo) = with(demo) { "demo-${organizationName.lowercase()}-${projectName.lowercase()}-1" }
+fun jobNameForDemo(demo: Demo) = with(demo) {
+    val sha1 = DigestUtils.sha1Hex("$organizationName$projectName")
+    "demo-${organizationName.lowercase()}-${projectName.lowercase()}-${ sha1.take(SHA1_PREFIX_SIZE) }"
+}
+
+/**
+ * @param demo demo entity
+ * @return name of service that is/should be connected with [demo]
+ */
+fun serviceNameForDemo(demo: Demo) = with(demo) {
+    val sha1 = DigestUtils.sha1Hex("$organizationName$projectName")
+    "demo-${organizationName.lowercase().first()}${projectName.lowercase().first()}-${ sha1.take(SHA1_PREFIX_SIZE) }"
+}
 
 @Suppress("SameParameterValue")
 private fun getConfigureMeUrl(baseUrl: String, demo: Demo, version: String) = with(demo) {
@@ -196,3 +252,5 @@ private fun demoAgentContainerSpec(
         }
     }
 }
+
+private const val SHA1_PREFIX_SIZE = 6

--- a/save-demo/src/main/resources/application-minikube.properties
+++ b/save-demo/src/main/resources/application-minikube.properties
@@ -7,7 +7,8 @@
 # Here, XXXX is a requested port
 demo.kubernetes.apiServerUrl=https://127.0.0.1:61234
 demo.kubernetes.serviceAccount=demo-sa
-demo.kubernetes.namespace=save-cloud
+demo.kubernetes.current-namespace=save-cloud
+demo.kubernetes.agent-namespace=save-agent
 demo.kubernetes.useGvisor=false
 demo.kubernetes.agentSubdomainName=save-demo-agent
 demo.kubernetes.agentPort=23456

--- a/save-demo/src/test/kotlin/com/saveourtool/save/demo/utils/HttpUtilsTest.kt
+++ b/save-demo/src/test/kotlin/com/saveourtool/save/demo/utils/HttpUtilsTest.kt
@@ -1,6 +1,8 @@
 package com.saveourtool.save.demo.utils
 
 import com.saveourtool.save.demo.config.KubernetesConfig
+import com.saveourtool.save.demo.entity.Demo
+import com.saveourtool.save.domain.Sdk
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
 import org.assertj.core.api.Assertions.assertThat
@@ -62,10 +64,33 @@ class HttpUtilsTest {
     @Test
     fun addressToDnsResolutionTest() {
         val resolvableAddress = addressToDnsResolution("192.168.0.1", stubKubernetesConfig)
-        assertThat(resolvableAddress).isEqualTo("192-168-0-1.my-subdomain-name.my-namespace.svc.cluster.local")
+        with(stubKubernetesConfig) {
+            assertThat(resolvableAddress).isEqualTo(
+                "192-168-0-1.${agentSubdomainName}.${currentNamespace}.svc.cluster.local"
+            )
+        }
+    }
+
+    @Test
+    fun addressByServiceNameTest() {
+        val resolvableAddress = addressByServiceName(stubDemo, stubKubernetesConfig)
+        assertThat(resolvableAddress).isEqualTo(
+            "${serviceNameForDemo(stubDemo)}.${stubKubernetesConfig.agentNamespace}.svc.cluster.local"
+        )
     }
 
     companion object {
+        private val stubDemo = Demo(
+            "organization",
+            "project",
+            Sdk.Default.toString(),
+            "",
+            null,
+            null,
+            null,
+            null,
+        )
+
         private val stubKubernetesConfig = KubernetesConfig(
             "",
             "",
@@ -73,6 +98,7 @@ class HttpUtilsTest {
             false,
             "my-subdomain-name",
             23456,
+            agentNamespace = "agent-namespace",
         )
     }
 }


### PR DESCRIPTION
This PR is connected with #2002

### What's done:
* Added `agent-namespace.yaml` for namespace creation for `save-demo-agents` (with configurable name)
* Moved `save-demo-agents` to a separate namespace
* Added service `agent-service.yaml` in order to make `http://demo` url be available from `save-demo-agents`
* Added `save-demo-agent` service creation (service is a child of a job)
* Implemented new way of resolving the pod address