### PR TITLE
cytoscape.js

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeEdge.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeEdge.kt
@@ -1,0 +1,24 @@
+package com.saveourtool.save.demo.cpg.cytoscape
+
+import kotlinx.serialization.Serializable
+
+/**
+ * @property data
+ * @property pannable
+ */
+@Serializable
+data class CytoscapeEdge(val data: Data, val pannable: Boolean = true) {
+    /**
+     * @property id
+     * @property source
+     * @property target
+     * @property label
+     */
+    @Serializable
+    data class Data(
+        val id: String,
+        val source: String,
+        val target: String,
+        val label: String? = null
+    )
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeGraph.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeGraph.kt
@@ -1,0 +1,21 @@
+package com.saveourtool.save.demo.cpg.cytoscape
+
+import kotlinx.serialization.Serializable
+
+/**
+ * @property nodes
+ * @property edges
+ * @property attributes
+ */
+@Serializable
+data class CytoscapeGraph(
+    val nodes: List<CytoscapeNode>,
+    val edges: List<CytoscapeEdge>,
+    val attributes: Attributes = Attributes(),
+) {
+    /**
+     * @property name
+     */
+    @Serializable
+    data class Attributes(val name: String = "Demo graph")
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeLayout.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeLayout.kt
@@ -1,0 +1,16 @@
+package com.saveourtool.save.demo.cpg.cytoscape
+
+/**
+ * @property layoutName lib-defined name of layout
+ */
+enum class CytoscapeLayout(val layoutName: String) {
+    BREADTHFIRST("breadthfirst"),
+    CIRCLE("circle"),
+    CONCENTRIC("concentric"),
+    COSE("cose"),
+    GRID("grid"),
+    NULL("null"),
+    PRESET("preset"),
+    RANDOM("random"),
+    ;
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeNode.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/demo/cpg/cytoscape/CytoscapeNode.kt
@@ -1,0 +1,33 @@
+package com.saveourtool.save.demo.cpg.cytoscape
+
+import com.saveourtool.save.demo.cpg.CpgNodeAdditionalInfo
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+
+/**
+ * @property data
+ * @property position
+ * @property additionalInfo
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class CytoscapeNode(
+    val data: Data,
+    val position: Position? = null,
+    val additionalInfo: CpgNodeAdditionalInfo? = null,
+) {
+    /**
+     * @property x
+     * @property y
+     */
+    @Serializable
+    data class Position(val x: Int, val y: Int)
+
+    /**
+     * @property id
+     * @property parent
+     * @property label
+     */
+    @Serializable
+    data class Data(val id: String, val parent: String? = null, val label: String? = null)
+}

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -123,6 +123,7 @@ kotlin {
             implementation(npm("@react-sigma/layout-circular", "^3.1.0"))
             implementation(npm("@react-sigma/layout-forceatlas2", "^3.1.0"))
             implementation(npm("react-graph-viz-engine", "^0.1.0"))
+            implementation(npm("cytoscape", "^3.25.0"))
             // transitive dependencies with explicit version ranges required for security reasons
             compileOnly(devNpm("minimist", "^1.2.6"))
             compileOnly(devNpm("async", "^2.6.4"))

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/cpg/GraphLoader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/cpg/GraphLoader.kt
@@ -7,13 +7,14 @@
 package com.saveourtool.save.frontend.components.basic.cpg
 
 import com.saveourtool.save.demo.cpg.CpgGraph
+import com.saveourtool.save.frontend.externals.graph.paintNodes
 import com.saveourtool.save.frontend.externals.graph.sigma.layouts.LayoutInstance
 import com.saveourtool.save.frontend.externals.graph.sigma.layouts.useLayoutCircular
 import com.saveourtool.save.frontend.externals.graph.sigma.layouts.useLayoutForceAtlas2
 import com.saveourtool.save.frontend.externals.graph.sigma.layouts.useLayoutRandom
-import com.saveourtool.save.frontend.externals.graph.sigma.paintNodes
-import com.saveourtool.save.frontend.externals.graph.sigma.toGraphologyJson
 import com.saveourtool.save.frontend.externals.graph.sigma.useLoadGraph
+import com.saveourtool.save.frontend.externals.graph.toGraphologyJson
+
 import js.core.jso
 import react.FC
 import react.Props

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/graph/CytoscapeVisualizer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/graph/CytoscapeVisualizer.kt
@@ -1,0 +1,32 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.basic.graph
+
+import com.saveourtool.save.demo.cpg.CpgGraph
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeLayout
+import com.saveourtool.save.frontend.externals.graph.asCytoscapeGraph
+import com.saveourtool.save.frontend.externals.graph.cytoscape.cytoscape
+import react.FC
+import react.Props
+
+val cytoscapeVisualizer: FC<CytoscapeVisualizerProps> = FC { props ->
+    cytoscape(
+        props.graph.asCytoscapeGraph(),
+        props.layout
+    )
+}
+
+/**
+ * [Props] for [cytoscapeVisualizer]
+ */
+external interface CytoscapeVisualizerProps : Props {
+    /**
+     * Graph to render, must be set
+     */
+    var graph: CpgGraph
+
+    /**
+     * [CytoscapeLayout] to apply to graph, must be set
+     */
+    var layout: CytoscapeLayout
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/graph/SigmaGraphVisualizer.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/graph/SigmaGraphVisualizer.kt
@@ -9,7 +9,7 @@ import com.saveourtool.save.frontend.components.basic.cpg.graphEvents
 import com.saveourtool.save.frontend.components.basic.cpg.graphLoader
 import com.saveourtool.save.frontend.externals.fontawesome.faTimesCircle
 import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
-import com.saveourtool.save.frontend.externals.graph.sigma.getSigmaContainerSettings
+import com.saveourtool.save.frontend.externals.graph.getSigmaContainerSettings
 import com.saveourtool.save.frontend.externals.graph.sigma.sigmaContainer
 import js.core.jso
 import react.ChildrenBuilder

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/demo/CpgView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/demo/CpgView.kt
@@ -7,15 +7,16 @@
 package com.saveourtool.save.frontend.components.views.demo
 
 import com.saveourtool.save.demo.cpg.CpgResult
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeLayout
 import com.saveourtool.save.frontend.components.basic.cardComponent
 import com.saveourtool.save.frontend.components.basic.cpg.SigmaLayout
 import com.saveourtool.save.frontend.components.basic.demo.graphDemoComponent
-import com.saveourtool.save.frontend.components.basic.graph.graphVizVisualizer
+import com.saveourtool.save.frontend.components.basic.graph.cytoscapeVisualizer
 import com.saveourtool.save.frontend.components.modal.displaySimpleModal
-import com.saveourtool.save.frontend.externals.graph.graphviz.GraphVizLayout
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.frontend.utils.loadingHandler
 import com.saveourtool.save.utils.Languages
+import js.core.jso
 
 import react.*
 import react.dom.html.ReactHTML.br
@@ -88,9 +89,12 @@ val cpgView: VFC = VFC {
                         with(builder) {
                             div {
                                 className = ClassName("card card-body p-0")
-                                graphVizVisualizer {
-                                    layout = GraphVizLayout.preferredLayout
-                                    graph = sampleData
+                                style = jso {
+                                    height = "90%".unsafeCast<Height>()
+                                }
+                                cytoscapeVisualizer {
+                                    graph = cpgResult.cpgGraph
+                                    layout = CytoscapeLayout.CONCENTRIC
                                 }
                                 div {
                                     val alertStyle = when {
@@ -135,53 +139,3 @@ val cpgView: VFC = VFC {
         }
     }
 }
-
-private val sampleData = js("""{
-    "data": {
-        "actors": [
-            {
-                "__typename": "Actor",
-                "ID": 1,
-                "name": "François Lallement",
-                "acted_in": [
-                    {
-                        "__typename": "Movie",
-                        "ID": 3,
-                        "title": "Trip to the Moon, A (Voyage dans la lune, Le)",
-                        "genres": [
-                            {
-                                "__typename": "Genre",
-                                "ID": 5,
-                                "name": "Action"
-                            },
-                            {
-                                "__typename": "Genre",
-                                "ID": 6,
-                                "name": "Adventure"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "__typename": "Actor",
-                "ID": 2,
-                "name": "Jules-Eugène Legris",
-                "acted_in": [
-                    {
-                        "__typename": "Movie",
-                        "ID": 3,
-                        "title": "Trip to the Moon, A (Voyage dans la lune, Le)",
-                        "genres": [
-                            {
-                                "__typename": "Genre",
-                                "ID": 7,
-                                "name": "Sci-Fi"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-}""")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/graph/CpgUtils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/graph/CpgUtils.kt
@@ -2,11 +2,14 @@
  * Utils for CpgGraph and Sigma in general
  */
 
-package com.saveourtool.save.frontend.externals.graph.sigma
+package com.saveourtool.save.frontend.externals.graph
 
 import com.saveourtool.save.demo.cpg.CpgEdge
 import com.saveourtool.save.demo.cpg.CpgGraph
 import com.saveourtool.save.demo.cpg.CpgNode
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeEdge
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeGraph
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeNode
 
 import js.core.jso
 
@@ -73,6 +76,30 @@ fun CpgGraph.paintEdges(
     .let { coloredEdges ->
         copy(edges = coloredEdges)
     }
+
+/**
+ * @return [CytoscapeEdge] from [CpgEdge]
+ */
+fun CpgEdge.asCytoscapeEdge() = CytoscapeEdge(
+    CytoscapeEdge.Data(key, source, target, attributes.label),
+    false
+)
+
+/**
+ * @return [CytoscapeNode] from [CpgNode]
+ */
+fun CpgNode.asCytoscapeNode() = CytoscapeNode(
+    CytoscapeNode.Data(key, label = attributes.label)
+)
+
+/**
+ * @return [CytoscapeGraph] from [CpgGraph]
+ */
+fun CpgGraph.asCytoscapeGraph() = CytoscapeGraph(
+    nodes.map { it.asCytoscapeNode() },
+    edges.map { it.asCytoscapeEdge() },
+    CytoscapeGraph.Attributes(name = attributes.name)
+)
 
 /**
  * @param edgeType type of the edge that should be displayed

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/graph/cytoscape/CytoscapeWrapper.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/graph/cytoscape/CytoscapeWrapper.kt
@@ -1,0 +1,89 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS", "HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package com.saveourtool.save.frontend.externals.graph.cytoscape
+
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeGraph
+import com.saveourtool.save.demo.cpg.cytoscape.CytoscapeLayout
+
+import js.core.jso
+import react.ChildrenBuilder
+import react.dom.html.ReactHTML.div
+import web.cssom.*
+import web.dom.document
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private const val CYTOSCAPE_DIV_ID = "cytoscape-div"
+
+/**
+ * @param graph data in [CytoscapeGraph] format
+ * @param layout [CytoscapeLayout] that should be applied to graph
+ * @param divId id that should be assigned to div with graph, [CYTOSCAPE_DIV_ID] by default
+ */
+@Suppress("UNUSED_VARIABLE", "TOO_LONG_FUNCTION")
+fun ChildrenBuilder.cytoscape(
+    graph: CytoscapeGraph,
+    layout: CytoscapeLayout,
+    divId: String = CYTOSCAPE_DIV_ID
+) {
+    div {
+        id = divId
+        style = jso {
+            width = "100%".unsafeCast<Width>()
+            height = "90%".unsafeCast<Height>()
+        }
+    }
+
+    val cytoscapeGraphJsonString = Json.encodeToString(graph)
+    val cytoscapeGraphJsonStringJs = js("JSON.parse(cytoscapeGraphJsonString);")
+    // language=json
+    val graphStyle = js("""
+        [
+            {
+                "selector": "node",
+                "style": {
+                    "background-color": "#666",
+                    "label": "data(label)",
+                    "height": 10,
+                    "width": 10,
+                    "font-size": 3
+                }
+            },
+            {
+                "selector": "edge",
+                "style": {
+                    "width": 2,
+                    "height": 2,
+                    "line-color": "#ccc",
+                    "target-arrow-color": "#ccc",
+                    "target-arrow-shape": "triangle",
+                    "curve-style": "bezier",
+                    "label": "data(label)",
+                    "font-size": 3
+                }
+            }
+        ]
+    """)
+    val layoutName = layout.layoutName
+    val graphLayout = js("""
+        {
+            "name": layoutName,
+            "padding": 10
+        }
+    """)
+    @Suppress("UNUSED_ANONYMOUS_PARAMETER")
+    val options = document.getElementById(divId)?.let { divContainer ->
+        js("""
+            {
+                "container" : divContainer,
+                "elements" : cytoscapeGraphJsonStringJs,
+                "layout" : graphLayout,
+                "style" : graphStyle
+            }
+        """)
+    }
+
+    val cytoscapeJs = kotlinext.js.require("cytoscape")
+    cytoscapeJs(options)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,7 +1950,7 @@ cytoscape-popper@^2.0.0:
   dependencies:
     "@popperjs/core" "^2.0.0"
 
-cytoscape@^3.21.0:
+cytoscape@^3.21.0, cytoscape@^3.25.0:
   version "3.25.0"
   resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.25.0.tgz#5289e9d18be0293b073bfe93f83bb95b908b2dc1"
   integrity sha512-7MW3Iz57mCUo6JQCho6CmPBCbTlJr7LzyEtIkutG255HLVd4XuBg2I9BkTZLI/e4HoaOB/BiAzXuQybQ95+r9Q==


### PR DESCRIPTION
### What's done:
 * Added `cytoscape` wrapper
 * Reused `cytoscape` wrapper with `cytoscapeVisualizer` in order to replace `graphVizVisualizer`

### TODO:
 * Fix visuals
 * Make all selectors on `DemoCpgView` work

### How it looks:
<img width="1406" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/9c670794-0dfb-466b-87b0-52193313be1a">
