### PR TITLE
Hotfix with a sanity test for api-gateway

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -12,4 +12,13 @@ dependencies {
     implementation(libs.spring.cloud.starter.kubernetes.client.config)
     implementation(libs.spring.security.core)
     implementation(projects.authenticationService)
+
+    // FixMe: we officially bring serialization CVE to our project
+    // easy way to hack us during the deserialization:
+    // https://github.com/advisories/GHSA-mjmj-j48q-9wg2
+    implementation("org.yaml:snakeyaml") {
+        version {
+            strictly("1.33")
+        }
+    }
 }

--- a/api-gateway/src/main/kotlin/com/saveourtool/save/gateway/config/ConfigurationProperties.kt
+++ b/api-gateway/src/main/kotlin/com/saveourtool/save/gateway/config/ConfigurationProperties.kt
@@ -1,6 +1,7 @@
 package com.saveourtool.save.gateway.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.security.web.util.matcher.IpAddressMatcher
 import java.net.InetAddress
 
@@ -8,6 +9,7 @@ import java.net.InetAddress
  * @property backend properties for connection to save-backend
  * @property knownActuatorConsumers comma-separated list of IPs of clients that are allowed to access spring boot actuator
  */
+@ConstructorBinding
 @ConfigurationProperties(prefix = "gateway")
 data class ConfigurationProperties(
     val backend: Backend,

--- a/api-gateway/src/test/kotlin/com/saveourtool/save/gateway/StartupTest.kt
+++ b/api-gateway/src/test/kotlin/com/saveourtool/save/gateway/StartupTest.kt
@@ -1,0 +1,18 @@
+package com.saveourtool.save.gateway
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+
+
+@SpringBootTest
+@SpringJUnitConfig
+class ApplicationStartupTest {
+    @Test
+    fun contextLoads() {
+        // This test method will be executed to check the application startup
+        // If the application starts successfully, the test will pass
+        // If there are any exceptions or failures during startup, the test will fail
+    }
+}
+

--- a/api-gateway/src/test/kotlin/com/saveourtool/save/gateway/StartupTest.kt
+++ b/api-gateway/src/test/kotlin/com/saveourtool/save/gateway/StartupTest.kt
@@ -7,7 +7,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 
 @SpringBootTest
 @SpringJUnitConfig
-class ApplicationStartupTest {
+class StartupTest {
     @Test
     fun contextLoads() {
         // This test method will be executed to check the application startup

--- a/api-gateway/src/test/kotlin/com/saveourtool/save/gateway/StartupTest.kt
+++ b/api-gateway/src/test/kotlin/com/saveourtool/save/gateway/StartupTest.kt
@@ -8,11 +8,9 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 @SpringBootTest
 @SpringJUnitConfig
 class StartupTest {
+    // This test method will be executed to check the application startup
+    // If the application starts successfully, the test will pass
+    // If there are any exceptions or failures during startup, the test will fail
     @Test
-    fun contextLoads() {
-        // This test method will be executed to check the application startup
-        // If the application starts successfully, the test will pass
-        // If there are any exceptions or failures during startup, the test will fail
-    }
+    fun contextLoads() = Unit
 }
-

--- a/api-gateway/src/test/resources/application-dev.yml
+++ b/api-gateway/src/test/resources/application-dev.yml
@@ -1,0 +1,67 @@
+gateway:
+  backend:
+    url: http://localhost:5800
+  frontend:
+    # In the "dev" environment, the front-end uses TCP port 8080 when run using `webpack-dev-server` (i.e. `browserDevelopmentRun` or `run` Gradle task).
+    url: http://localhost:8080
+  sandbox:
+    url: http://localhost:5400
+  demo:
+    url: http://localhost:5421
+  demo-cpg:
+    url: http://localhost:5500
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          # example: https://github.com/wearearima/spring-boot-dex/blob/master/src/main/resources/application.properties
+          dex:
+            authorization-uri: http://localhost:5556/dex/auth
+            token-uri: http://localhost:5556/dex/token
+            jwk-set-uri: http://localhost:5556/dex/keys
+          github:
+            # This is because in the default configuration
+            # (o.s.s.c.o.c.CommonOAuth2Provider#GITHUB), the numeric "id" field
+            # is taken from the JSON response from https://api.github.com/user.
+            #
+            # We want the publicly-visible "login" value instead.
+            #
+            # See https://docs.github.com/en/rest/users/users#get-the-authenticated-user
+            # for more details.
+            user-name-attribute: login
+        registration:
+          dex:
+            client-id: save-gateway-dev
+            client-secret: 123test123
+            authorization-grant-type: authorization_code
+            redirect-uri: '${gateway.frontend.url}/{action}/oauth2/code/{registrationId}'
+            scope:
+              - openid
+          github:
+            # We don't set any redirect-uri here, because it's managed by GitHub
+            # (the field is called "Authorization callback URL" and, for a local
+            # deployment, it should be exactly "http://localhost:8080/login/oauth2/code/github").
+            #
+            # Navigate to http://localhost:8080/sec/oauth-providers or
+            # http://localhost:5300/sec/oauth-providers to check that the OAuth
+            # provider is correctly installed.
+            #
+            # This is the public Client ID of your GitHub OAuth application.
+            # See https://docs.github.com/en/developers/apps/building-oauth-apps/
+            # for details.
+            client-id: cd74c74af6b5c595f088
+
+            # This is the per-service secret used by your service to authenticate
+            # against your GitHub OAuth application. You can generate a new secret
+            # under Settings -> Developer settings -> OAuth Apps.
+            #
+            # If the integration is set up correctly, in the OAuth application
+            # settings, you'll see that the secret has been used
+            # (e.g.: "Last used within the last week").
+            client-secret: 2c05929edd949d670c3454258bbdbfefb7ba3eb7
+logging:
+  level:
+    org.springframework.web: DEBUG
+    org.springframework.security: DEBUG
+    com.nimbusds: TRACE


### PR DESCRIPTION
### What's done:
- fixed gateway typo
- due to the change in snakeyaml API (2.0), api-gateway is not able to start: `Caused by: java.lang.NoSuchMethodError: org.yaml.snakeyaml.constructor.SafeConstructor: method 'void <init>()' not found`
