### PR TITLE
Removed ResourceQuota for save-agent namespace

### DIFF
--- a/save-cloud-charts/save-cloud/templates/agent-namespace.yaml
+++ b/save-cloud-charts/save-cloud/templates/agent-namespace.yaml
@@ -5,18 +5,4 @@ kind: Namespace
 metadata:
   name: {{ .Values.agentNamespace }}
 
----
-
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  namespace: {{ .Values.agentNamespace }}
-  name: {{ .Values.agentNamespace }}-resource-quota
-spec:
-  hard:
-    requests.cpu: "1"
-    limits.cpu: "4"
-
----
-
 {{ end }}

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/ConfigProperties.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/config/ConfigProperties.kt
@@ -53,7 +53,7 @@ data class KubernetesConfig(
     val agentSubdomainName: String,
     val agentPort: Int,
     val agentNamespace: String = currentNamespace,
-    val agentCpuLimitations: Limitations? = null,
+    val agentCpuLimitations: Limitations? = defaultAgentCpuLimitations,
     val agentMemoryLimitations: Limitations? = defaultAgentMemoryLimitations,
     val agentEphemeralStorageLimitations: Limitations? = defaultEphemeralStorageLimitations
 ) {
@@ -87,6 +87,7 @@ data class KubernetesConfig(
         fun limitsQuantity() = Quantity(limits)
     }
     companion object {
+        private val defaultAgentCpuLimitations = Limitations("200m", "2")
         private val defaultAgentMemoryLimitations = Limitations("300Mi", "500Mi")
         private val defaultEphemeralStorageLimitations = Limitations("100Mi", "500Mi")
     }

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
@@ -40,7 +40,7 @@ private val logger = LoggerFactory.getLogger("KubernetesUtils")
  * @throws KubernetesRunnerException on failed job creation
  */
 fun <T : HasMetadata> KubernetesClient.createResourceOrThrow(resourceToCreate: T, namespace: String): T = try {
-    logger.debug { "Attempt to create ${resourceToCreate.kind} with the following name: ${resourceToCreate.fullResourceName}" }
+    logger.debug { "Attempt to create ${resourceToCreate.kind} with the following name: ${resourceToCreate.metadata.name}" }
     resource(resourceToCreate).inNamespace(namespace).create().also {
         logger.info("Created ${resourceToCreate.kind} with the following name: ${resourceToCreate.fullResourceName}")
     }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/topbar/TopBarLinks.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/topbar/TopBarLinks.kt
@@ -10,14 +10,17 @@ import react.*
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.li
 import react.dom.html.ReactHTML.ul
-import react.router.NavigateFunction
 import react.router.dom.Link
-import react.router.useLocation
-import react.router.useNavigate
 import remix.run.router.Location
 import web.cssom.ClassName
 import web.cssom.Width
 import web.cssom.rem
+
+/**
+ * If [Location.pathname] has more slashes then [TOP_BAR_PATH_SEGMENTS_HIGHLIGHT],
+ * there is no need to highlight topbar element as we have `/#/demo` and `/#/project/.../demo`
+ */
+private const val TOP_BAR_PATH_SEGMENTS_HIGHLIGHT = 4
 
 val topBarLinks = topBarLinks()
 
@@ -44,31 +47,11 @@ data class TopBarLink(
     val isExternalLink: Boolean = false,
 )
 
-private fun ChildrenBuilder.demoDropdownEntry(
-    name: String,
-    href: String,
-    location: Location,
-    navigate: NavigateFunction,
-    deactivateDropdown: () -> Unit,
-) {
-    dropdownEntry(null, name, location.pathname.endsWith(href)) { attrs ->
-        attrs.onClick = {
-            deactivateDropdown()
-            navigate(to = href)
-        }
-    }
-}
-
 /**
  * Displays the static links that do not depend on the url.
  */
 @Suppress("MAGIC_NUMBER", "LongMethod", "TOO_LONG_FUNCTION")
 private fun topBarLinks() = FC<TopBarLinksProps> { props ->
-    val navigate = useNavigate()
-    val location = useLocation()
-    var isDemoDropdownActive by useState(false)
-    val deactivateDropdown = { isDemoDropdownActive = false }
-
     ul {
         className = ClassName("navbar-nav mx-auto")
         sequenceOf(
@@ -104,5 +87,11 @@ private fun topBarLinks() = FC<TopBarLinksProps> { props ->
     }
 }
 
-private fun textColor(hrefAnchor: String, location: Location) =
-        if (location.pathname.endsWith(hrefAnchor)) "text-warning" else "text-light"
+private fun textColor(
+    hrefAnchor: String,
+    location: Location,
+) = if (location.pathname.endsWith(hrefAnchor) && location.pathname.count { it == '/' } < TOP_BAR_PATH_SEGMENTS_HIGHLIGHT) {
+    "text-warning"
+} else {
+    "text-light"
+}


### PR DESCRIPTION
### What's done:
* removed `ResourceQuota` for `save-agent` namespace
* Fixed wrong `demo` highlighting in top bar (used to be highlighted when ProjectView->DemoMenu was opened)
* Added default agent cpu limitations
* Fixed logging for `createResourceOrThrow` of save-demo