### PR TITLE
Hide `AuthenticationDetails` from BL

### DIFF
--- a/authentication-service/src/main/kotlin/com/saveourtool/save/authservice/utils/SecurityUtils.kt
+++ b/authentication-service/src/main/kotlin/com/saveourtool/save/authservice/utils/SecurityUtils.kt
@@ -41,19 +41,19 @@ fun Authentication.username(): String = when (principal) {
  * @return identitySource
  * @throws BadCredentialsException
  */
-fun Authentication.identitySource(): String {
-    val identitySource = (this.details as AuthenticationDetails).identitySource
-    if (identitySource == null || !this.name.startsWith("$identitySource:")) {
-        throw BadCredentialsException(this.name)
-    }
-    return identitySource
-}
+fun Authentication.identitySource(): String? = (this.details as AuthenticationDetails).identitySource
 
 /**
  * @return pair of username and identitySource from this [Authentication].
  * @throws BadCredentialsException
  */
-fun Authentication.extractUserNameAndIdentitySource(): Pair<String, String> = this.username() to this.identitySource()
+fun Authentication.extractUserNameAndIdentitySource(): Pair<String, String> = this.username() to run {
+    val identitySource = this.identitySource()
+    if (identitySource == null || !this.name.startsWith("$identitySource:")) {
+        throw BadCredentialsException(this.name)
+    }
+    identitySource
+}
 
 /**
  * Convert [Authentication] to [User] based on convention in backend.

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkContestProjectController.kt
@@ -7,7 +7,7 @@
 
 package com.saveourtool.save.backend.controllers
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.service.*
 import com.saveourtool.save.configs.ApiSwaggerSupport
 import com.saveourtool.save.configs.RequiresAuthorizationSourceHeader
@@ -111,7 +111,7 @@ class LnkContestProjectController(
         @PathVariable contestName: String,
         authentication: Authentication,
     ): Mono<List<String>> = Mono.fromCallable {
-        lnkUserProjectService.getProjectsByUserIdAndStatuses((authentication.details as AuthenticationDetails).id).filter { it.public }
+        lnkUserProjectService.getProjectsByUserIdAndStatuses(authentication.userId()).filter { it.public }
     }
         .map { userProjects ->
             userProjects to lnkContestProjectService.getProjectsFromListAndContest(contestName, userProjects).map { it.project }
@@ -295,7 +295,7 @@ class LnkContestProjectController(
             "Contest with name $contestName was not found."
         }
         .map { contest ->
-            contest to lnkUserProjectService.getProjectsByUserIdAndStatuses((authentication.details as AuthenticationDetails).id).map { it.requiredId() }
+            contest to lnkUserProjectService.getProjectsByUserIdAndStatuses(authentication.userId()).map { it.requiredId() }
         }
         .flatMapMany { (contest, projectIds) ->
             blockingToFlux {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkUserOrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkUserOrganizationController.kt
@@ -7,8 +7,8 @@
 
 package com.saveourtool.save.backend.controllers
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
 import com.saveourtool.save.authservice.utils.toUser
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.security.OrganizationPermissionEvaluator
 import com.saveourtool.save.backend.service.LnkUserOrganizationService
 import com.saveourtool.save.backend.service.OrganizationService
@@ -244,7 +244,7 @@ class LnkUserOrganizationController(
     fun getAllUsersOrganizationsThatCanCreateContests(
         authentication: Authentication,
     ): Flux<Organization> = Flux.fromIterable(
-        lnkUserOrganizationService.getSuperOrganizationsWithRole((authentication.details as AuthenticationDetails).id)
+        lnkUserOrganizationService.getSuperOrganizationsWithRole(authentication.userId())
     )
 
     @PostMapping("/by-filters")
@@ -265,7 +265,7 @@ class LnkUserOrganizationController(
         @RequestBody organizationFilter: OrganizationFilter,
         authentication: Authentication,
     ): Flux<OrganizationWithUsers> = Mono.justOrEmpty(
-        lnkUserOrganizationService.getUserById((authentication.details as AuthenticationDetails).id)
+        lnkUserOrganizationService.getUserById(authentication.userId())
     )
         .switchIfEmptyToNotFound()
         .flatMapIterable {

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkUserProjectController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/LnkUserProjectController.kt
@@ -7,7 +7,7 @@
 
 package com.saveourtool.save.backend.controllers
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.security.ProjectPermissionEvaluator
 import com.saveourtool.save.backend.service.LnkUserProjectService
 import com.saveourtool.save.backend.service.ProjectService
@@ -58,16 +58,13 @@ class LnkUserProjectController(
     )
     @PreAuthorize("permitAll()")
     @ApiResponse(responseCode = "200", description = "Successfully fetched users from project.")
-    fun getProjectsOfCurrentUser(authentication: Authentication): Flux<ProjectDto> {
-        val userIdFromAuth = (authentication.details as AuthenticationDetails).id
-        return Flux.fromIterable(
-            lnkUserProjectService.getProjectsByUserIdAndStatuses(userIdFromAuth)
-        )
-            .filter {
-                it.public
-            }
-            .map { it.toDto() }
-    }
+    fun getProjectsOfCurrentUser(authentication: Authentication): Flux<ProjectDto> = Flux.fromIterable(
+        lnkUserProjectService.getProjectsByUserIdAndStatuses(authentication.userId())
+    )
+        .filter {
+            it.public
+        }
+        .map { it.toDto() }
 
     @GetMapping(path = ["/{organizationName}/{projectName}/users"])
     @RequiresAuthorizationSourceHeader

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/OrganizationController.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.controllers
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.configs.ConfigProperties
 import com.saveourtool.save.backend.security.OrganizationPermissionEvaluator
 import com.saveourtool.save.backend.service.*
@@ -136,7 +136,7 @@ internal class OrganizationController(
         authentication: Authentication?,
     ): Flux<OrganizationDto> = authentication.toMono()
         .map { auth ->
-            (auth.details as AuthenticationDetails).id
+            auth.userId()
         }
         .flatMapMany {
             lnkUserOrganizationService.findAllByAuthenticationAndStatuses(it)
@@ -239,7 +239,7 @@ internal class OrganizationController(
         }
         .map { (organizationId, organizationStatus) ->
             lnkUserOrganizationService.setRoleByIds(
-                (authentication.details as AuthenticationDetails).id,
+                authentication.userId(),
                 organizationId,
                 Role.OWNER,
             )

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ProjectController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/ProjectController.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.controllers
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.security.ProjectPermissionEvaluator
 import com.saveourtool.save.backend.service.LnkUserProjectService
 import com.saveourtool.save.backend.service.OrganizationService
@@ -169,7 +169,7 @@ class ProjectController(
             ))
         }
         .map { (projectId, status) ->
-            lnkUserProjectService.setRoleByIds((authentication.details as AuthenticationDetails).id, projectId, Role.OWNER)
+            lnkUserProjectService.setRoleByIds(authentication.userId(), projectId, Role.OWNER)
             ResponseEntity.ok(status.message)
         }
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/UsersDetailsController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/UsersDetailsController.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.controllers
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.OriginalLoginRepository
 import com.saveourtool.save.backend.repository.UserRepository
 import com.saveourtool.save.backend.service.UserDetailsService
@@ -105,8 +105,7 @@ class UsersDetailsController(
     fun saveUser(@RequestBody newUserInfo: UserInfo, authentication: Authentication): Mono<StringResponse> = Mono.just(newUserInfo)
         .map {
             val user: User = userRepository.findByName(newUserInfo.oldName ?: newUserInfo.name).orNotFound()
-            val userId = (authentication.details as AuthenticationDetails).id
-            val response = if (user.id == userId) {
+            val response = if (user.id == authentication.userId()) {
                 userDetailsService.saveUser(user.apply {
                     name = newUserInfo.name
                     email = newUserInfo.email
@@ -142,7 +141,7 @@ class UsersDetailsController(
     @PreAuthorize("isAuthenticated()")
     fun saveUserToken(@PathVariable userName: String, @RequestBody token: String, authentication: Authentication): Mono<StringResponse> {
         val user = userRepository.findByName(userName).orNotFound()
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val response = if (user.id == userId) {
             userRepository.save(user.apply {
                 password = "{bcrypt}${BCryptPasswordEncoder().encode(token)}"

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/OrganizationPermissionEvaluator.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.security
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.service.LnkUserOrganizationService
 import com.saveourtool.save.backend.utils.hasRole
 import com.saveourtool.save.domain.Role
@@ -27,7 +27,7 @@ class OrganizationPermissionEvaluator(
      */
     fun hasOrganizationRole(authentication: Authentication?, organization: Organization, role: Role): Boolean {
         authentication ?: return false
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         if (authentication.hasRole(Role.SUPER_ADMIN)) {
             return true
         }
@@ -59,7 +59,7 @@ class OrganizationPermissionEvaluator(
      */
     fun hasPermission(authentication: Authentication?, organization: Organization, permission: Permission): Boolean {
         authentication ?: return permission == Permission.READ
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         if (authentication.hasRole(Role.SUPER_ADMIN)) {
             return true
         }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/ProjectPermissionEvaluator.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.security
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.LnkUserProjectRepository
 import com.saveourtool.save.backend.service.LnkUserOrganizationService
 import com.saveourtool.save.backend.service.LnkUserProjectService
@@ -59,7 +59,7 @@ class ProjectPermissionEvaluator(
             return true
         }
 
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val organizationRole = lnkUserOrganizationService.findRoleByUserIdAndOrganization(userId, project.organization)
         val projectRole = lnkUserProjectService.findRoleByUserIdAndProject(userId, project)
 

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/VulnerabilityPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/security/VulnerabilityPermissionEvaluator.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.security
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.service.vulnerability.VulnerabilityService
 import com.saveourtool.save.backend.utils.hasRole
 import com.saveourtool.save.domain.Role
@@ -48,6 +48,6 @@ class VulnerabilityPermissionEvaluator(
         val vulnerability = vulnerabilityService.findByName(vulnerabilityName).orNotFound { "Not found vulnerability $vulnerabilityName" }
         val linkUsers = vulnerabilityService.getUsers(vulnerability.requiredId()).map { it.user.name }
 
-        return vulnerability.userId == (authentication.details as AuthenticationDetails).id || authentication.name in linkUsers
+        return vulnerability.userId == authentication.userId() || authentication.name in linkUsers
     }
 }

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/CommentService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/CommentService.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.service
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.CommentRepository
 import com.saveourtool.save.backend.repository.UserRepository
 import com.saveourtool.save.entities.Comment
@@ -28,7 +28,7 @@ class CommentService(
      */
     @Transactional
     fun saveComment(comment: CommentDto, authentication: Authentication) {
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val user = userRepository.getByIdOrNotFound(userId)
 
         val newComment = Comment(

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ContestSampleService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ContestSampleService.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.service
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.UserRepository
 import com.saveourtool.save.backend.repository.contest.ContestSampleFieldRepository
 import com.saveourtool.save.backend.repository.contest.ContestSampleRepository
@@ -34,7 +34,7 @@ class ContestSampleService(
         contestSampleDto: ContestSampleDto,
         authentication: Authentication,
     ) {
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val user = userRepository.getByIdOrNotFound(userId)
         val contestSample = ContestSample(
             name = contestSampleDto.name,

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserOrganizationService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserOrganizationService.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.service
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.LnkUserOrganizationRepository
 import com.saveourtool.save.backend.repository.UserRepository
 import com.saveourtool.save.domain.Role
@@ -171,7 +171,7 @@ class LnkUserOrganizationService(
      * @return the highest of two roles: the one in [organization] and global one.
      */
     fun getGlobalRoleOrOrganizationRole(authentication: Authentication, organization: Organization): Role {
-        val selfId = (authentication.details as AuthenticationDetails).id
+        val selfId = authentication.userId()
         val selfGlobalRole = userDetailsService.getGlobalRole(authentication)
         val selfOrganizationRole = findRoleByUserIdAndOrganization(selfId, organization)
         return getHighestRole(selfOrganizationRole, selfGlobalRole)
@@ -183,7 +183,7 @@ class LnkUserOrganizationService(
      * @return the highest of two roles: the one in organization with name [organizationName] and global one.
      */
     fun getGlobalRoleOrOrganizationRole(authentication: Authentication, organizationName: String): Role {
-        val selfId = (authentication.details as AuthenticationDetails).id
+        val selfId = authentication.userId()
         val selfGlobalRole = userDetailsService.getGlobalRole(authentication)
         val selfOrganizationRole = findRoleByUserIdAndOrganizationName(selfId, organizationName)
         return getHighestRole(selfOrganizationRole, selfGlobalRole)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserProjectService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/LnkUserProjectService.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.service
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.LnkUserProjectRepository
 import com.saveourtool.save.backend.repository.UserRepository
 import com.saveourtool.save.domain.Role
@@ -129,7 +129,7 @@ class LnkUserProjectService(
      * @return the highest of two roles: the one in [project] and global one.
      */
     fun getGlobalRoleOrProjectRole(authentication: Authentication, project: Project): Role {
-        val selfId = (authentication.details as AuthenticationDetails).id
+        val selfId = authentication.userId()
         val selfGlobalRole = userDetailsService.getGlobalRole(authentication)
         val selfOrganizationRole = findRoleByUserIdAndProject(selfId, project)
         return getHighestRole(selfOrganizationRole, selfGlobalRole)

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ProjectProblemService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/ProjectProblemService.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.service
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.ProjectProblemRepository
 import com.saveourtool.save.backend.repository.ProjectRepository
 import com.saveourtool.save.backend.repository.UserRepository
@@ -51,7 +51,7 @@ class ProjectProblemService(
     fun saveProjectProblem(problem: ProjectProblemDto, authentication: Authentication) {
         val vulnerability = problem.vulnerabilityName?.let { vulnerabilityRepository.findByName(it) }
         val project = projectRepository.findByNameAndOrganizationName(problem.projectName, problem.organizationName).orNotFound()
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val user = userRepository.getByIdOrNotFound(userId)
 
         val projectProblem = ProjectProblem(

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/vulnerability/VulnerabilityService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/vulnerability/VulnerabilityService.kt
@@ -1,6 +1,6 @@
 package com.saveourtool.save.backend.service.vulnerability
 
-import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.userId
 import com.saveourtool.save.backend.repository.OrganizationRepository
 import com.saveourtool.save.backend.repository.UserRepository
 import com.saveourtool.save.backend.repository.vulnerability.LnkVulnerabilityUserRepository
@@ -116,7 +116,7 @@ class VulnerabilityService(
                 }
 
                 val ownerPredicate = authentication?.let {
-                    val userId = (authentication.details as AuthenticationDetails).id
+                    val userId = authentication.userId()
                     if (isOwner) {
                         cb.equal(root.get<Vulnerability>("userId"), userId)
                     } else {
@@ -198,7 +198,7 @@ class VulnerabilityService(
         vulnerabilityDto: VulnerabilityDto,
         authentication: Authentication,
     ) {
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val user = userRepository.getByIdOrNotFound(userId)
         val organizationNew = vulnerabilityDto.organization?.name?.let { organizationRepository.findByName(it) }
         val vulnerability = Vulnerability(
@@ -360,7 +360,7 @@ class VulnerabilityService(
         vulnerabilityDateDto: VulnerabilityDateDto,
         authentication: Authentication,
     ) {
-        val userId = (authentication.details as AuthenticationDetails).id
+        val userId = authentication.userId()
         val user = userRepository.getByIdOrNotFound(userId)
 
         vulnerabilityRepository.findByName(vulnerabilityDateDto.vulnerabilityName)?.let { vulnerability ->

--- a/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/ConverterTest.kt
+++ b/save-backend/src/test/kotlin/com/saveourtool/save/backend/security/ConverterTest.kt
@@ -2,6 +2,7 @@ package com.saveourtool.save.backend.security
 
 import com.saveourtool.save.authservice.security.CustomAuthenticationBasicConverter
 import com.saveourtool.save.authservice.utils.AuthenticationDetails
+import com.saveourtool.save.authservice.utils.identitySource
 import com.saveourtool.save.utils.AUTHORIZATION_SOURCE
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -28,7 +29,7 @@ class ConverterTest {
         Assertions.assertInstanceOf(UsernamePasswordAuthenticationToken::class.java, authentication)
         Assertions.assertInstanceOf(AuthenticationDetails::class.java, authentication.details)
         Assertions.assertEquals("basic:user", authentication.principal)
-        Assertions.assertEquals("basic", (authentication.details as AuthenticationDetails).identitySource)
+        Assertions.assertEquals("basic", authentication.identitySource())
     }
 }
 


### PR DESCRIPTION
### What's done:
- small refactoring to hide AuthenticationDetails to get userId and identitySource

It's part of #2336