### PR TITLE
Downgraded ktor version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.8.22"
 jetbrains-annotations = "24.0.1"
 save-cli = "0.4.0-SNAPSHOT"
-ktor = "2.3.1"
+ktor = "2.3.0"
 okio = "3.3.0"
 serialization = "1.5.1"
 kotlinx-datetime = "0.4.0"


### PR DESCRIPTION
### What's done:
- downgraded ktor version to 2.3.0 is due to https://github.com/ktorio/ktor/pull/3609 is not released yet