### PR TITLE
KubernetesServiceAccountAuthHeaderPlugin

### DIFF
--- a/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/Main.kt
+++ b/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/Main.kt
@@ -9,6 +9,7 @@ import com.saveourtool.save.agent.utils.ktorLogger
 import com.saveourtool.save.core.config.LogType
 import com.saveourtool.save.core.logging.describe
 import com.saveourtool.save.core.logging.logType
+import com.saveourtool.save.utils.KubernetesServiceAccountAuthHeaderPlugin
 import com.saveourtool.save.utils.fs
 import com.saveourtool.save.utils.parseConfig
 
@@ -91,4 +92,5 @@ private fun configureHttpClient(agentConfiguration: AgentConfiguration) = HttpCl
         logger = ktorLogger
         level = if (agentConfiguration.debug) LogLevel.ALL else LogLevel.INFO
     }
+    install(KubernetesServiceAccountAuthHeaderPlugin)
 }

--- a/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -16,10 +16,7 @@ import com.saveourtool.save.core.utils.runIf
 import com.saveourtool.save.domain.TestResultDebugInfo
 import com.saveourtool.save.plugins.fix.FixPlugin
 import com.saveourtool.save.reporter.Report
-import com.saveourtool.save.utils.fs
-import com.saveourtool.save.utils.requiredEnv
-import com.saveourtool.save.utils.toTestResultDebugInfo
-import com.saveourtool.save.utils.toTestResultStatus
+import com.saveourtool.save.utils.*
 
 import io.ktor.client.*
 import io.ktor.client.call.body
@@ -46,9 +43,10 @@ import kotlinx.serialization.modules.subclass
  * @property httpClient
  */
 @Suppress("AVOID_NULL_CHECKS")
-class SaveAgent(private val config: AgentConfiguration,
-                internal val httpClient: HttpClient,
-                private val coroutineScope: CoroutineScope,
+class SaveAgent(
+    private val config: AgentConfiguration,
+    internal val httpClient: HttpClient,
+    private val coroutineScope: CoroutineScope,
 ) {
     /**
      * The current [AgentState] of this agent. Initial value corresponds to the period when agent needs to finish its configuration.

--- a/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/utils/HttpUtils.kt
+++ b/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/utils/HttpUtils.kt
@@ -8,6 +8,7 @@ import com.saveourtool.save.agent.AgentState
 import com.saveourtool.save.agent.SaveAgent
 import com.saveourtool.save.core.logging.logWarn
 import com.saveourtool.save.core.utils.runIf
+import com.saveourtool.save.utils.AtomicLong
 import com.saveourtool.save.utils.failureOrNotOk
 import com.saveourtool.save.utils.fs
 import com.saveourtool.save.utils.notOk

--- a/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/utils/PlatformUtils.kt
+++ b/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/utils/PlatformUtils.kt
@@ -5,45 +5,6 @@
 package com.saveourtool.save.agent.utils
 
 /**
- * Atomic values
- */
-expect class AtomicLong(value: Long) {
-    /**
-     * @return value
-     */
-    fun get(): Long
-
-    /**
-     * @param newValue
-     */
-    fun set(newValue: Long)
-
-    /**
-     * @param delta increments the value_ by delta
-     * @return the new value
-     */
-    fun addAndGet(delta: Long): Long
-}
-
-/**
- *  Class that holds value and shares atomic reference to the value
- *
- *  @param valueToStore value to store
- */
-@Suppress("USE_DATA_CLASS")
-expect class GenericAtomicReference<T>(valueToStore: T) {
-    /**
-     * @return stored value
-     */
-    fun get(): T
-
-    /**
-     * @param newValue new value to store
-     */
-    fun set(newValue: T)
-}
-
-/**
  * Process sigterm signal
  */
 internal expect fun handleSigterm()

--- a/save-agent/src/jvmMain/kotlin/com/saveourtool/save/agent/utils/PlatformUtils.kt
+++ b/save-agent/src/jvmMain/kotlin/com/saveourtool/save/agent/utils/PlatformUtils.kt
@@ -10,17 +10,6 @@ package com.saveourtool.save.agent.utils
 import sun.misc.Signal
 import kotlin.system.exitProcess
 
-actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong
-
-@Suppress("USE_DATA_CLASS")
-actual class GenericAtomicReference<T> actual constructor(valueToStore: T) {
-    private val holder: java.util.concurrent.atomic.AtomicReference<T> = java.util.concurrent.atomic.AtomicReference(valueToStore)
-    actual fun get(): T = holder.get()
-    actual fun set(newValue: T) {
-        holder.set(newValue)
-    }
-}
-
 internal actual fun handleSigterm() {
     Signal.handle(Signal("TERM")) {
         logInfoCustom("Agent is shutting down because SIGTERM has been received")

--- a/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/utils/PlatformUtils.kt
+++ b/save-agent/src/linuxX64Main/kotlin/com/saveourtool/save/agent/utils/PlatformUtils.kt
@@ -10,28 +10,6 @@ import platform.posix.signal
 
 import kotlinx.cinterop.staticCFunction
 
-@Suppress("MemberNameEqualsClassName")
-actual class AtomicLong actual constructor(value: Long) {
-    private val atomicLong = kotlin.native.concurrent.AtomicLong(value)
-
-    actual fun get(): Long = atomicLong.value
-
-    actual fun set(newValue: Long) {
-        atomicLong.value = newValue
-    }
-
-    actual fun addAndGet(delta: Long): Long = atomicLong.addAndGet(delta)
-}
-
-@Suppress("USE_DATA_CLASS")
-actual class GenericAtomicReference<T> actual constructor(valueToStore: T) {
-    private val holder: kotlin.native.concurrent.AtomicReference<T> = kotlin.native.concurrent.AtomicReference(valueToStore)
-    actual fun get(): T = holder.value
-    actual fun set(newValue: T) {
-        holder.value = newValue
-    }
-}
-
 internal actual fun handleSigterm() {
     signal(SIGTERM, staticCFunction<Int, Unit> {
         logInfoCustom("Agent is shutting down because SIGTERM has been received")

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/HttpUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/HttpUtils.kt
@@ -2,10 +2,67 @@
  * Utils to check results of http requests
  */
 
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
 package com.saveourtool.save.utils
 
+import io.ktor.client.plugins.api.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import okio.Path.Companion.toPath
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Kubernetes token header name
+ */
+const val SA_HEADER_NAME = "X-Service-Account-Token"
+
+/**
+ * Kubernetes service account based authentication plugin for ktor client.
+ *
+ * Basically it:
+ *  * keeps control over token ([KubernetesServiceAccountAuthHeaderPluginConfig.tokenPath]);
+ *  * refreshes it every [KubernetesServiceAccountAuthHeaderPluginConfig.expirationTime];
+ *  * appends required [KubernetesServiceAccountAuthHeaderPluginConfig.headerName] header to every request.
+ */
+@Suppress("VARIABLE_NAME_INCORRECT_FORMAT")
+val KubernetesServiceAccountAuthHeaderPlugin = createClientPlugin(
+    "KubernetesServiceAccountAuthHeaderPlugin",
+    ::KubernetesServiceAccountAuthHeaderPluginConfig,
+) {
+    val token = ExpiringValueWrapper(pluginConfig.expirationTime) {
+        fs.read(pluginConfig.tokenPath.toPath()) { readUtf8() }
+    }
+    onRequest { request, _ ->
+        request.headers.append(SA_HEADER_NAME, token.getValue())
+    }
+}
+
+/**
+ * Configuration for [KubernetesServiceAccountAuthHeaderPlugin]
+ */
+@Suppress("USE_DATA_CLASS")
+class KubernetesServiceAccountAuthHeaderPluginConfig {
+    /**
+     * Kubernetes service account token path configuration
+     */
+    var tokenPath: String = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    /**
+     * Token expiration [Duration] configuration
+     */
+    var expirationTime: Duration = DEFAULT_EXPIRATION_TIME_MINUTES.minutes
+
+    /**
+     * Header name
+     */
+    var headerName: String = SA_HEADER_NAME
+
+    companion object {
+        private const val DEFAULT_EXPIRATION_TIME_MINUTES = 5
+    }
+}
 
 /**
  * @return true if [HttpResponse] is not ok or some failure has happened, false otherwise

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -5,6 +5,78 @@
 package com.saveourtool.save.utils
 
 import com.saveourtool.save.core.logging.logDebug
+import com.saveourtool.save.core.utils.GenericAtomicReference
+
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlinx.datetime.Clock
+
+/**
+ * Atomic values
+ */
+expect class AtomicLong(value: Long) {
+    /**
+     * @return value
+     */
+    fun get(): Long
+
+    /**
+     * @param newValue
+     */
+    fun set(newValue: Long)
+
+    /**
+     * @param delta increments the value_ by delta
+     * @return the new value
+     */
+    fun addAndGet(delta: Long): Long
+}
+
+/**
+ *  Class that holds value and shares atomic reference to the value
+ *
+ *  @param valueToStore value to store
+ */
+@Suppress("USE_DATA_CLASS")
+expect class GenericAtomicReference<T>(valueToStore: T) {
+    /**
+     * @return stored value
+     */
+    fun get(): T
+
+    /**
+     * @param newValue new value to store
+     */
+    fun set(newValue: T)
+}
+
+/**
+ * A wrapper around a value of type [T] that caches it for [expirationTimeSeconds] and then recalculates
+ * using [valueGetter]
+ *
+ * @param expirationTime value expiration time
+ * @property valueGetter a function to calculate the value of type [T]
+ */
+class ExpiringValueWrapper<T : Any>(
+    expirationTime: Duration,
+    private val valueGetter: () -> T,
+) {
+    private val expirationTimeSeconds = expirationTime.toLong(DurationUnit.SECONDS)
+    private val lastUpdateTimeSeconds = AtomicLong(0)
+    private val value: GenericAtomicReference<T> = GenericAtomicReference(valueGetter())
+
+    /**
+     * @return cached value or refreshes the value and returns it
+     */
+    fun getValue(): T {
+        val current = Clock.System.now().epochSeconds
+        if (current - lastUpdateTimeSeconds.get() > expirationTimeSeconds) {
+            value.set(valueGetter())
+            lastUpdateTimeSeconds.set(current)
+        }
+        return value.get()
+    }
+}
 
 /**
  * @param envName

--- a/save-cloud-common/src/jsMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/jsMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -4,7 +4,6 @@
 
 package com.saveourtool.save.utils
 
-@Suppress("MemberNameEqualsClassName")
 actual class AtomicLong actual constructor(value: Long) {
     actual fun get(): Long = throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)
 

--- a/save-cloud-common/src/jsMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/jsMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -4,4 +4,23 @@
 
 package com.saveourtool.save.utils
 
+@Suppress("MemberNameEqualsClassName")
+actual class AtomicLong actual constructor(value: Long) {
+    actual fun get(): Long = throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)
+
+    actual fun set(newValue: Long) {
+        throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)
+    }
+
+    actual fun addAndGet(delta: Long): Long = throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)
+}
+
+@Suppress("USE_DATA_CLASS")
+actual class GenericAtomicReference<T> actual constructor(valueToStore: T) {
+    actual fun get(): T = throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)
+    actual fun set(newValue: T) {
+        throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)
+    }
+}
+
 actual fun getenv(envName: String): String? = throw NotImplementedError(NOT_IMPLEMENTED_ON_JS)

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -1,3 +1,4 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
 /**
  * Platform dependent utility methods
  */
@@ -5,5 +6,16 @@
 @file:JvmName("PlatformUtilsJVM")
 
 package com.saveourtool.save.utils
+
+actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong
+
+@Suppress("USE_DATA_CLASS")
+actual class GenericAtomicReference<T> actual constructor(valueToStore: T) {
+    private val holder: java.util.concurrent.atomic.AtomicReference<T> = java.util.concurrent.atomic.AtomicReference(valueToStore)
+    actual fun get(): T = holder.get()
+    actual fun set(newValue: T) {
+        holder.set(newValue)
+    }
+}
 
 actual fun getenv(envName: String): String? = System.getProperty(envName) ?: System.getenv(envName)

--- a/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -6,4 +6,26 @@ package com.saveourtool.save.utils
 
 import kotlinx.cinterop.toKString
 
+@Suppress("MemberNameEqualsClassName")
+actual class AtomicLong actual constructor(value: Long) {
+    private val atomicLong = kotlin.native.concurrent.AtomicLong(value)
+
+    actual fun get(): Long = atomicLong.value
+
+    actual fun set(newValue: Long) {
+        atomicLong.value = newValue
+    }
+
+    actual fun addAndGet(delta: Long): Long = atomicLong.addAndGet(delta)
+}
+
+@Suppress("USE_DATA_CLASS")
+actual class GenericAtomicReference<T> actual constructor(valueToStore: T) {
+    private val holder: kotlin.native.concurrent.AtomicReference<T> = kotlin.native.concurrent.AtomicReference(valueToStore)
+    actual fun get(): T = holder.value
+    actual fun set(newValue: T) {
+        holder.value = newValue
+    }
+}
+
 actual fun getenv(envName: String): String? = platform.posix.getenv(envName)?.toKString()

--- a/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -6,7 +6,6 @@ package com.saveourtool.save.utils
 
 import kotlinx.cinterop.toKString
 
-@Suppress("MemberNameEqualsClassName")
 actual class AtomicLong actual constructor(value: Long) {
     private val atomicLong = kotlin.native.concurrent.AtomicLong(value)
 

--- a/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -6,17 +6,16 @@ package com.saveourtool.save.utils
 
 import kotlinx.cinterop.toKString
 
-@Suppress("MemberNameEqualsClassName")
 actual class AtomicLong actual constructor(value: Long) {
-    private val atomicLong = kotlin.native.concurrent.AtomicLong(value)
+    private val kotlinAtomicLong = kotlin.native.concurrent.AtomicLong(value)
 
-    actual fun get(): Long = atomicLong.value
+    actual fun get(): Long = kotlinAtomicLong.value
 
     actual fun set(newValue: Long) {
-        atomicLong.value = newValue
+        kotlinAtomicLong.value = newValue
     }
 
-    actual fun addAndGet(delta: Long): Long = atomicLong.addAndGet(delta)
+    actual fun addAndGet(delta: Long): Long = kotlinAtomicLong.addAndGet(delta)
 }
 
 @Suppress("USE_DATA_CLASS")

--- a/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
+++ b/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/PlatformUtils.kt
@@ -6,6 +6,7 @@ package com.saveourtool.save.utils
 
 import kotlinx.cinterop.toKString
 
+@Suppress("MemberNameEqualsClassName")
 actual class AtomicLong actual constructor(value: Long) {
     private val atomicLong = kotlin.native.concurrent.AtomicLong(value)
 

--- a/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/utils/HttpUtils.kt
+++ b/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/utils/HttpUtils.kt
@@ -10,10 +10,7 @@ import com.saveourtool.save.core.logging.logInfo
 import com.saveourtool.save.core.logging.logWarn
 import com.saveourtool.save.core.utils.runIf
 import com.saveourtool.save.demo.DemoAgentConfig
-import com.saveourtool.save.utils.failureOrNotOk
-import com.saveourtool.save.utils.fs
-import com.saveourtool.save.utils.notOk
-import com.saveourtool.save.utils.requiredEnv
+import com.saveourtool.save.utils.*
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
@@ -36,6 +33,7 @@ private const val DOWNLOAD_REQUEST_TIMEOUT_MILLIS = 5 * 60 * 1000L
 private val httpClient = HttpClient(CIO) {
     install(ContentNegotiation) { json() }
     install(HttpTimeout)
+    install(KubernetesServiceAccountAuthHeaderPlugin)
 }
 
 private suspend fun HttpClient.download(url: String, file: Path): Result<HttpResponse> = runCatching {

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/service/DownloadToolService.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/service/DownloadToolService.kt
@@ -195,6 +195,7 @@ class DownloadToolService(
         @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
         private val logger = getLogger<DownloadToolService>()
         private fun httpClient(): HttpClient = HttpClient {
+            install(KubernetesServiceAccountAuthHeaderPlugin)
             install(ContentNegotiation) {
                 val json = Json { ignoreUnknownKeys = true }
                 json(json)


### PR DESCRIPTION
### What's done:
 * Moved `GenericAtomicReference` and `AtomicLong` from `save-agent` to `save-cloud-common`
 * Implemented `KubernetesServiceAccountAuthHeaderPlugin` which gets control over kubernetes service-account token and appends it to every request header