### PR TITLE
Added status and language columns

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/filters/VulnerabilityFilter.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/filters/VulnerabilityFilter.kt
@@ -15,6 +15,6 @@ data class VulnerabilityFilter(
     val isOwner: Boolean = false,
 ) {
     companion object {
-        val created = VulnerabilityFilter("")
+        val approved = VulnerabilityFilter("")
     }
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/FossGraphCollectionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/FossGraphCollectionView.kt
@@ -40,6 +40,7 @@ val fossGraphCollectionView: FC<FossGraphCollectionViewProps> = FC { props ->
 
     val (vulnerabilityFilters, setVulnerabilityFilters) = useState(VulnerabilityFilter.created)
     val (selectedMenu, setSelectedMenu) = useState(VulnerabilityListTab.PUBLIC)
+    val (publicTable, setPublicTable) = useState(true)
 
     @Suppress(
         "TYPE_ALIAS",
@@ -69,6 +70,22 @@ val fossGraphCollectionView: FC<FossGraphCollectionViewProps> = FC { props ->
                     Fragment.create {
                         td {
                             +"${ cellContext.row.original.progress }"
+                        }
+                    }
+                }
+                column(id = "language", header = "Language", { language }) { cellContext ->
+                    Fragment.create {
+                        td {
+                            +"${ cellContext.row.original.language }"
+                        }
+                    }
+                }
+                if (!publicTable) {
+                    column(id = "status", header = "Status", { status }) { cellContext ->
+                        Fragment.create {
+                            td {
+                                +"${cellContext.row.original.status}"
+                            }
                         }
                     }
                 }
@@ -140,23 +157,36 @@ val fossGraphCollectionView: FC<FossGraphCollectionViewProps> = FC { props ->
                                 }
                                 tab(selectedMenu.name, tabList, "nav nav-tabs mt-3") { value ->
                                     setSelectedMenu { VulnerabilityListTab.valueOf(value) }
-                                    setVulnerabilityFilters {
-                                        when (VulnerabilityListTab.valueOf(value)) {
-                                            VulnerabilityListTab.PUBLIC -> VulnerabilityFilter(
-                                                prefixName = "",
-                                                status = VulnerabilityStatus.APPROVED,
-                                            )
+                                    when (VulnerabilityListTab.valueOf(value)) {
+                                        VulnerabilityListTab.PUBLIC -> {
+                                            setVulnerabilityFilters {
+                                                VulnerabilityFilter(
+                                                    prefixName = "",
+                                                    status = VulnerabilityStatus.APPROVED,
+                                                )
+                                            }
+                                            setPublicTable(true)
+                                        }
 
-                                            VulnerabilityListTab.ADMIN -> VulnerabilityFilter(
-                                                prefixName = "",
-                                                status = VulnerabilityStatus.CREATED,
-                                            )
+                                        VulnerabilityListTab.ADMIN -> {
+                                            setVulnerabilityFilters {
+                                                VulnerabilityFilter(
+                                                    prefixName = "",
+                                                    status = VulnerabilityStatus.CREATED,
+                                                )
+                                            }
+                                            setPublicTable(false)
+                                        }
 
-                                            VulnerabilityListTab.OWNER -> VulnerabilityFilter(
-                                                prefixName = "",
-                                                status = VulnerabilityStatus.CREATED,
-                                                isOwner = true,
-                                            )
+                                        VulnerabilityListTab.OWNER -> {
+                                            setVulnerabilityFilters {
+                                                VulnerabilityFilter(
+                                                    prefixName = "",
+                                                    status = VulnerabilityStatus.CREATED,
+                                                    isOwner = true,
+                                                )
+                                            }
+                                            setPublicTable(false)
                                         }
                                     }
                                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/FossGraphCollectionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/FossGraphCollectionView.kt
@@ -38,7 +38,7 @@ val fossGraphCollectionView: FC<FossGraphCollectionViewProps> = FC { props ->
     useBackground(Style.BLUE)
     val navigate = useNavigate()
 
-    val (vulnerabilityFilters, setVulnerabilityFilters) = useState(VulnerabilityFilter.created)
+    val (vulnerabilityFilters, setVulnerabilityFilters) = useState(VulnerabilityFilter.approved)
     val (selectedMenu, setSelectedMenu) = useState(VulnerabilityListTab.PUBLIC)
     val (publicTable, setPublicTable) = useState(true)
 
@@ -160,10 +160,7 @@ val fossGraphCollectionView: FC<FossGraphCollectionViewProps> = FC { props ->
                                     when (VulnerabilityListTab.valueOf(value)) {
                                         VulnerabilityListTab.PUBLIC -> {
                                             setVulnerabilityFilters {
-                                                VulnerabilityFilter(
-                                                    prefixName = "",
-                                                    status = VulnerabilityStatus.APPROVED,
-                                                )
+                                                VulnerabilityFilter.approved
                                             }
                                             setPublicTable(true)
                                         }


### PR DESCRIPTION
Added status and language columns

<img width="567" alt="Снимок" src="https://github.com/saveourtool/save-cloud/assets/50615459/1b9cb51e-0a1a-4ae7-9a82-73e1871609be">
