### PR TITLE
Minor vulnerability style fixes

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/Carousel.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/Carousel.kt
@@ -36,7 +36,7 @@ fun <T : Any> ChildrenBuilder.carousel(
     displayItem: ChildrenBuilder.(T) -> Unit,
 ) {
     div {
-        className = ClassName("carousel slide card flex-md-row box-shadow $outerClasses")
+        className = ClassName("carousel slide flex-md-row box-shadow $outerClasses")
         if (isIndicated && items.size > 1) {
             ol {
                 className = ClassName("carousel-indicators mt-2 mb-2")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TimelineComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TimelineComponent.kt
@@ -25,20 +25,20 @@ val timelineComponent: FC<TimelineComponentProps> = FC { props ->
         div {
             className = ClassName("p-0 timeline-container")
             div {
-                style = jso {
-                    position = "absolute".unsafeCast<Position>()
-                    right = "1%".unsafeCast<Right>()
-                    top = "14%".unsafeCast<Top>()
-                    zIndex = "4".unsafeCast<ZIndex>()
-                }
-                props.onAddClick?.let { onClickCallback ->
-                    buttonBuilder(faPlus, style = "secondary", isOutline = true, classes = "rounded-circle btn-sm mt-1 mr-1") {
-                        onClickCallback()
+                className = ClassName("steps-container")
+                div {
+                    style = jso {
+                        position = "absolute".unsafeCast<Position>()
+                        right = "1%".unsafeCast<Right>()
+                        top = "0%".unsafeCast<Top>()
+                        zIndex = "4".unsafeCast<ZIndex>()
+                    }
+                    props.onAddClick?.let { onClickCallback ->
+                        buttonBuilder(faPlus, style = "secondary", isOutline = true, classes = "rounded-circle btn-sm mt-1 mr-1") {
+                            onClickCallback()
+                        }
                     }
                 }
-            }
-            div {
-                className = ClassName("steps-container")
                 div {
                     className = ClassName("line completed")
                 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/welcome/FeaturedDemos.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/welcome/FeaturedDemos.kt
@@ -50,7 +50,7 @@ internal val featuredDemos = VFC {
         }
     }
 
-    carousel(featuredDemos, "demoCarousel", outerClasses = "p-2") { demoDto ->
+    carousel(featuredDemos, "demoCarousel", outerClasses = "p-2 card") { demoDto ->
         div {
             className = ClassName("col-3 ml-auto justify-content-center")
             img {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/tables/TableComponent.kt
@@ -222,7 +222,7 @@ fun <D : RowData, P : TableProps<D>> tableComponent(
             }
         }
         div {
-            className = ClassName("card-body ${props.cardBodyClassName}")
+            className = ClassName("${props.cardBodyClassName} card-body")
             div {
                 className = ClassName("table-responsive")
                 table {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/FeaturedContests.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/contests/FeaturedContests.kt
@@ -15,9 +15,7 @@ import com.saveourtool.save.frontend.externals.fontawesome.fontAwesomeIcon
 import com.saveourtool.save.frontend.utils.*
 
 import js.core.jso
-import react.ChildrenBuilder
-import react.StateSetter
-import react.VFC
+import react.*
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
@@ -25,7 +23,6 @@ import react.dom.html.ReactHTML.h3
 import react.dom.html.ReactHTML.img
 import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.strong
-import react.useState
 import web.cssom.*
 import web.html.ButtonType
 
@@ -79,7 +76,7 @@ internal val featuredContests = VFC {
                 stayTuned()
             }
         } else {
-            carousel(featuredContests, "contestCarousel", jso { height = 15.rem }) { contestToShow ->
+            carousel(featuredContests, "contestCarousel", jso { height = 15.rem }, "card") { contestToShow ->
                 div {
                     className = ClassName("col-3 ml-auto")
                     img {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/CreateVulnerabilityView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/CreateVulnerabilityView.kt
@@ -3,10 +3,7 @@
 package com.saveourtool.save.frontend.components.views.fossgraph
 
 import com.saveourtool.save.entities.OrganizationDto
-import com.saveourtool.save.entities.vulnerability.VulnerabilityDto
-import com.saveourtool.save.entities.vulnerability.VulnerabilityLanguage
-import com.saveourtool.save.entities.vulnerability.VulnerabilityProjectDto
-import com.saveourtool.save.entities.vulnerability.VulnerabilityStatus
+import com.saveourtool.save.entities.vulnerability.*
 import com.saveourtool.save.frontend.components.basic.markdown
 import com.saveourtool.save.frontend.components.inputform.InputTypes
 import com.saveourtool.save.frontend.components.inputform.inputTextFormOptional
@@ -160,7 +157,7 @@ val createVulnerabilityView: VFC = VFC {
                         form {
                             className = ClassName("needs-validation")
                             div {
-                                className = ClassName("row-3")
+                                className = ClassName("row")
 
                                 div {
                                     className = ClassName("col-12 mt-3 mb-3 pl-2 pr-2 text-left")
@@ -298,7 +295,7 @@ val createVulnerabilityView: VFC = VFC {
                                     +"Organization"
 
                                     select {
-                                        className = ClassName("form-control input-group input-group")
+                                        className = ClassName("form-control input-group input-group custom-select")
                                         val elements = userOrganizations.map { it.name }.toMutableList()
                                         elements.add(0, "")
                                         elements.map {
@@ -317,50 +314,42 @@ val createVulnerabilityView: VFC = VFC {
                                 }
 
                                 div {
-                                    className = ClassName("col-12 pl-2 pr-2 mt-3 text-left")
+                                    className = ClassName("col-12 px-2 mt-3 d-flex align-items-center justify-content-between")
 
-                                    label {
-                                        className = ClassName("form-label")
+                                    div {
+                                        className = ClassName("form-label mb-0 text-left")
                                         +"Affected projects:"
+                                    }
+                                    div {
+                                        className = ClassName("")
+                                        buttonBuilder(faPlus, isOutline = true, classes = "btn-sm rounded-circle") {
+                                            projectWindowOpenness.openWindow()
+                                        }
                                     }
                                 }
 
                                 vulnerability.projects.forEach { project ->
                                     val url = project.url
                                     div {
-                                        className = ClassName("row mt-2 mr-0 justify-content-between align-items-center")
+                                        className = ClassName("col-12 mt-2 px-2 d-flex align-items-center")
                                         div {
-                                            className = ClassName("col-11 d-flex justify-content-start align-items-center")
-                                            div {
-                                                className = ClassName("col-2 align-items-center")
-                                                fontAwesomeIcon(
-                                                    when {
-                                                        url.contains("github") -> faGithub
-                                                        url.contains("codehub") -> faCopyright
-                                                        else -> faHome
-                                                    },
-                                                )
-                                            }
-                                            div {
-                                                className = ClassName("col-10 text-left align-self-center pl-0")
-                                                +url
-                                            }
+                                            className = ClassName("col-2 d-flex justify-content-center align-items-center")
+                                            fontAwesomeIcon(
+                                                when {
+                                                    url.contains("github") -> faGithub
+                                                    url.contains("codehub") -> faCopyright
+                                                    else -> faHome
+                                                },
+                                            )
                                         }
                                         div {
-                                            className = ClassName("col-1 align-self-right d-flex align-items-center justify-content-end")
-                                            buttonBuilder(style = "", classes = "col-2 align-items-center mr-2", icon = faTimesCircle) {
-                                                setDeleteProject(project)
-                                                deleteProjectWindowOpenness.openWindow()
-                                            }
+                                            className = ClassName("col-8 text-left pl-0")
+                                            +url
                                         }
-                                    }
-                                }
-
-                                div {
-                                    className = ClassName("col-12 pl-2 pr-2 mt-3 text-left")
-
-                                    buttonBuilder("+") {
-                                        projectWindowOpenness.openWindow()
+                                        buttonBuilder(style = "", classes = "col-2", icon = faTimesCircle) {
+                                            setDeleteProject(project)
+                                            deleteProjectWindowOpenness.openWindow()
+                                        }
                                     }
                                 }
                             }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityBadge.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityBadge.kt
@@ -19,9 +19,9 @@ val vulnerabilityBadge: FC<VulnerabilityBadgeProps> = FC { props ->
     div {
         className = ClassName("col")
         val (color, criticalityLabel) = when (props.vulnerability.progress) {
-            in 0..FOR_GREEN -> Color.GREEN.hexColor to "Low"
-            in FOR_GREEN..FOR_YELLOW -> Color.YELLOW.hexColor to "Moderate"
-            in FOR_YELLOW..MAX_VALUE -> Color.RED.hexColor to "Critical"
+            in 0..FOR_GREEN -> Color.SUCCESS.hexColor to "Low"
+            in FOR_GREEN..FOR_YELLOW -> Color.WARNING.hexColor to "Moderate"
+            in FOR_YELLOW..MAX_VALUE -> Color.DANGER.hexColor to "Critical"
             else -> throw IllegalStateException("Progress should be in [0; 100], got ${props.vulnerability.progress}")
         }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityBadge.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityBadge.kt
@@ -3,8 +3,8 @@
 package com.saveourtool.save.frontend.components.views.fossgraph
 
 import com.saveourtool.save.entities.vulnerability.VulnerabilityDto
-import com.saveourtool.save.frontend.externals.progressbar.Color
 import com.saveourtool.save.frontend.externals.progressbar.progressBar
+import com.saveourtool.save.frontend.themes.Colors
 import js.core.jso
 import react.FC
 import react.Props
@@ -19,9 +19,9 @@ val vulnerabilityBadge: FC<VulnerabilityBadgeProps> = FC { props ->
     div {
         className = ClassName("col")
         val (color, criticalityLabel) = when (props.vulnerability.progress) {
-            in 0..FOR_GREEN -> Color.SUCCESS.hexColor to "Low"
-            in FOR_GREEN..FOR_YELLOW -> Color.WARNING.hexColor to "Moderate"
-            in FOR_YELLOW..MAX_VALUE -> Color.DANGER.hexColor to "Critical"
+            in 0..FOR_GREEN -> Colors.SUCCESS.value to "Low"
+            in FOR_GREEN..FOR_YELLOW -> Colors.WARNING.value to "Moderate"
+            in FOR_YELLOW..MAX_VALUE -> Colors.DANGER.value to "Critical"
             else -> throw IllegalStateException("Progress should be in [0; 100], got ${props.vulnerability.progress}")
         }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityInfoTab.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/VulnerabilityInfoTab.kt
@@ -280,10 +280,10 @@ private fun ChildrenBuilder.renderProjects(
         if (data.isNotEmpty()) {
             if (isTableView) {
                 div {
-                    className = ClassName("card card-body mt-0 p-0")
+                    className = ClassName("mt-0 p-0")
                     table {
                         getData = { _, _ -> data.toTypedArray() }
-                        cardBodyClassName = "p-0"
+                        cardBodyClassName = "p-0 card"
                     }
                 }
             } else {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/progressbar/ReactCircleBuilder.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/progressbar/ReactCircleBuilder.kt
@@ -2,21 +2,9 @@
 
 package com.saveourtool.save.frontend.externals.progressbar
 
+import com.saveourtool.save.frontend.themes.Colors
 import react.ChildrenBuilder
 import react.react
-
-/**
- * @property hexColor color in hex format with leading `#` (example: #aabbcc)
- */
-enum class Color(val hexColor: String) {
-    DANGER("#dc3545"),
-    GREEN("#00d500"),
-    RED("#ac0000"),
-    SUCCESS("#28a745"),
-    WARNING("#ffc107"),
-    YELLOW("#f0dd0e"),
-    ;
-}
 
 /**
  * @param progress progress and percentage
@@ -30,7 +18,7 @@ fun ChildrenBuilder.progressBar(
     progress: Int,
     size: Int = 100,
     lineWidth: Int = 50,
-    color: String = Color.SUCCESS.hexColor,
+    color: String = Colors.SUCCESS.value,
     handler: ChildrenBuilder.(ReactCircleProps) -> Unit = {},
 ) {
     ReactCircle::class.react {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/progressbar/ReactCircleBuilder.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/progressbar/ReactCircleBuilder.kt
@@ -9,8 +9,11 @@ import react.react
  * @property hexColor color in hex format with leading `#` (example: #aabbcc)
  */
 enum class Color(val hexColor: String) {
+    DANGER("#dc3545"),
     GREEN("#00d500"),
     RED("#ac0000"),
+    SUCCESS("#28a745"),
+    WARNING("#ffc107"),
     YELLOW("#f0dd0e"),
     ;
 }
@@ -27,7 +30,7 @@ fun ChildrenBuilder.progressBar(
     progress: Int,
     size: Int = 100,
     lineWidth: Int = 50,
-    color: String = Color.GREEN.hexColor,
+    color: String = Color.SUCCESS.hexColor,
     handler: ChildrenBuilder.(ReactCircleProps) -> Unit = {},
 ) {
     ReactCircle::class.react {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/themes/Colors.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/themes/Colors.kt
@@ -4,10 +4,13 @@ package com.saveourtool.save.frontend.themes
  * @property value - string with the color in rgb
  */
 enum class Colors(val value: String) {
+    DANGER("#dc3545"),
     DARK_RED("rgba(130, 50, 58, 0.1)"),
     GOLD("rgba(188,187,47, 0.1)"),
     GREEN("rgba(139, 237, 78, 0.1)"),
     GREY("rgba(188,186,179, 0.1)"),
     RED("rgba(245, 50, 50, 0.1)"),
+    SUCCESS("#28a745"),
+    WARNING("#ffc107"),
     ;
 }


### PR DESCRIPTION
### What's done:
 * Changed `green`, `yellow` and `red` colors to bootstrap's `success`, `warning` and `danger`
 * Fixed style of organization selector on createVulnerabilityView
 * Fixed `Affected projects` section
 * Fixed `Add date` button positioning on timelineComponent
 * Fixed project card corners

### How it looks:
<img width="544" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/8c7c61f3-e1aa-453a-8d26-6013d78efeba">
<img width="307" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/afd0792a-e283-4305-9814-5e705c8bc669">
<img width="307" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/d54b70eb-7520-4027-bb6a-edb115a4395d">
<img width="307" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/e9066448-51d3-48b8-82da-64cba66d1bdd">
<img width="1411" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/b0a96f0f-e43c-413c-a260-fe4f9c2ca89a">


