### PR TITLE
Added tables for contest samples

### DIFF
--- a/db/v-2/tables/contest-sample-field.xml
+++ b/db/v-2/tables/contest-sample-field.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="contest-sample-field" author="frolov" context="dev or prod">
+        <createTable tableName="contest_sample_field">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="contest_sample_id" type="bigint">
+                <constraints foreignKeyName="fk_contest_sample_field" references="contest_sample(id)" nullable="false" deleteCascade="true"/>
+            </column>
+            <column name="name" type="varchar(250)"/>
+            <column name="type" type="varchar(250)"/>
+            <column name="create_date" type="DATETIME(3)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="update_date" type="DATETIME(3)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="user_id" type="bigint">
+                <constraints foreignKeyName="fk_contest_sample_field_user" references="user(id)" nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/db/v-2/tables/contest-sample.xml
+++ b/db/v-2/tables/contest-sample.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="contest-sample" author="frolov" context="dev or prod">
+        <createTable tableName="contest_sample">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(250)">
+                <constraints unique="true" uniqueConstraintName="uq_contest_sample_name" nullable="false"/>
+            </column>
+            <column name="description" type="varchar(250)"/>
+            <column name="create_date" type="DATETIME(3)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="update_date" type="DATETIME(3)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="user_id" type="bigint">
+                <constraints foreignKeyName="fk_contest_sample_user" references="user(id)" nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/db/v-2/tables/db.changelog-tables.xml
+++ b/db/v-2/tables/db.changelog-tables.xml
@@ -40,6 +40,8 @@
     <include file="vulnerability-project.xml" relativeToChangelogFile="true"/>
     <include file="project-problem.xml" relativeToChangelogFile="true"/>
     <include file="comments.xml" relativeToChangelogFile="true"/>
+    <include file="contest-sample.xml" relativeToChangelogFile="true"/>
+    <include file="contest-sample-field.xml" relativeToChangelogFile="true"/>
 
     <changeSet id="02-tables" author="frolov">
         <tagDatabase tag="v2.0-tables"/>

--- a/save-api/src/main/kotlin/com/saveourtool/save/api/SaveCloudClientEx.kt
+++ b/save-api/src/main/kotlin/com/saveourtool/save/api/SaveCloudClientEx.kt
@@ -5,11 +5,11 @@ package com.saveourtool.save.api
 import com.saveourtool.save.agent.TestExecutionExtDto
 import com.saveourtool.save.api.errors.SaveCloudError
 import com.saveourtool.save.api.impl.DefaultSaveCloudClient
-import com.saveourtool.save.entities.ContestDto
 import com.saveourtool.save.entities.FileDto
 import com.saveourtool.save.entities.Organization
 import com.saveourtool.save.entities.ProjectDto
 import com.saveourtool.save.entities.ProjectStatus.CREATED
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.execution.ExecutionDto
 import com.saveourtool.save.permission.Permission.READ
 import com.saveourtool.save.request.CreateExecutionRequest

--- a/save-api/src/main/kotlin/com/saveourtool/save/api/impl/DefaultSaveCloudClient.kt
+++ b/save-api/src/main/kotlin/com/saveourtool/save/api/impl/DefaultSaveCloudClient.kt
@@ -11,6 +11,8 @@ import com.saveourtool.save.api.http.getAndCheck
 import com.saveourtool.save.api.http.postAndCheck
 import com.saveourtool.save.api.io.readChannel
 import com.saveourtool.save.entities.*
+import com.saveourtool.save.entities.contest.ContestDto
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.execution.ExecutionDto
 import com.saveourtool.save.execution.TestingType.CONTEST_MODE
 import com.saveourtool.save.filters.ProjectFilter

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ContestController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ContestController.kt
@@ -7,6 +7,8 @@ import com.saveourtool.save.configs.ApiSwaggerSupport
 import com.saveourtool.save.configs.RequiresAuthorizationSourceHeader
 import com.saveourtool.save.entities.*
 import com.saveourtool.save.entities.Contest.Companion.toContest
+import com.saveourtool.save.entities.contest.ContestDto
+import com.saveourtool.save.entities.contest.ContestStatus
 import com.saveourtool.save.permission.Permission
 import com.saveourtool.save.request.TestFilesRequest
 import com.saveourtool.save.test.TestFilesContent

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
@@ -11,8 +11,8 @@ import com.saveourtool.save.authservice.utils.AuthenticationDetails
 import com.saveourtool.save.backend.service.*
 import com.saveourtool.save.configs.ApiSwaggerSupport
 import com.saveourtool.save.configs.RequiresAuthorizationSourceHeader
-import com.saveourtool.save.entities.ContestResult
 import com.saveourtool.save.entities.LnkContestProject
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.execution.ExecutionDto
 import com.saveourtool.save.permission.Permission
 import com.saveourtool.save.utils.*

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/ContestRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/ContestRepository.kt
@@ -1,7 +1,7 @@
 package com.saveourtool.save.backend.repository
 
 import com.saveourtool.save.entities.Contest
-import com.saveourtool.save.entities.ContestStatus
+import com.saveourtool.save.entities.contest.ContestStatus
 import com.saveourtool.save.spring.repository.BaseEntityRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ContestService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ContestService.kt
@@ -2,12 +2,14 @@ package com.saveourtool.save.backend.service
 
 import com.saveourtool.save.backend.repository.ContestRepository
 import com.saveourtool.save.entities.Contest
-import com.saveourtool.save.entities.ContestStatus
 import com.saveourtool.save.entities.Organization
+import com.saveourtool.save.entities.contest.ContestStatus
+
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
 import java.time.LocalDateTime
 import java.util.*
 

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/LnkContestTestSuiteDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/LnkContestTestSuiteDto.kt
@@ -1,5 +1,6 @@
 package com.saveourtool.save.entities
 
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.testsuite.TestSuiteDto
 import kotlinx.serialization.Serializable
 

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestDto.kt
@@ -1,4 +1,4 @@
-package com.saveourtool.save.entities
+package com.saveourtool.save.entities.contest
 
 import com.saveourtool.save.testsuite.TestSuiteVersioned
 import com.saveourtool.save.validation.Validatable

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestResult.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestResult.kt
@@ -1,4 +1,4 @@
-package com.saveourtool.save.entities
+package com.saveourtool.save.entities.contest
 
 import com.saveourtool.save.execution.ExecutionStatus
 import kotlinx.datetime.LocalDateTime

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleDto.kt
@@ -14,7 +14,7 @@ data class ContestSampleDto(
     companion object {
         val empty = ContestSampleDto(
             "",
-            "",
+            null,
         )
     }
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleDto.kt
@@ -1,0 +1,20 @@
+package com.saveourtool.save.entities.contest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * @property name name of contest sample
+ * @property description description of contest sample
+ */
+@Serializable
+data class ContestSampleDto(
+    val name: String,
+    val description: String?,
+) {
+    companion object {
+        val empty = ContestSampleDto(
+            "",
+            "",
+        )
+    }
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleFieldDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleFieldDto.kt
@@ -1,0 +1,23 @@
+package com.saveourtool.save.entities.contest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * @property contestSample contest sample dto
+ * @property name name of field
+ * @property type type of field
+ */
+@Serializable
+data class ContestSampleFieldDto(
+    val contestSample: ContestSampleDto,
+    val name: String,
+    val type: ContestSampleFieldType,
+) {
+    companion object {
+        val empty = ContestSampleFieldDto(
+            ContestSampleDto.empty,
+            "",
+            ContestSampleFieldType.NUM,
+        )
+    }
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleFieldType.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestSampleFieldType.kt
@@ -1,0 +1,25 @@
+package com.saveourtool.save.entities.contest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Enum of contest sample field type
+ */
+@Serializable
+enum class ContestSampleFieldType {
+    /**
+     * Multi string type
+     */
+    MULTI_STRING,
+
+    /**
+     * Number type
+     */
+    NUM,
+
+    /**
+     * Single string type
+     */
+    SINGLE_STRING,
+    ;
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestStatus.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/contest/ContestStatus.kt
@@ -1,4 +1,4 @@
-package com.saveourtool.save.entities
+package com.saveourtool.save.entities.contest
 
 import kotlin.js.JsExport
 import kotlinx.serialization.Serializable

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Contest.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/Contest.kt
@@ -1,5 +1,7 @@
 package com.saveourtool.save.entities
 
+import com.saveourtool.save.entities.contest.ContestDto
+import com.saveourtool.save.entities.contest.ContestStatus
 import com.saveourtool.save.spring.entity.BaseEntity
 import com.saveourtool.save.validation.isValidName
 

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/ContestSample.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/ContestSample.kt
@@ -1,0 +1,30 @@
+package com.saveourtool.save.entities
+
+import com.saveourtool.save.entities.contest.ContestSampleDto
+import com.saveourtool.save.spring.entity.BaseEntityWithDateAndDto
+import javax.persistence.Entity
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+
+/**
+ * @property name name of contest sample
+ * @property description description of contest sample
+ * @property user creator contestSample
+ */
+@Entity
+class ContestSample(
+
+    var name: String,
+
+    var description: String?,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    var user: User,
+
+) : BaseEntityWithDateAndDto<ContestSampleDto>() {
+    override fun toDto() = ContestSampleDto(
+        name = name,
+        description = description,
+    )
+}

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/ContestSampleField.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/ContestSampleField.kt
@@ -1,0 +1,34 @@
+package com.saveourtool.save.entities
+
+import com.saveourtool.save.entities.contest.ContestSampleFieldDto
+import com.saveourtool.save.entities.contest.ContestSampleFieldType
+import com.saveourtool.save.spring.entity.BaseEntityWithDateAndDto
+import javax.persistence.*
+
+/**
+ * @property contestSample contest sample
+ * @property name name of field
+ * @property type type of field
+ * @property userId creator contestSampleField
+ */
+@Entity
+class ContestSampleField(
+
+    @ManyToOne
+    @JoinColumn(name = "contest_sample_id")
+    var contestSample: ContestSample,
+
+    var name: String,
+
+    @Enumerated(EnumType.STRING)
+    var type: ContestSampleFieldType,
+
+    var userId: Long,
+
+) : BaseEntityWithDateAndDto<ContestSampleFieldDto>() {
+    override fun toDto() = ContestSampleFieldDto(
+        contestSample = contestSample.toDto(),
+        name = name,
+        type = type,
+    )
+}

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/LnkContestExecution.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/LnkContestExecution.kt
@@ -1,5 +1,6 @@
 package com.saveourtool.save.entities
 
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.spring.entity.BaseEntity
 
 import javax.persistence.Entity

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/LnkContestProject.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/LnkContestProject.kt
@@ -1,5 +1,6 @@
 package com.saveourtool.save.entities
 
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.spring.entity.BaseEntity
 import javax.persistence.Entity
 import javax.persistence.JoinColumn

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestResourcesSelection.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TestResourcesSelection.kt
@@ -6,7 +6,7 @@
 
 package com.saveourtool.save.frontend.components.basic
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.execution.TestingType
 import com.saveourtool.save.frontend.components.basic.testsuiteselector.showPrivateTestSuitesSelectorModal
 import com.saveourtool.save.frontend.components.basic.testsuiteselector.showPublicTestSuitesSelectorModal

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestCreationComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestCreationComponent.kt
@@ -2,7 +2,7 @@
 
 package com.saveourtool.save.frontend.components.basic.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.components.basic.*
 import com.saveourtool.save.frontend.components.basic.testsuiteselector.showContestTestSuitesSelectorModal
 import com.saveourtool.save.frontend.components.inputform.*

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestInfoMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestInfoMenu.kt
@@ -2,7 +2,7 @@
 
 package com.saveourtool.save.frontend.components.basic.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.components.basic.cardComponent
 import com.saveourtool.save.frontend.components.basic.markdown
 import com.saveourtool.save.frontend.utils.*

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestSubmissionsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestSubmissionsMenu.kt
@@ -2,7 +2,7 @@
 
 package com.saveourtool.save.frontend.components.basic.contests
 
-import com.saveourtool.save.entities.ContestResult
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.execution.ExecutionStatus
 import com.saveourtool.save.frontend.components.tables.TableProps
 import com.saveourtool.save.frontend.components.tables.columns

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestSummaryMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestSummaryMenu.kt
@@ -2,7 +2,7 @@
 
 package com.saveourtool.save.frontend.components.basic.contests
 
-import com.saveourtool.save.entities.ContestResult
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.frontend.utils.*
 
 import react.*

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationContestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationContestsMenu.kt
@@ -7,8 +7,8 @@
 package com.saveourtool.save.frontend.components.basic.organizations
 
 import com.saveourtool.save.domain.Role
-import com.saveourtool.save.entities.ContestDto
-import com.saveourtool.save.entities.ContestStatus
+import com.saveourtool.save.entities.contest.ContestDto
+import com.saveourtool.save.entities.contest.ContestStatus
 import com.saveourtool.save.frontend.components.basic.contests.showContestCreationModal
 import com.saveourtool.save.frontend.components.modal.displayConfirmationModal
 import com.saveourtool.save.frontend.components.modal.displaySimpleModal

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectInfoMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectInfoMenu.kt
@@ -2,8 +2,8 @@
 
 package com.saveourtool.save.frontend.components.basic.projects
 
-import com.saveourtool.save.entities.ContestResult
 import com.saveourtool.save.entities.ProjectDto
+import com.saveourtool.save.entities.contest.ContestResult
 import com.saveourtool.save.frontend.components.basic.*
 import com.saveourtool.save.frontend.externals.fontawesome.faCalendarAlt
 import com.saveourtool.save.frontend.externals.fontawesome.faHistory

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectRunMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectRunMenu.kt
@@ -4,9 +4,9 @@ package com.saveourtool.save.frontend.components.basic.projects
 
 import com.saveourtool.save.domain.ProjectCoordinates
 import com.saveourtool.save.domain.Sdk
-import com.saveourtool.save.entities.ContestDto
 import com.saveourtool.save.entities.FileDto
 import com.saveourtool.save.entities.ProjectDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.execution.TestingType
 import com.saveourtool.save.frontend.components.basic.*
 import com.saveourtool.save.frontend.components.basic.fileuploader.fileUploaderForProjectRun

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ContestView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ContestView.kt
@@ -3,7 +3,7 @@
 package com.saveourtool.save.frontend.components.views
 
 import com.saveourtool.save.domain.Role
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.TabMenuBar
 import com.saveourtool.save.frontend.components.RequestStatusContext
 import com.saveourtool.save.frontend.components.basic.contests.contestInfoMenu

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/ContestListCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/ContestListCard.kt
@@ -6,7 +6,7 @@
 
 package com.saveourtool.save.frontend.components.views.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.components.basic.ContestNameProps
 import com.saveourtool.save.frontend.components.basic.showContestEnrollerModal
 import com.saveourtool.save.frontend.components.modal.displayModal

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/ContestsStatistics.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/ContestsStatistics.kt
@@ -4,7 +4,7 @@
 
 package com.saveourtool.save.frontend.components.views.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.utils.*
 
 import js.core.jso

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/CountDownTimer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/CountDownTimer.kt
@@ -7,7 +7,7 @@
 
 package com.saveourtool.save.frontend.components.views.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import react.FC
 import react.Props
 import kotlin.js.Date

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/FeaturedContests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/FeaturedContests.kt
@@ -4,7 +4,7 @@
 
 package com.saveourtool.save.frontend.components.views.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.components.basic.ContestNameProps
 import com.saveourtool.save.frontend.components.basic.carousel
 import com.saveourtool.save.frontend.components.basic.showContestEnrollerModal

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/NewContestsCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/NewContestsCard.kt
@@ -4,7 +4,7 @@
 
 package com.saveourtool.save.frontend.components.views.contests
 
-import com.saveourtool.save.entities.ContestDto
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.utils.*
 
 import js.core.jso

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/http/Requests.kt
@@ -6,6 +6,7 @@ package com.saveourtool.save.frontend.http
 
 import com.saveourtool.save.agent.TestExecutionDto
 import com.saveourtool.save.entities.*
+import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.utils.AvatarType


### PR DESCRIPTION
The user can create a template for a specific future contest. He will need to describe the fields that are required to be filled in by the participants of this contest.

The ContestSampleField table will contain a description of each specific field for the contest.

**what's done**

- Added tables for contest sample and contest sample fields
- Added entities and dto for contest sample
- moved all dto for contest in contest folder

Closes #2152 