### PR TITLE
Agents should be in their namespace

### DIFF
--- a/save-cloud-charts/save-cloud/templates/agent-demo-service.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-demo-service.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.demo.agentNamespace }}
+{{ if .Values.agentNamespace }}
 
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.demo.name }}
-  namespace: {{ .Values.demo.agentNamespace }}
+  namespace: {{ .Values.agentNamespace }}
 spec:
   type: ExternalName
   externalName: {{ .Values.demo.name }}.save-cloud.svc.cluster.local

--- a/save-cloud-charts/save-cloud/templates/agent-namespace.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-namespace.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.demo.agentNamespace }}
+{{ if .Values.agentNamespace }}
 
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.demo.agentNamespace }}
+  name: {{ .Values.agentNamespace }}
 
 {{ end }}

--- a/save-cloud-charts/save-cloud/templates/agent-network-policy-demo.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-network-policy-demo.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-network-policy-demo
+  namespace: {{ .Values.agentNamespace }}
+spec:
+  # Should be applied to save-demo-agents only
+  podSelector:
+    matchLabels:
+      io.kompose.service: save-demo-agent
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        # Allow traffic to save-demo
+        - namespaceSelector:
+            matchLabels:
+              name: save-cloud
+        - podSelector:
+            matchLabels:
+              io.kompose.service: demo
+      ports:
+        - protocol: TCP
+          port: {{ .Values.demo.containerPort }}

--- a/save-cloud-charts/save-cloud/templates/agent-network-policy-general.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-network-policy-general.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-network-policy-general
+  namespace: {{ .Values.agentNamespace }}
+spec:
+  # Should be applied to all pods in namespace
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        # https://stackoverflow.com/q/73049535
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            # Forbid private IP ranges effectively allowing only egress to the Internet
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    - to:
+        # Allow traffic to kubernetes DNS service
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: "kube-system"
+        - podSelector:
+            matchLabels:
+              k8s-app: "kube-dns"

--- a/save-cloud-charts/save-cloud/templates/agent-network-policy-orchestrator.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-network-policy-orchestrator.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-network-policy-orchestrator
+  namespace: {{ .Values.agentNamespace }}
+spec:
+  # Should be applied to save-agents only
+  #
+  # As for now, there is no way to tell orchestrator pod from sandbox pod so need to allow connection to both
+  # orchestrator and sandbox.
+  podSelector:
+    matchLabels:
+      io.kompose.service: save-agent
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        # Allow traffic to save-orchestrator
+        - namespaceSelector:
+            matchLabels:
+              name: save-cloud
+        - podSelector:
+            matchLabels:
+              io.kompose.service: orchestrator
+      ports:
+        - protocol: TCP
+          port: {{ .Values.orchestrator.containerPort }}
+    - to:
+        # Allow traffic to save-sandbox
+        - namespaceSelector:
+            matchLabels:
+              name: save-cloud
+        - podSelector:
+            matchLabels:
+              io.kompose.service: sandbox
+      ports:
+        - protocol: TCP
+          port: {{ .Values.sandbox.containerPort }}

--- a/save-cloud-charts/save-cloud/templates/agent-orchestrator-service.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-orchestrator-service.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.agentNamespace }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.orchestrator.name }}
+  namespace: {{ .Values.agentNamespace }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.orchestrator.name }}.save-cloud.svc.cluster.local
+
+{{ end }}

--- a/save-cloud-charts/save-cloud/templates/agent-sandbox-service.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-sandbox-service.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.agentNamespace }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.sandbox.name }}
+  namespace: {{ .Values.agentNamespace }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.sandbox.name }}.save-cloud.svc.cluster.local
+
+{{ end }}

--- a/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
@@ -7,7 +7,7 @@ data:
     demo.kubernetes.apiServerUrl=http://kubernetes.default.svc
     demo.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
     demo.kubernetes.current-namespace=${POD_NAMESPACE}
-    demo.kubernetes.agent-namespace={{ .Values.demo.agentNamespace }}
+    demo.kubernetes.agent-namespace={{ .Values.agentNamespace }}
     demo.kubernetes.agentPort={{ .Values.demo.agentPort }}
     demo.kubernetes.agentSubdomainName={{ .Values.demo.agentSubdomainName }}
 

--- a/save-cloud-charts/save-cloud/templates/orchestrator-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/orchestrator-configmap.yaml
@@ -8,7 +8,8 @@ data:
 
     orchestrator.kubernetes.apiServerUrl=http://kubernetes.default.svc
     orchestrator.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
-    orchestrator.kubernetes.namespace=${POD_NAMESPACE}
+    orchestrator.kubernetes.current-namespace=${POD_NAMESPACE}
+    orchestrator.kubernetes.agent-namespace={{ .Values.agentNamespace }}
 
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*

--- a/save-cloud-charts/save-cloud/templates/sandbox-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/sandbox-configmap.yaml
@@ -6,7 +6,8 @@ data:
   application.properties: |
     orchestrator.kubernetes.apiServerUrl=http://kubernetes.default.svc
     orchestrator.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
-    orchestrator.kubernetes.namespace=${POD_NAMESPACE}
+    orchestrator.kubernetes.current-namespace=${POD_NAMESPACE}
+    orchestrator.kubernetes.agent-namespace= {{ .Values.agentNamespace }}
 
     server.shutdown=graceful
     management.endpoints.web.exposure.include=*

--- a/save-cloud-charts/save-cloud/values.yaml
+++ b/save-cloud-charts/save-cloud/values.yaml
@@ -219,4 +219,5 @@ demo:
   clusterIP: null
   agentSubdomainName: demo-agent-service
   agentPort: 23456
-  agentNamespace: save-agent
+
+agentNamespace: save-agent

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/ConfigProperties.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/ConfigProperties.kt
@@ -34,21 +34,22 @@ data class ConfigProperties(
  * `m` stands for milli, `M` stands for Mega.
  * By default, `M` and `m` are powers of 10.
  * To be more accurate and use `M` as 1024 instead of 1000, `i` should be provided: `Mi`
- * https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
+ * [reference](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
  *
- * @property apiServerUrl
- * @property serviceAccount
+ * @property apiServerUrl URL of Kubernetes API Server. See [docs on accessing API from within a pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)
+ * @property serviceAccount Name of [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) that will be used
+ * to authenticate save-demo to the API server
  * @property currentNamespace namespace that demo works in
- * @property useGvisor
+ * @property useGvisor if true, will try to use gVisor's runsc runtime for starting agents
  * @property agentSubdomainName name of service that is created in order to access agents
  * @property agentPort port of agent that should be used to access it
  * @property agentNamespace namespace that demo-agents should work in, [currentNamespace] by default
- * @property agentCpuRequests
- * @property agentCpuLimits
- * @property agentMemoryRequests
- * @property agentMemoryLimits
- * @property agentEphemeralStorageRequests
- * @property agentEphemeralStorageLimits
+ * @property agentCpuRequests configures `resources.requests.cpu` for demo-agent pods
+ * @property agentCpuLimits configures `resources.limits.cpu` for demo-agent pods
+ * @property agentMemoryRequests configures `resources.requests.memory` for demo-agent pods
+ * @property agentMemoryLimits configures `resources.limits.memory` for demo-agent pods
+ * @property agentEphemeralStorageRequests configures `resources.requests.ephemeralStorage` for demo-agent pods
+ * @property agentEphemeralStorageLimits configures `resources.limits.ephemeralStorage` for demo-agent pods
  */
 data class KubernetesConfig(
     val apiServerUrl: String,

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
@@ -184,6 +184,7 @@ fun getServiceObjectForDemo(
  * @return name of job that is/should be assigned to [demo]
  */
 fun jobNameForDemo(demo: Demo) = with(demo) {
+    // sha1 is required due to kubernetes naming restrictions - no capital letters are allowed while in save-cloud it is ok
     val sha1 = DigestUtils.sha1Hex("$organizationName$projectName")
     "demo-${organizationName.lowercase()}-${projectName.lowercase()}-${ sha1.take(SHA1_PREFIX_SIZE) }"
 }
@@ -193,6 +194,7 @@ fun jobNameForDemo(demo: Demo) = with(demo) {
  * @return name of service that is/should be connected with [demo]
  */
 fun serviceNameForDemo(demo: Demo) = with(demo) {
+    // sha1 is required due to kubernetes naming restrictions - no capital letters are allowed while in save-cloud it is ok
     val sha1 = DigestUtils.sha1Hex("$organizationName$projectName")
     "demo-${organizationName.lowercase().first()}${projectName.lowercase().first()}-${ sha1.take(SHA1_PREFIX_SIZE) }"
 }

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/Beans.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/Beans.kt
@@ -57,7 +57,7 @@ class Beans {
 
         return KubernetesClientBuilder()
             .withConfig(ConfigBuilder()
-                .withNamespace(kubernetesSettings.namespace)
+                .withNamespace(kubernetesSettings.currentNamespace)
                 .build())
             .build()
     }

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/config/ConfigProperties.kt
@@ -61,23 +61,30 @@ data class ConfigProperties(
     )
 
     /**
+     * `m` stands for milli, `M` stands for Mega.
+     * By default, `M` and `m` are powers of 10.
+     * To be more accurate and use `M` as 1024 instead of 1000, `i` should be provided: `Mi`
+     * [reference](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
+     *
      * @property apiServerUrl URL of Kubernetes API Server. See [docs on accessing API from within a pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)
      * @property serviceAccount Name of [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) that will be used
      * to authenticate orchestrator to the API server
-     * @property namespace Kubernetes namespace, into which agents will be deployed.
+     * @property currentNamespace namespace that demo works in
      * @property useGvisor if true, will try to use gVisor's runsc runtime for starting agents
+     * @property agentNamespace namespace that agents should work in, [currentNamespace] by default
      * @property agentCpuRequests configures `resources.requests.cpu` for agent pods
      * @property agentCpuLimits configures `resources.limits.cpu` for agent pods
      * @property agentMemoryRequests configures `resources.requests.memory` for agent pods
-     * @property agentMemoryLimits configures `resources.requests.memory` for agent pods
+     * @property agentMemoryLimits configures `resources.limits.memory` for agent pods
      * @property ttlAfterFinished agent job time to live after it is marked as completed
      */
     @Suppress("MagicNumber")
     data class KubernetesSettings(
         val apiServerUrl: String,
         val serviceAccount: String,
-        val namespace: String,
+        val currentNamespace: String,
         val useGvisor: Boolean,
+        val agentNamespace: String = currentNamespace,
         val agentCpuRequests: String = "100m",
         val agentCpuLimits: String = "500m",
         val agentMemoryRequests: String = "300Mi",

--- a/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
+++ b/save-orchestrator-common/src/main/kotlin/com/saveourtool/save/orchestrator/kubernetes/KubernetesManager.kt
@@ -51,6 +51,7 @@ class KubernetesManager(
         val job = Job().apply {
             metadata = ObjectMeta().apply {
                 name = jobNameForExecution(executionId)
+                namespace = kubernetesSettings.agentNamespace
             }
             spec = JobSpec().apply {
                 parallelism = replicas

--- a/save-orchestrator-common/src/test/resources/application-kubernetes.properties
+++ b/save-orchestrator-common/src/test/resources/application-kubernetes.properties
@@ -1,4 +1,5 @@
 orchestrator.kubernetes.apiServerUrl=http://kubernetes.default.svc
 orchestrator.kubernetes.serviceAccount=${POD_SERVICE_ACCOUNT}
-orchestrator.kubernetes.namespace=${POD_NAMESPACE}
+orchestrator.kubernetes.current-namespace=${POD_NAMESPACE}
+orchestrator.kubernetes.agent-namespace=save-agent
 orchestrator.kubernetes.useGvisor=false

--- a/save-orchestrator/src/main/resources/application-minikube.properties
+++ b/save-orchestrator/src/main/resources/application-minikube.properties
@@ -5,7 +5,8 @@
 # Here, XXXX is a requested port
 orchestrator.kubernetes.apiServerUrl=https://127.0.0.1:61234
 orchestrator.kubernetes.serviceAccount=orchestrator-sa
-orchestrator.kubernetes.namespace=save-cloud
+orchestrator.kubernetes.current-namespace=save-cloud
+orchestrator.kubernetes.agent-namespace=save-agent
 orchestrator.kubernetes.useGvisor=false
 orchestrator.agent-settings.debug=true
 

--- a/save-sandbox/src/main/resources/application-minikube.properties
+++ b/save-sandbox/src/main/resources/application-minikube.properties
@@ -5,7 +5,8 @@
 # Here, XXXX is a requested port
 orchestrator.kubernetes.apiServerUrl=https://127.0.0.1:61234
 orchestrator.kubernetes.serviceAccount=sandbox-sa
-orchestrator.kubernetes.namespace=save-cloud
+orchestrator.kubernetes.current-namespace=save-cloud
+orchestrator.kubernetes.agent-namespace=save-agent
 orchestrator.kubernetes.useGvisor=false
 orchestrator.agent-settings.debug=true
 


### PR DESCRIPTION
### What's done:
 * Moved `save-agent`s to `save-agent` namespace (now all the agents work in `save-agent` namespace)
 * Created `agent-sandbox-service.yaml` in order to make `http://sandbox` be resolvable in `save-agent` namespace
 * Created `agent-orchestrator-service.yaml` in order to make `http://orchestrator` be resolvable in `save-agent` namespace
 * Created `agent-network-policy-general.yaml` to forbid inter-cluster connections (except dns)
 * Created `agent-network-policy-demo.yaml` to allow connection to `save-demo`
 * Created `agent-network-policy-orchestrator.yaml` to allow connection to `save-orchestrator` and `save-sandbox`