### PR TITLE
Upgrade neo4j back to version 5.7.0

### DIFF
--- a/save-cloud-charts/save-cloud/Chart.lock
+++ b/save-cloud-charts/save-cloud/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 4.4.2
 - name: neo4j
   repository: https://helm.neo4j.com/neo4j
-  version: 5.4.0
-digest: sha256:7ab661935ab7bc938985d3108ad683e39f14dcbbe4b00b29aba56bad10b9727b
-generated: "2023-02-06T09:05:52.437014971Z"
+  version: 5.7.0
+digest: sha256:70c985d635dd6232488363eadbbb2ddedd8458c851b62be6fc04a4756383d665
+generated: "2023-07-03T15:54:23.3732866+03:00"

--- a/save-cloud-charts/save-cloud/Chart.yaml
+++ b/save-cloud-charts/save-cloud/Chart.yaml
@@ -9,22 +9,22 @@ sources:
   - https://github.com/saveourtool/save-cli
 dependencies:
   - name: grafana
-    version: ^6.0.0
+    version: ^6.0.0 <=6.50.7
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: prometheus
-    version: ^19.0.0
+    version: ^19.0.0 <=19.3.3
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: promtail
-    version: ^6.0.0
+    version: ^6.0.0 <=6.8.2
     repository: https://grafana.github.io/helm-charts
     condition: loki.enabled
   - name: loki
-    version: ^4.0.0
+    version: ^4.0.0 <=4.4.2
     repository: https://grafana.github.io/helm-charts
     condition: loki.enabled
   - name: neo4j
-    version: ^5.0.0
+    version: ^5.0.0 <=5.7.0
     repository: https://helm.neo4j.com/neo4j
     condition: neo4j.enabled


### PR DESCRIPTION
This fixes the problem introduced when downgrading to version **5.4.0** with #2265.

Otherwise, the (older) database fails to read the (newer) data. `kubectl logs pods/save-cloud-0` returns:

```
Changed password for user 'neo4j'. IMPORTANT: this change will only take effect if performed before the database is started for the first time.
2023-07-03 12:24:11.539+0000 INFO  Command expansion is explicitly enabled for configuration
2023-07-03 12:24:11.621+0000 WARN  Unrecognized setting. No declared setting with name: server.panic.shutdown_on_panic.
2023-07-03 12:24:11.718+0000 INFO  Starting...
2023-07-03 12:24:14.032+0000 INFO  This instance is ServerId{a9c4e5be} (a9c4e5be-c37f-4bda-8daa-94e343bda9a9)
2023-07-03 12:24:18.139+0000 INFO  ======== Neo4j 5.4.0 ========
2023-07-03 12:24:28.657+0000 ERROR Failed to start Neo4j on 0.0.0.0:7474.
java.lang.RuntimeException: Error starting Neo4j database server at /data/databases
        at org.neo4j.graphdb.facade.DatabaseManagementServiceFactory.startDatabaseServer(DatabaseManagementServiceFactory.java:255) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.graphdb.facade.DatabaseManagementServiceFactory.build(DatabaseManagementServiceFactory.java:193) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.server.CommunityBootstrapper.createNeo(CommunityBootstrapper.java:36) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.server.NeoBootstrapper.start(NeoBootstrapper.java:170) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.server.NeoBootstrapper.start(NeoBootstrapper.java:86) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.server.CommunityEntryPoint.main(CommunityEntryPoint.java:30) ~[neo4j-5.4.0.jar:5.4.0]
Caused by: org.neo4j.kernel.lifecycle.LifecycleException: Component 'org.neo4j.dbms.database.DefaultSystemGraphInitializer@2cd4e16a' was successfully initialized, but failed to start. Please
 see the attached cause exception "Unsupported component state for 'dbms-runtime': The sub-graph is unsupported because it is a newer version, this component cannot function".
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:370) ~[neo4j-common-5.4.0.jar:5.4.0]
        at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:92) ~[neo4j-common-5.4.0.jar:5.4.0]
        at org.neo4j.graphdb.facade.DatabaseManagementServiceFactory.startDatabaseServer(DatabaseManagementServiceFactory.java:246) ~[neo4j-5.4.0.jar:5.4.0]
        ... 5 more
Caused by: java.lang.IllegalStateException: Failed to initialize system graph component: Unsupported component state for 'dbms-runtime': The sub-graph is unsupported because it is a newer ve
rsion, this component cannot function
        at org.neo4j.dbms.database.SystemGraphComponents.initializeSystemGraph(SystemGraphComponents.java:113) ~[neo4j-kernel-5.4.0.jar:5.4.0]
        at org.neo4j.dbms.database.DefaultSystemGraphInitializer.initializeSystemGraph(DefaultSystemGraphInitializer.java:38) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.dbms.database.SystemGraphInitializer.start(SystemGraphInitializer.java:27) ~[neo4j-kernel-5.4.0.jar:5.4.0]
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:353) ~[neo4j-common-5.4.0.jar:5.4.0]
        at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:92) ~[neo4j-common-5.4.0.jar:5.4.0]
        at org.neo4j.graphdb.facade.DatabaseManagementServiceFactory.startDatabaseServer(DatabaseManagementServiceFactory.java:246) ~[neo4j-5.4.0.jar:5.4.0]
        ... 5 more
Caused by: java.lang.IllegalStateException: Unsupported component state for 'dbms-runtime': The sub-graph is unsupported because it is a newer version, this component cannot function
        at org.neo4j.dbms.database.AbstractVersionComponent.initializeSystemGraph(AbstractVersionComponent.java:104) ~[neo4j-kernel-5.4.0.jar:5.4.0]
        at org.neo4j.dbms.database.SystemGraphComponents.initializeSystemGraph(SystemGraphComponents.java:105) ~[neo4j-kernel-5.4.0.jar:5.4.0]
        at org.neo4j.dbms.database.DefaultSystemGraphInitializer.initializeSystemGraph(DefaultSystemGraphInitializer.java:38) ~[neo4j-5.4.0.jar:5.4.0]
        at org.neo4j.dbms.database.SystemGraphInitializer.start(SystemGraphInitializer.java:27) ~[neo4j-kernel-5.4.0.jar:5.4.0]
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:353) ~[neo4j-common-5.4.0.jar:5.4.0]
        at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:92) ~[neo4j-common-5.4.0.jar:5.4.0]
        at org.neo4j.graphdb.facade.DatabaseManagementServiceFactory.startDatabaseServer(DatabaseManagementServiceFactory.java:246) ~[neo4j-5.4.0.jar:5.4.0]
        ... 5 more
2023-07-03 12:24:28.659+0000 INFO  Neo4j Server shutdown initiated by request
2023-07-03 12:24:28.659+0000 INFO  Stopped.
```

`kubectl describe` for the same Pod returns:

```
Events:
  Type     Reason        Age                    From     Message
  ----     ------        ----                   ----     -------
  Warning  Unhealthy     28m (x100 over 73m)    kubelet  Startup probe failed: dial tcp 172.17.0.180:7687: connect: connection refused
  Warning  BackOffStart  3m37s (x296 over 72m)  kubelet  the failed container exited with ExitCode: 1
```