### PR TITLE
Hotfix for Google authorization

### DIFF
--- a/api-gateway/src/main/resources/application-dev.yml
+++ b/api-gateway/src/main/resources/application-dev.yml
@@ -39,8 +39,6 @@ spring:
             # See https://docs.github.com/en/rest/users/users#get-the-authenticated-user
             # for more details.
             user-name-attribute: login
-          google:
-            user-name-attribute: email
         registration:
           google:
             client-id: 943335421056-7ova0sgv6o4goapkripv8dk3ov4og6kc.apps.googleusercontent.com

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -97,9 +97,9 @@ spring:
     oauth2:
       client:
         provider:
+            # we also have "google" provider, but its default implementation is good enough by for now
+            # until we have fixed https://github.com/saveourtool/save-cloud/issues/2336
           github:
             # value that will work with GitHub API, where GitHub provides username as "login" in the response
             # https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
             user-name-attribute: login
-          google:
-            user-name-attribute: email

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
@@ -222,7 +222,7 @@ class RegistrationView : AbstractView<RegistrationProps, RegistrationViewState>(
     )
     private fun ChildrenBuilder.renderInputForm() {
         // google does not provide us login, only e-mail, so need to trim everything after "@gmail"
-        val rawInput = state.fieldsMap[InputTypes.USER_NAME] ?: ""
+        val rawInput = state.fieldsMap[InputTypes.USER_NAME]?.trim().orEmpty()
         val atIndex = rawInput.indexOf('@')
         val inputUpdated = if (atIndex >= 0) rawInput.substring(0, atIndex) else rawInput
         form {


### PR DESCRIPTION
### What's done:
- SAVE uses '@' as a special mark to separate user and source https://github.com/saveourtool/save-cloud/issues/2336 so we cannot use e-mail as login in SAVE by for now




https://github.com/saveourtool/save-cloud/assets/58667063/a94ca093-1b58-4c99-915e-5edf2ac392cd

