### PR TITLE
Participants on fossGraph view

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/AvatarRenderers.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/AvatarRenderers.kt
@@ -1,0 +1,75 @@
+/**
+ * File containing functions to render avatars
+ */
+
+package com.saveourtool.save.frontend.components.basic
+
+import com.saveourtool.save.entities.OrganizationDto
+import com.saveourtool.save.info.UserInfo
+import js.core.jso
+import react.CSSProperties
+import react.ChildrenBuilder
+import react.dom.html.ReactHTML.img
+import react.router.dom.Link
+import web.cssom.ClassName
+
+/**
+ * Placeholder for organization avatar
+ */
+const val ORGANIZATION_AVATAR_PLACEHOLDER = "img/company.svg"
+
+/**
+ * Placeholder for user avatar
+ */
+const val USER_AVATAR_PLACEHOLDER = "img/undraw_profile.svg"
+
+/**
+ * Render organization avatar or placeholder
+ *
+ * @param organizationDto organization to render avatar
+ * @param classes classes applied to [img] html tag
+ * @param link link to redirect to if clicked
+ * @param styleBuilder [CSSProperties] builder
+ */
+fun ChildrenBuilder.renderAvatar(
+    organizationDto: OrganizationDto,
+    classes: String = "",
+    link: String? = null,
+    styleBuilder: CSSProperties.() -> Unit = {},
+) = renderAvatar(organizationDto.avatar ?: ORGANIZATION_AVATAR_PLACEHOLDER, classes, link, styleBuilder)
+
+/**
+ * Render user avatar or placeholder
+ *
+ * @param userInfo user to render avatar
+ * @param classes classes applied to [img] html tag
+ * @param link link to redirect to if clicked
+ * @param styleBuilder [CSSProperties] builder
+ */
+fun ChildrenBuilder.renderAvatar(
+    userInfo: UserInfo,
+    classes: String = "",
+    link: String? = null,
+    styleBuilder: CSSProperties.() -> Unit = {},
+) = renderAvatar(userInfo.avatar ?: USER_AVATAR_PLACEHOLDER, classes, link, styleBuilder)
+
+private fun ChildrenBuilder.renderAvatar(
+    avatarLink: String,
+    classes: String,
+    link: String?,
+    styleBuilder: CSSProperties.() -> Unit,
+) {
+    val renderImg: ChildrenBuilder.() -> Unit = {
+        img {
+            className = ClassName("avatar avatar-user border color-bg-default rounded-circle $classes")
+            src = avatarLink
+            style = jso { styleBuilder() }
+        }
+    }
+    link?.let {
+        Link {
+            to = it
+            renderImg()
+        }
+    } ?: renderImg()
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/UserBoard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/UserBoard.kt
@@ -7,68 +7,50 @@
 package com.saveourtool.save.frontend.components.basic
 
 import com.saveourtool.save.info.UserInfo
-import com.saveourtool.save.v1
 import com.saveourtool.save.validation.FrontendRoutes
 
-import js.core.jso
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.figure
-import react.dom.html.ReactHTML.img
-import react.router.dom.Link
-import web.cssom.BorderRadius
 import web.cssom.ClassName
 
 /**
- * React element type that represents user board and can be rendered
- */
-val userBoard = userBoard()
-
-/**
- * [Props] for user board component
- */
-external interface UserBoardProps : Props {
-    /**
-     * list of users that should be displayed
-     */
-    var users: List<UserInfo>
-}
-
-/**
  * A functional component to display users' avatars.
- *
- * @return a functional component representing a board of users
  */
-@Suppress("EMPTY_BLOCK_STRUCTURE_ERROR")
-private fun userBoard() = FC<UserBoardProps> { props ->
+val userBoard: FC<UserBoardProps> = FC { props ->
     div {
         className = ClassName("latest-photos")
         div {
             className = ClassName("row")
             props.users.forEach { user ->
                 div {
-                    className = ClassName("col-4 px-0")
+                    className = ClassName(props.avatarOuterClasses.orEmpty())
                     figure {
-                        Link {
-                            img {
-                                className = ClassName("img-fluid px-sm-3")
-                                style = jso {
-                                    borderRadius = "50%".unsafeCast<BorderRadius>()
-                                }
-                                src = user.avatar?.let { path ->
-                                    "/api/$v1/avatar$path"
-                                }
-                                    ?: run {
-                                        "img/undraw_profile.svg"
-                                    }
-                                alt = ""
-                            }
-                            to = "/${FrontendRoutes.PROFILE.path}/${user.name}"
-                        }
+                        renderAvatar(user, props.avatarInnerClasses.orEmpty(), "/${FrontendRoutes.PROFILE.path}/${user.name}")
                     }
                 }
             }
         }
     }
+}
+
+/**
+ * [Props] for [userBoard] component
+ */
+external interface UserBoardProps : Props {
+    /**
+     * list of users that should be displayed
+     */
+    var users: List<UserInfo>
+
+    /**
+     * Classes that are applied to [div] that contains img tag
+     */
+    var avatarOuterClasses: String?
+
+    /**
+     * Classes that are applied to img tag
+     */
+    var avatarInnerClasses: String?
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectInfoMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectInfoMenu.kt
@@ -131,6 +131,8 @@ private fun projectInfoMenu() = FC<ProjectInfoMenuProps> { props ->
             }
             userBoard {
                 users = usersInProject
+                avatarOuterClasses = "col-4 px-0"
+                avatarInnerClasses = "mx-sm-3"
             }
         }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
@@ -343,6 +343,8 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
                 className = ClassName("col-3")
                 userBoard {
                     users = state.usersInOrganization.orEmpty()
+                    avatarOuterClasses = "col-4 px-0"
+                    avatarInnerClasses = "mx-sm-3"
                 }
             }
         }
@@ -534,7 +536,7 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
                         width = 100.0
                         onError = {
                             setState {
-                                avatar = AVATAR_PLACEHOLDER
+                                avatar = ORGANIZATION_AVATAR_PLACEHOLDER
                             }
                         }
                     }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/FossGraphView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/fossgraph/FossGraphView.kt
@@ -11,13 +11,14 @@ import com.saveourtool.save.entities.vulnerability.VulnerabilityDto
 import com.saveourtool.save.entities.vulnerability.VulnerabilityLanguage
 import com.saveourtool.save.entities.vulnerability.VulnerabilityStatus
 import com.saveourtool.save.frontend.TabMenuBar
+import com.saveourtool.save.frontend.components.basic.renderAvatar
+import com.saveourtool.save.frontend.components.basic.userBoard
 import com.saveourtool.save.frontend.components.modal.displayModal
 import com.saveourtool.save.frontend.components.modal.mediumTransparentModalStyle
 import com.saveourtool.save.frontend.components.views.contests.tab
 import com.saveourtool.save.frontend.externals.fontawesome.faTrash
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
-import com.saveourtool.save.v1
 import com.saveourtool.save.validation.FrontendRoutes
 
 import js.core.jso
@@ -26,7 +27,6 @@ import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h1
 import react.dom.html.ReactHTML.h6
 import react.dom.html.ReactHTML.hr
-import react.dom.html.ReactHTML.img
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.textarea
 import react.router.dom.Link
@@ -200,23 +200,27 @@ val fossGraph: FC<FossGraphViewProps> = FC { props ->
                         vulnerability.organization?.run {
                             hr { }
                             h6 {
-                                className = ClassName("font-weight-bold text-primary mb-4")
+                                className = ClassName("font-weight-bold text-primary mb-3")
                                 +"Organization"
                             }
                             Link {
-                                img {
-                                    className =
-                                            ClassName("avatar avatar-user width-full border color-bg-default rounded-circle")
-                                    src = avatar?.let {
-                                        "/api/$v1/avatar$it"
-                                    } ?: "img/company.svg"
-                                    style = jso {
-                                        height = 2.rem
-                                        width = 2.rem
-                                    }
+                                renderAvatar(this@run) {
+                                    height = 2.rem
+                                    width = 2.rem
                                 }
                                 to = "/${vulnerability.organization?.name}"
                                 +" ${vulnerability.organization?.name}"
+                            }
+                        }
+                        if (vulnerability.participants.isNotEmpty()) {
+                            hr { }
+                            h6 {
+                                className = ClassName("font-weight-bold text-primary mb-4")
+                                +"Users"
+                            }
+                            userBoard {
+                                users = vulnerability.participants
+                                avatarOuterClasses = "col-2"
                             }
                         }
                     }


### PR DESCRIPTION
### What's done:
 * Added avatar renderers
 * Improved existing `userBoard`
 * Reused existing `userBoard` on `fossGraph` view

### How it looks:
<img width="357" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/5cafa109-00ff-4d80-aad5-00793e28e64c">
<img width="357" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/f4a22a8d-dc28-45e3-a2ed-8f84d6a203e9">
<img width="357" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/eb786e53-3027-4204-992b-9015eb1ad35d">

