### PR TITLE
Prepend path to temp dir in run command

### DIFF
--- a/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
+++ b/save-cloud-common/src/nativeMain/kotlin/com/saveourtool/save/utils/FileUtils.kt
@@ -12,6 +12,7 @@ import platform.posix.*
 
 import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.convert
+import kotlinx.datetime.Clock
 import kotlinx.serialization.serializer
 
 actual val fs: FileSystem = FileSystem.SYSTEM
@@ -31,9 +32,14 @@ actual fun ByteArray.writeToFile(file: Path, mustCreate: Boolean) {
  *
  * @param fileName name of a file
  * @param lines lines to be written to file with name [fileName]
+ * @param dirPath path to directory where a file should be created
  * @return path to file
  */
-fun FileSystem.createAndWrite(fileName: String, lines: List<String>) = fileName.toPath().also { path ->
+fun FileSystem.createAndWrite(
+    fileName: String,
+    lines: List<String>,
+    dirPath: Path = ".".toPath(),
+) = dirPath.div(fileName).also { path ->
     write(path, true) { lines.forEach { codeLine -> writeUtf8("$codeLine\n") } }
 }
 
@@ -42,11 +48,27 @@ fun FileSystem.createAndWrite(fileName: String, lines: List<String>) = fileName.
  *
  * @param fileName name of a file
  * @param lines lines to be written to file with name [fileName]
+ * @param dirPath path to directory where a file should be created
  * @return path to file if both [fileName] and [lines] are provided, null otherwise
  */
-fun FileSystem.createAndWriteIfNeeded(fileName: String?, lines: List<String>?) = fileName?.toPath()?.also { path ->
+fun FileSystem.createAndWriteIfNeeded(
+    fileName: String?,
+    lines: List<String>?,
+    dirPath: Path = ".".toPath(),
+) = fileName?.let { dirPath / it }?.also { path ->
     write(path, true) { lines?.forEach { codeLine -> writeUtf8("$codeLine\n") } }
 }
+
+/**
+ * Create temporary directory
+ *
+ * @param mustCreate if true and file is already created, IOException is thrown
+ * @return path to newly-created temp dir
+ */
+fun FileSystem.createTempDir(mustCreate: Boolean = true) = Clock.System.now()
+    .toString()
+    .toPath()
+    .also { createDirectory(it, mustCreate) }
 
 actual inline fun <reified C : Any> parseConfig(configPath: Path): C = TomlFileReader.decodeFromFile(
     serializer(),

--- a/save-demo-agent/src/nativeTest/kotlin/com/saveoourtool/save/demo/agent/RelativizeRunCommandTest.kt
+++ b/save-demo-agent/src/nativeTest/kotlin/com/saveoourtool/save/demo/agent/RelativizeRunCommandTest.kt
@@ -1,0 +1,29 @@
+package com.saveoourtool.save.demo.agent
+
+import com.saveourtool.save.demo.DemoRunRequest
+import com.saveourtool.save.demo.RunConfiguration
+import com.saveourtool.save.demo.agent.getRelativeRunCommand
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RelativizeRunCommandTest {
+    private val pathToTempDir = "path/to/temp/dir".toPath()
+    private val runRequest = DemoRunRequest(emptyList(), "test", null)
+
+    @Test
+    fun diktatRunCommandTest() {
+        val runConfiguration = RunConfiguration(
+            "Test.kt",
+            null,
+            mapOf(
+                runRequest.mode to "./ktlint -R diktat-1.2.4.2.jar --disabled_rules=standard --reporter=plain,output=output.txt Test.kt"
+            ),
+            "output.txt"
+        )
+        assertEquals(
+            runConfiguration.getRelativeRunCommand(runRequest, pathToTempDir),
+            "./ktlint -R diktat-1.2.4.2.jar --disabled_rules=standard --reporter=plain,output=$pathToTempDir/output.txt $pathToTempDir/Test.kt"
+        )
+    }
+}


### PR DESCRIPTION
This PR closes #2190 

### What's done:
* Added `createTempDir` function to native `FileUtils`
* Started to execute all demo runs in temp dir
* Added test for run command modification with temp dir