### PR TITLE
Changed volume for preprocessor

### DIFF
--- a/save-cloud-charts/save-cloud/templates/preprocessor-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/preprocessor-deployment.yaml
@@ -42,5 +42,5 @@ spec:
         - name: repos-storage
           # This mount is not intended to be shared among nodes, because this is temporary data,
           # and each pod of preprocessor can `git clone` on its own.
-          hostPath:
-            path: /tmp/save/repos
+          emptyDir:
+            sizeLimit: 100Mi


### PR DESCRIPTION
### What's done:
- changed volume for preprocessor from `hostPath` to `emptyDir`

It closes #2119