### PR TITLE
Vulnerability dates should be able to be deleted

### DIFF
--- a/db/v-2/tables/vulnerability-date.xml
+++ b/db/v-2/tables/vulnerability-date.xml
@@ -31,4 +31,8 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="vulnerability-date-2-unique-const" author="sanyavertolet" context="dev or prod">
+        <addUniqueConstraint tableName="vulnerability_date" columnNames="type,vulnerability_id" constraintName="uq_type_vulnerability_id"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/vulnerability/VulnerabilityController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/vulnerability/VulnerabilityController.kt
@@ -11,10 +11,7 @@ import com.saveourtool.save.entities.vulnerability.VulnerabilityDto
 import com.saveourtool.save.entities.vulnerability.VulnerabilityProjectDto
 import com.saveourtool.save.filters.VulnerabilityFilter
 import com.saveourtool.save.info.UserInfo
-import com.saveourtool.save.utils.StringResponse
-import com.saveourtool.save.utils.blockingToFlux
-import com.saveourtool.save.utils.blockingToMono
-import com.saveourtool.save.utils.switchIfEmptyToNotFound
+import com.saveourtool.save.utils.*
 import com.saveourtool.save.v1
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -28,6 +25,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
 
 typealias VulnerabilityDtoList = List<VulnerabilityDto>
 
@@ -247,15 +245,38 @@ class VulnerabilityController(
         summary = "Save new date.",
         description = "Save new date.",
     )
+    @PreAuthorize("permitAll()")
     @ApiResponse(responseCode = "200", description = "Successfully saved new date in vulnerability")
+    @ApiResponse(responseCode = "404", description = "Could not either find user or find vulnerability")
+    @ApiResponse(responseCode = "409", description = "Could not save date as it is already present in vulnerability")
     fun saveDate(
         @RequestBody vulnerabilityDateDto: VulnerabilityDateDto,
         authentication: Authentication,
     ): Mono<StringResponse> = blockingToMono {
         vulnerabilityService.saveDate(vulnerabilityDateDto, authentication)
-    }.map {
-        ResponseEntity.ok("Date was successfully saved in vulnerability")
     }
+        .switchIfErrorToConflict {
+            "Date with type ${vulnerabilityDateDto.type} is already present in ${vulnerabilityDateDto.vulnerabilityName} vulnerability"
+        }
+        .map { ResponseEntity.ok("Date was successfully saved in vulnerability") }
+
+    @PostMapping("/delete-date")
+    @Operation(
+        method = "POST",
+        summary = "Delete date.",
+        description = "Delete date.",
+    )
+    @PreAuthorize("permitAll()")
+    @ApiResponse(responseCode = "200", description = "Successfully deleted date in vulnerability")
+    @ApiResponse(responseCode = "404", description = "Requested date is not found")
+    @Suppress("UnusedParameter")
+    fun deleteDate(
+        @RequestBody vulnerabilityDateDto: VulnerabilityDateDto,
+        authentication: Authentication,
+    ): Mono<StringResponse> = vulnerabilityDateDto.toMono()
+        // TODO: add permission check
+        .flatMap { blockingToMono { vulnerabilityService.deleteDate(it) } }
+        .map { ResponseEntity.ok("Date was successfully saved in vulnerability") }
 
     @DeleteMapping("/delete-project")
     @Operation(

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/vulnerability/VulnerabilityDateRepository.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/repository/vulnerability/VulnerabilityDateRepository.kt
@@ -1,11 +1,25 @@
 package com.saveourtool.save.backend.repository.vulnerability
 
 import com.saveourtool.save.entities.vulnerabilities.VulnerabilityDate
+import com.saveourtool.save.entities.vulnerability.VulnerabilityDateType
 import com.saveourtool.save.spring.repository.BaseEntityRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 /**
  * Repository of vulnerabilityDateRepository
  */
 @Repository
-interface VulnerabilityDateRepository : BaseEntityRepository<VulnerabilityDate>
+interface VulnerabilityDateRepository : BaseEntityRepository<VulnerabilityDate> {
+    /**
+     * @param vulnerabilityName name of vulnerability
+     * @param date date that is connected with vulnerability
+     * @param type type of [VulnerabilityDate]
+     * @return [VulnerabilityDate] if found, null otherwise
+     */
+    fun findByVulnerabilityNameAndDateAndType(
+        vulnerabilityName: String,
+        date: LocalDateTime,
+        type: VulnerabilityDateType,
+    ): VulnerabilityDate?
+}

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/vulnerability/VulnerabilityService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/vulnerability/VulnerabilityService.kt
@@ -314,6 +314,19 @@ class VulnerabilityService(
     @Transactional
     fun deleteProject(name: String, vulnerabilityName: String) = vulnerabilityProjectRepository.deleteByNameAndVulnerabilityName(name, vulnerabilityName)
 
+    /**
+     * @param dateDto [VulnerabilityDateDto] that corresponds with [VulnerabilityDate] that should be deleted
+     * @return [Unit]
+     */
+    @Transactional
+    fun deleteDate(dateDto: VulnerabilityDateDto) = vulnerabilityDateRepository.findByVulnerabilityNameAndDateAndType(
+        dateDto.vulnerabilityName,
+        dateDto.date.toJavaLocalDateTime(),
+        dateDto.type
+    )
+        .orNotFound { "Could not find date for ${dateDto.vulnerabilityName} of type ${dateDto.type} (${dateDto.date})." }
+        .let { vulnerabilityDateRepository.delete(it) }
+
     companion object {
         private const val VULNERABILITY_ORGANIZATION_RATING = 10
         private const val VULNERABILITY_OWNER_RATING = 10

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/ReactorUtils.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/utils/ReactorUtils.kt
@@ -260,6 +260,24 @@ fun ByteReadChannel.toByteArrayFlow(partSize: Long = DEFAULT_PART_SIZE): Flow<By
 }
 
 /**
+ * @param status [HttpStatus] that the [ResponseStatusException] should have
+ * @param messageCreator lazy error message
+ * @return [Mono] filled with [ResponseStatusException] with [status] and message created with [messageCreator]
+ */
+fun <T> Mono<T>.switchIfErrorToResponseException(
+    status: HttpStatus,
+    messageCreator: () -> String? = { null },
+) = onErrorMap { _ -> ResponseStatusException(status, messageCreator()) }
+
+/**
+ * @param messageCreator lazy error message
+ * @return [Mono] filled with [ResponseStatusException] with [HttpStatus.CONFLICT] status and message created with [messageCreator]
+ */
+fun <T> Mono<T>.switchIfErrorToConflict(
+    messageCreator: () -> String? = { null },
+) = switchIfErrorToResponseException(HttpStatus.CONFLICT, messageCreator)
+
+/**
  * Taking from https://projectreactor.io/docs/core/release/reference/#faq.wrap-blocking
  *
  * @param supplier blocking operation like JDBC

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityDateModal.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityDateModal.kt
@@ -25,17 +25,20 @@ import kotlinx.serialization.json.Json
  */
 val vulnerabilityDateModal: FC<VulnerabilityDateModalProps> = FC { props ->
     val (vulnerabilityDate, setVulnerabilityDate) = useState(VulnerabilityDateDto.empty)
-
+    val (conflictMessage, setConflictMessage) = useState<String?>(null)
     val addDate = useDeferredRequest {
         post(
             url = "$apiUrl/vulnerabilities/save-date",
             headers = jsonHeaders,
             body = Json.encodeToString(vulnerabilityDate.copy(vulnerabilityName = props.vulnerabilityName)),
             loadingHandler = ::loadingHandler,
+            responseHandler = ::responseHandlerWithValidation,
         ).run {
             if (ok) {
                 props.onSuccess()
                 props.windowOpenness.closeWindow()
+            } else if (isConflict()) {
+                setConflictMessage(unpackMessage())
             }
         }
     }
@@ -75,6 +78,7 @@ val vulnerabilityDateModal: FC<VulnerabilityDateModalProps> = FC { props ->
                     )
                     date.copy(type = type)
                 }
+                setConflictMessage(null)
             }
         }
 
@@ -86,6 +90,13 @@ val vulnerabilityDateModal: FC<VulnerabilityDateModalProps> = FC { props ->
         ) { event ->
             setVulnerabilityDate { date ->
                 date.copy(date = event.target.value.dateStringToLocalDateTime())
+            }
+        }
+
+        conflictMessage?.let {
+            div {
+                className = ClassName("text-center text-danger mt-2")
+                +it
             }
         }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityInfoTab.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityInfoTab.kt
@@ -2,6 +2,7 @@
 
 package com.saveourtool.save.frontend.components.views.fossgraph
 
+import com.saveourtool.save.entities.vulnerability.VulnerabilityDateDto
 import com.saveourtool.save.entities.vulnerability.VulnerabilityDto
 import com.saveourtool.save.entities.vulnerability.VulnerabilityProjectDto
 import com.saveourtool.save.entities.vulnerability.VulnerabilityProjectType
@@ -66,6 +67,21 @@ val vulnerabilityInfoTab: FC<VulnerabilityInfoTabProps> = FC { props ->
             val response = delete(
                 url = "$apiUrl/vulnerabilities/delete-project?projectName=${project.name}&vulnerabilityName=${props.vulnerability.name}",
                 headers = jsonHeaders,
+                loadingHandler = ::loadingHandler,
+            )
+            if (response.ok) {
+                props.fetchVulnerability()
+            }
+        }
+    }
+
+    val (dateToDelete, setDateToDelete) = useState<VulnerabilityDateDto?>(null)
+    useRequest(arrayOf(dateToDelete)) {
+        dateToDelete?.let { dateDto ->
+            val response = post(
+                url = "$apiUrl/vulnerabilities/delete-date",
+                headers = jsonHeaders,
+                body = Json.encodeToString(dateDto),
                 loadingHandler = ::loadingHandler,
             )
             if (response.ok) {
@@ -162,7 +178,12 @@ val vulnerabilityInfoTab: FC<VulnerabilityInfoTabProps> = FC { props ->
             dates = props.vulnerability.getDatesWithLabels()
             onAddClick = { dateWindowOpenness.openWindow() }
                 .takeIf { props.currentUserInfo.isNotNull() }
-            onNodeClick = { _: LocalDateTime, _: String -> Unit }
+            onNodeClick = { date: LocalDateTime, type: String ->
+                props.vulnerability.dates
+                    .find { it.type.value == type && it.date == date }
+                    ?.let { setDateToDelete(it) }
+                    ?: Unit
+            }
                 .takeIf { isAbleToEdit }
         }
     } else {

--- a/save-frontend/src/main/resources/scss/utilities/_timeline.scss
+++ b/save-frontend/src/main/resources/scss/utilities/_timeline.scss
@@ -63,6 +63,7 @@ $color-label-loading: $color-in-progress;
         color: $color-label-default;
         transition: all 200ms ease;
         font-weight: 5;
+        pointer-events: none;
         &.completed {
           color: $color-label-completed;
         }
@@ -80,6 +81,7 @@ $color-label-loading: $color-in-progress;
         font-weight: 700;
         width: 6.5rem;
         text-align: center;
+        pointer-events: none;
         &.completed {
           color: $color-label-completed;
         }


### PR DESCRIPTION
### What's done:
 * Implemented vulnerability date deletion on backend
 * Supported vulnerability date deletion on frontend
 * Fixed an issue when timeline labels acted the same as timeline nodes (now labels are not clickable and `onHover` is not triggered on them)
 * Added unique constraint on dates in order to prevent saving duplicates
 * Added `409 CONFLICT` as possible API response code for `/save-date` in order to handle it on frontend


### How it looks:

https://github.com/saveourtool/save-cloud/assets/35039155/393d64f4-a051-4057-b416-350ec84aa2a6