### PR TITLE
Table placeholders follow-ups

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
@@ -182,7 +182,7 @@ private fun manageUserRoleCardComponent() = FC<ManageUserRoleCardProps> { props 
                         }
                     }
                     div {
-                        className = ClassName("col-5 align-self-right d-flex align-items-center justify-content-end")
+                        className = ClassName("col-5 align-self-right d-flex align-items-center justify-content-end pr-0")
                         select {
                             className = ClassName("custom-select col-9")
                             onChange = { event ->

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestCreationComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/contests/ContestCreationComponent.kt
@@ -87,14 +87,9 @@ fun ChildrenBuilder.showContestCreationModal(
             onSaveError = onFailure
         }
         div {
-            className = ClassName("d-flex justify-content-center")
-            button {
-                type = ButtonType.button
-                className = ClassName("btn btn-secondary mt-4")
-                +"Cancel"
-                onClick = {
-                    onClose()
-                }
+            className = ClassName("d-flex justify-content-center mt-4")
+            buttonBuilder("Cancel", "secondary", isOutline = true) {
+                onClose()
             }
         }
     }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationContestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationContestsMenu.kt
@@ -10,16 +10,17 @@ import com.saveourtool.save.domain.Role
 import com.saveourtool.save.entities.contest.ContestDto
 import com.saveourtool.save.entities.contest.ContestStatus
 import com.saveourtool.save.frontend.components.basic.contests.showContestCreationModal
-import com.saveourtool.save.frontend.components.modal.displayConfirmationModal
-import com.saveourtool.save.frontend.components.modal.displaySimpleModal
 import com.saveourtool.save.frontend.components.tables.TableProps
 import com.saveourtool.save.frontend.components.tables.columns
 import com.saveourtool.save.frontend.components.tables.tableComponent
 import com.saveourtool.save.frontend.components.tables.value
+import com.saveourtool.save.frontend.externals.fontawesome.faPlus
+import com.saveourtool.save.frontend.externals.fontawesome.faTrash
 import com.saveourtool.save.frontend.utils.*
 
 import org.w3c.fetch.Response
 import react.*
+import react.dom.html.ReactHTML.br
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.input
 import react.dom.html.ReactHTML.td
@@ -28,13 +29,9 @@ import react.router.useNavigate
 import web.cssom.ClassName
 import web.html.InputType
 
+import kotlinx.browser.window
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-
-/**
- * CONTESTS tab in OrganizationView
- */
-val organizationContestsMenu = organizationContestsMenu()
 
 @Suppress("MAGIC_NUMBER", "TYPE_ALIAS")
 private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tableComponent(
@@ -98,6 +95,129 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
     arrayOf(it.isContestCreated)
 }
 
+@Suppress(
+    "EMPTY_BLOCK_STRUCTURE_ERROR",
+)
+/**
+ * CONTESTS tab in OrganizationView
+ */
+val organizationContestsMenu: FC<OrganizationContestsMenuProps> = FC { props ->
+    useTooltip()
+    val (isToUpdateTable, setIsToUpdateTable) = useState(false)
+    val contestCreationWindowOpenness = useWindowOpenness()
+    val (selectedContests, setSelectedContests) = useState<Set<ContestDto>>(setOf())
+    val (contests, setContests) = useState<Set<ContestDto>>(setOf())
+    val refreshTable = { setIsToUpdateTable { !it } }
+    val addSelectedContestsFun: (ContestDto) -> Unit = { contest ->
+        setSelectedContests { it.plus(contest) }
+    }
+    val removeSelectedContestsFun: (ContestDto) -> Unit = { contest ->
+        setSelectedContests { it.minus(contest) }
+    }
+    val deleteContestsFun = useDeferredRequest {
+        val deleteContests = selectedContests.map { it.copy(status = ContestStatus.DELETED) }
+        val response = post(
+            "$apiUrl/contests/update-all",
+            jsonHeaders,
+            Json.encodeToString(deleteContests),
+            loadingHandler = ::noopLoadingHandler,
+        )
+        if (response.ok) {
+            setContests(contests.minus(selectedContests))
+            setSelectedContests(setOf())
+            refreshTable()
+        }
+    }
+    val navigate = useNavigate()
+
+    useRequest {
+        val response = get(
+            url = "$apiUrl/contests/by-organization?organizationName=${props.organizationName}",
+            headers = jsonHeaders,
+            loadingHandler = ::loadingHandler,
+        )
+        val newContests = if (response.ok) {
+            response.unsafeMap { it.decodeFromJsonString<List<ContestDto>>() }.toSet()
+        } else {
+            emptySet()
+        }
+        setContests(newContests)
+        refreshTable()
+    }
+
+    showContestCreationModal(
+        props.organizationName,
+        contestCreationWindowOpenness.isOpen(),
+        {
+            contestCreationWindowOpenness.closeWindow()
+            navigate(
+                to = it,
+            )
+        },
+        {
+            contestCreationWindowOpenness.closeWindow()
+            props.updateErrorMessage(it)
+        }
+    ) {
+        contestCreationWindowOpenness.closeWindow()
+    }
+
+    div {
+        className = ClassName("col-8 mx-auto")
+        div {
+            className = ClassName("d-flex justify-content-end mb-1")
+            if (selectedContests.isNotEmpty()) {
+                buttonBuilder(
+                    faTrash,
+                    classes = "mr-2 text-sm btn-sm",
+                    title = "Delete selected contests",
+                    style = "danger",
+                ) {
+                    if (window.confirm("Are you sure you want to delete selected contests?")) {
+                        deleteContestsFun()
+                    }
+                }
+            }
+            if (props.selfRole.hasDeletePermission()) {
+                buttonBuilder(
+                    faPlus,
+                    title = "Create contest",
+                    isOutline = true,
+                    classes = "text-sm btn-sm",
+                ) {
+                    contestCreationWindowOpenness.openWindow()
+                }
+            }
+        }
+        div {
+            className = ClassName("my-3")
+            if (contests.isNotEmpty()) {
+                contestsTable {
+                    getData = { _, _ -> contests.toTypedArray() }
+                    isContestCreated = isToUpdateTable
+                    addSelectedContests = addSelectedContestsFun
+                    removeSelectedContests = removeSelectedContestsFun
+                    selectedContestDtos = selectedContests
+                }
+            } else {
+                renderTablePlaceholder("text-center p-4 bg-white text-sm", "dashed") {
+                    +"This organization has not created any contest yet."
+                    if (props.selfRole.hasDeletePermission()) {
+                        br { }
+                        buttonBuilder(
+                            "You can be the first contest creator in ${props.organizationName}.",
+                            style = "",
+                            classes = "text-sm text-primary"
+                        ) {
+                            contestCreationWindowOpenness.openWindow()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /**
  * OrganizationContestsMenu component props
  */
@@ -141,140 +261,4 @@ external interface OrganizationContestsTableProps<D : Any> : TableProps<D> {
      * Selected contests
      */
     var selectedContestDtos: Set<ContestDto>
-}
-
-@Suppress(
-    "TOO_LONG_FUNCTION",
-    "LongMethod",
-    "MAGIC_NUMBER",
-    "ComplexMethod",
-    "GENERIC_VARIABLE_WRONG_DECLARATION",
-)
-private fun organizationContestsMenu() = FC<OrganizationContestsMenuProps> { props ->
-    val (isToUpdateTable, setIsToUpdateTable) = useState(false)
-    val (isContestCreationModalOpen, setIsContestCreationModalOpen) = useState(false)
-    val (selectedContests, setSelectedContests) = useState<Set<ContestDto>>(setOf())
-    val (contests, setContests) = useState<Set<ContestDto>>(setOf())
-    val refreshTable = { setIsToUpdateTable { !it } }
-    val addSelectedContestsFun: (ContestDto) -> Unit = { contest ->
-        setSelectedContests {
-            it.plus(contest)
-        }
-    }
-    val removeSelectedContestsFun: (ContestDto) -> Unit = { contest ->
-        setSelectedContests {
-            it.minus(contest)
-        }
-    }
-    val deleteContestsFun = useDeferredRequest {
-        val deleteContests = mutableListOf<ContestDto>()
-        selectedContests.map {
-            deleteContests.add(it.copy(status = ContestStatus.DELETED))
-        }
-        val response = post(
-            "$apiUrl/contests/update-all",
-            jsonHeaders,
-            Json.encodeToString(deleteContests),
-            loadingHandler = ::noopLoadingHandler,
-        )
-        if (response.ok) {
-            setContests(contests.minus(selectedContests))
-            setSelectedContests(setOf())
-            refreshTable()
-        }
-    }
-    val windowOpenness = useWindowOpenness()
-    val windowErrorOpenness = useWindowOpenness()
-    val navigate = useNavigate()
-
-    useRequest {
-        val response = get(
-            url = "$apiUrl/contests/by-organization?organizationName=${props.organizationName}",
-            headers = jsonHeaders,
-            loadingHandler = ::loadingHandler,
-        )
-        val newContests = if (response.ok) {
-            response.unsafeMap {
-                it.decodeFromJsonString<List<ContestDto>>()
-            }
-                .toSet()
-        } else {
-            setOf()
-        }
-        setContests(newContests)
-        refreshTable()
-    }
-
-    displayConfirmationModal(
-        windowOpenness,
-        "",
-        "Are you sure you want to delete selected contests?",
-    ) {
-        if (selectedContests.isNotEmpty()) {
-            deleteContestsFun()
-        } else {
-            windowErrorOpenness.openWindow()
-        }
-    }
-
-    displaySimpleModal(
-        windowErrorOpenness,
-        title = "Error",
-        "You have not selected contests to delete."
-    )
-
-    showContestCreationModal(
-        props.organizationName,
-        isContestCreationModalOpen,
-        {
-            setIsContestCreationModalOpen(false)
-            navigate(
-                to = it,
-            )
-        },
-        {
-            setIsContestCreationModalOpen(false)
-            props.updateErrorMessage(it)
-        }
-    ) {
-        setIsContestCreationModalOpen(false)
-    }
-
-    div {
-        className = ClassName("col-8 mx-auto")
-        div {
-            className = ClassName("d-flex justify-content-end mb-1")
-            buttonBuilder(
-                classes = "mr-2",
-                label = "Delete selected contests",
-                style = "danger",
-            ) {
-                windowOpenness.openWindow()
-            }
-            buttonBuilder(
-                label = "Create contest",
-                isDisabled = !props.selfRole.hasDeletePermission(),
-            ) {
-                setIsContestCreationModalOpen(true)
-            }
-        }
-        div {
-            className = ClassName("my-3")
-            if (contests.isNotEmpty()) {
-                contestsTable {
-                    getData = { _, _ ->
-                        contests.toTypedArray()
-                    }
-                    isContestCreated = isToUpdateTable
-                    addSelectedContests = addSelectedContestsFun
-                    removeSelectedContests = removeSelectedContestsFun
-                    selectedContestDtos = selectedContests
-                }
-            } else {
-                renderTablePlaceholder("text-center p-4 bg-white") {
-                    +"This organization has not participated in any contest yet."
-                }
-            }
-        }
-    }
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationVulnerabilitiesTab.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationVulnerabilitiesTab.kt
@@ -17,6 +17,7 @@ import com.saveourtool.save.frontend.utils.noopResponseHandler
 import com.saveourtool.save.validation.FrontendRoutes
 import js.core.jso
 import react.*
+import react.dom.html.ReactHTML.br
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.td
 import react.router.dom.Link
@@ -63,7 +64,7 @@ private val vulnerabilityTable: FC<TableProps<VulnerabilityDto>> = tableComponen
     useServerPaging = false,
 )
 
-@Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
+@Suppress("EMPTY_BLOCK_STRUCTURE_ERROR")
 val organizationVulnerabilitiesTab: FC<OrganizationVulnerabilitiesMenuProps> = FC { props ->
     val (vulnerabilities, setVulnerabilities) = useState<Array<VulnerabilityDto>>(emptyArray())
     useRequest {
@@ -90,7 +91,16 @@ val organizationVulnerabilitiesTab: FC<OrganizationVulnerabilitiesMenuProps> = F
                 }
             }
         } else {
-            renderTablePlaceholder("text-center p-4 bg-white") { +"No vulnerabilities were found for this organization." }
+            renderTablePlaceholder("text-center p-4 bg-white", "dashed") {
+                +"No vulnerabilities were found for this organization."
+                if (props.isMember) {
+                    br { }
+                    Link {
+                        to = "/vuln/create-vulnerability"
+                        +"You can be the first one to create vulnerability."
+                    }
+                }
+            }
         }
     }
 }
@@ -103,4 +113,9 @@ external interface OrganizationVulnerabilitiesMenuProps : Props {
      * Current organization name
      */
     var organizationName: String
+
+    /**
+     * Flag that defines if current user can change anything in this organization
+     */
+    var isMember: Boolean
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationView.kt
@@ -211,7 +211,6 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
         }
     }
 
-    @Suppress("TOO_LONG_FUNCTION", "LongMethod", "MAGIC_NUMBER")
     override fun ChildrenBuilder.render() {
         val errorCloseCallback = {
             setState {
@@ -412,6 +411,9 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
     private fun ChildrenBuilder.renderVulnerabilities() {
         organizationVulnerabilitiesTab {
             organizationName = props.organizationName
+            isMember = state.usersInOrganization?.let { usersInOrg ->
+                props.currentUserInfo in usersInOrg || props.currentUserInfo.isSuperAdmin()
+            } ?: false
         }
     }
 
@@ -479,14 +481,10 @@ class OrganizationView : AbstractView<OrganizationProps, OrganizationViewState>(
 
     private suspend fun getUsers(): List<UserInfo> = get(
         url = "$apiUrl/organizations/${props.organizationName}/users",
-        headers = Headers().also {
-            it.set("Accept", "application/json")
-        },
+        headers = jsonHeaders,
         loadingHandler = ::classLoadingHandler,
     )
-        .unsafeMap {
-            it.decodeFromJsonString()
-        }
+        .unsafeMap { it.decodeFromJsonString() }
 
     private fun ChildrenBuilder.renderTopProject(topProject: ProjectDto?) {
         div {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/ChildrenBuilderUtils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/ChildrenBuilderUtils.kt
@@ -175,6 +175,7 @@ private fun ChildrenBuilder.buttonBuilder(
         title?.let {
             asDynamic()["data-toggle"] = "tooltip"
             asDynamic()["data-placement"] = "top"
+            asDynamic()["data-original-title"] = title
             this.title = title
         }
         labelBuilder()


### PR DESCRIPTION
### This PR closes #2378 

### What's done:
 * Added placeholder suggestions (e.g. create first contest etc.)
 * Replaced old text buttons with new label buttons on `organizationContestsMenu`

### How it looks:

https://github.com/saveourtool/save-cloud/assets/35039155/a05b4c79-9268-467c-bc12-33a95ec95274

<img width="1423" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/2f1a3f1a-62ce-4a19-882d-904223fe209c">

<img width="1423" alt="screenshot" src="https://github.com/saveourtool/save-cloud/assets/35039155/3c5d7083-52bd-4481-8aa0-600c46df85c8">
