### PR TITLE
Fix build image for save-backend and save-sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ save-cloud-charts/save-cloud/charts
 
 # Vim swap files
 *.swp
+
+/save/save-*-SNAPSHOT-linuxX64.kexe


### PR DESCRIPTION
### What's done:
- added save/save-0.4.0-SNAPSHOT-linuxX64.kexe to gitignore to have a clean git repo for reckon version