### PR TITLE
Add more CPU to demo agent pods

### DIFF
--- a/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
+++ b/save-cloud-charts/save-cloud/templates/demo-configmap.yaml
@@ -10,6 +10,8 @@ data:
     demo.kubernetes.agent-namespace={{ .Values.agentNamespace }}
     demo.kubernetes.agentPort={{ .Values.demo.agentPort }}
     demo.kubernetes.agentSubdomainName={{ .Values.demo.agentSubdomainName }}
+    demo.kubernetes.agent-cpu-requests=100M
+    demo.kubernetes.agent-cpu-limits=500M
 
     management.endpoints.web.exposure.include=*
     management.server.port={{ .Values.demo.managementPort }}


### PR DESCRIPTION
### What's done:
 * Increased `demo.kubernetes.agent-cpu-requests` from 100m to 100M
 * Increased `demo.kubernetes.agent-cpu-limits` from 500m to 500M