### PR TITLE
Correct the dependencies between `publish*` and `sign*` tasks in Kotlin/MPP

### DIFF
--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
@@ -14,6 +14,7 @@ import org.gradle.api.Named
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutput.Style.Failure
@@ -24,6 +25,7 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 /**
@@ -149,6 +151,16 @@ private fun Project.configureSigningCommon(useKeys: SigningExtension.() -> Unit 
         }
         styledOut(logCategory = "signing").style(style).println(message)
         sign(*publications.toTypedArray())
+    }
+
+    /*-
+     * A Kotlin/MPP work-around for https://youtrack.jetbrains.com/issue/KT-46466.
+     *
+     * See also https://github.com/gradle/gradle/issues/17043.
+     */
+    val signingTasks = tasks.withType<Sign>()
+    tasks.withType<AbstractPublishToMaven>().configureEach {
+        dependsOn(signingTasks)
     }
 }
 

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/save/buildutils/PublishingConfiguration.kt
@@ -15,6 +15,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutput.Style.Failure
@@ -158,7 +159,7 @@ private fun Project.configureSigningCommon(useKeys: SigningExtension.() -> Unit 
      *
      * See also https://github.com/gradle/gradle/issues/17043.
      */
-    val signingTasks = tasks.withType<Sign>()
+    val signingTasks: TaskCollection<Sign> = tasks.withType()
     tasks.withType<AbstractPublishToMaven>().configureEach {
         dependsOn(signingTasks)
     }

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -67,6 +67,7 @@ kotlin {
             }
         }
 
+        @Suppress("UNUSED_VARIABLE")
         val jvmMain by getting {
             dependencies {
                 implementation(libs.ktor.client.apache)
@@ -74,6 +75,7 @@ kotlin {
             }
         }
 
+        @Suppress("UNUSED_VARIABLE")
         val jvmTest by getting {
             tasks.withType<Test> {
                 useJUnitPlatform()
@@ -84,12 +86,14 @@ kotlin {
             }
         }
 
+        @Suppress("UNUSED_VARIABLE")
         val linuxX64Main by getting {
             dependencies {
                 implementation(libs.ktor.client.curl)
                 implementation(libs.kotlinx.coroutines.core.linuxx64)
             }
         }
+        @Suppress("UNUSED_VARIABLE")
         val linuxX64Test by getting
     }
 

--- a/save-cloud-common/build.gradle.kts
+++ b/save-cloud-common/build.gradle.kts
@@ -64,6 +64,7 @@ kotlin {
                 }
             }
         }
+        @Suppress("UNUSED_VARIABLE")
         val jvmMain by getting {
             dependencies {
                 implementation(project.dependencies.platform(libs.spring.boot.dependencies))
@@ -89,6 +90,7 @@ kotlin {
                 api(libs.kotlinx.coroutines.reactor)
             }
         }
+        @Suppress("UNUSED_VARIABLE")
         val jvmTest by getting {
             tasks.withType<Test> {
                 useJUnitPlatform()
@@ -104,6 +106,7 @@ kotlin {
         val linuxX64Main by getting
         val macosX64Main by getting
 
+        @Suppress("UNUSED_VARIABLE")
         val nativeMain by creating {
             dependsOn(commonMain)
             linuxX64Main.dependsOn(this)

--- a/save-demo-agent/build.gradle.kts
+++ b/save-demo-agent/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
         val macosX64Main by getting
         val linuxX64Main by getting
 
+        @Suppress("UNUSED_VARIABLE")
         val nativeMain by creating {
             macosX64Main.dependsOn(this)
             linuxX64Main.dependsOn(this)
@@ -53,6 +54,7 @@ kotlin {
         val macosX64Test by getting
         val linuxX64Test by getting
 
+        @Suppress("UNUSED_VARIABLE")
         val nativeTest by creating {
             macosX64Test.dependsOn(this)
             linuxX64Test.dependsOn(this)


### PR DESCRIPTION
### What's done:

 - Now, `gradle publish` or `gradle publishToMavenLocal` no longer fail when the project is built with Gradle 8.
 - See https://github.com/gradle/gradle/issues/17043 for more details.
 - This is a Kotlin issue, targeted at Kotlin 1.9 (see https://youtrack.jetbrains.com/issue/KT-46466).
 - Fixes #2286.