### PR TITLE
Fix deploy_images_reusable.yml

### DIFF
--- a/.github/workflows/deploy_images_reusable.yml
+++ b/.github/workflows/deploy_images_reusable.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           echo GRADLE_TASKS=:${{ inputs.module}}:buildImage >> $GITHUB_ENV
       - name: Prepare to build from branch
+        if: inputs.branch
         run: |
           git checkout origin/${{ inputs.branch }}
       - name: Override dockerTag


### PR DESCRIPTION
### What's done:
- checkout only if inputs.branch is provided