### PR TITLE
Hide all backend endpoints under `/api` and `/internal`

### DIFF
--- a/api-gateway/src/main/kotlin/com/saveourtool/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/com/saveourtool/save/gateway/security/WebSecurityConfig.kt
@@ -67,7 +67,7 @@ class WebSecurityConfig(
                 // all requests to backend are permitted on gateway, if user agent is authenticated in gateway or doesn't have
                 // any authentication data at all.
                 // backend returns 401 for those endpoints that require authentication
-                .pathMatchers("/api/**", "/sandbox/api/**", "/demo/api/**")
+                .pathMatchers("/api/**")
                 .access { authentication, authorizationContext ->
                     AuthenticatedReactiveAuthorizationManager.authenticated<AuthorizationContext>().check(
                         authentication, authorizationContext
@@ -98,7 +98,7 @@ class WebSecurityConfig(
         }
         .exceptionHandling {
             it.authenticationEntryPoint(
-                // return 401 for unauthorized requests instead of redirect to login
+                // return 401 for unauthorized requests instead of redirect to log-in
                 HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)
             )
         }
@@ -106,7 +106,7 @@ class WebSecurityConfig(
             it.authenticationSuccessHandler(
                 DelegatingServerAuthenticationSuccessHandler(
                     StoringServerAuthenticationSuccessHandler(backendService),
-                    RedirectServerAuthenticationSuccessHandler("/#"),
+                    RedirectServerAuthenticationSuccessHandler("/"),
                 )
             )
             it.authenticationFailureHandler(

--- a/api-gateway/src/main/resources/application-dev.yml
+++ b/api-gateway/src/main/resources/application-dev.yml
@@ -69,9 +69,9 @@ spring:
             scope:
               - openid
           github:
-            # IMPORTANT! When you create a github application on the GITHUB you need to provide a callback API.
+            # IMPORTANT! When you create a GitHub application on the GITHUB you need to provide a callback API.
             # If you will only provide a domain name: 'saveourtool.com' in CALLBACK URL field, everything will go well.
-            # Github will automatically add all the remaining endpoint information (after the domain name): /login/oauth2/code/github
+            # GitHub will automatically add all the remaining endpoint information (after the domain name): /login/oauth2/code/github
             #
             # We don't set any redirect-uri here, because it's managed by GitHub
             # (the field is called "Authorization callback URL" and, for a local

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -27,6 +27,29 @@ spring:
   cloud:
     gateway:
       routes:
+        - id: sandbox-api_route
+          uri: ${gateway.sandbox.url}
+          predicates:
+            - Path=/api/sandbox/**
+          filters:
+            # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
+            - RemoveRequestHeader=Cookie
+            - ConvertAuthorizationHeader=
+        - id: demo-api_route
+          uri: ${gateway.demo.url}
+          predicates:
+            - Path=/api/demo/**
+          filters:
+            # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
+            - RemoveRequestHeader=Cookie
+            - ConvertAuthorizationHeader=
+        - id: demo-cpg-api_route
+          uri: ${gateway.demo-cpg.url}
+          predicates:
+            - Path=/api/cpg/**
+          filters:
+            # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
+            - RemoveRequestHeader=Cookie
         - id: api_route
           uri: ${gateway.backend.url}
           predicates:
@@ -50,29 +73,6 @@ spring:
           uri: ${gateway.frontend.url}
           predicates:
             - Path=/*.html,/*.js*,/*.css,/img/**,/*.ico,/*.png
-          filters:
-            # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
-            - RemoveRequestHeader=Cookie
-        - id: sandbox-api_route
-          uri: ${gateway.sandbox.url}
-          predicates:
-            - Path=/sandbox/api/**
-          filters:
-            # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
-            - RemoveRequestHeader=Cookie
-            - ConvertAuthorizationHeader=
-        - id: demo-api_route
-          uri: ${gateway.demo.url}
-          predicates:
-            - Path=/demo/api/**
-          filters:
-            # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
-            - RemoveRequestHeader=Cookie
-            - ConvertAuthorizationHeader=
-        - id: demo-cpg-api_route
-          uri: ${gateway.demo-cpg.url}
-          predicates:
-            - Path=/cpg/api/**
           filters:
             # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
             - RemoveRequestHeader=Cookie

--- a/authentication-service/src/main/kotlin/com/saveourtool/save/authservice/config/WebSecurityConfig.kt
+++ b/authentication-service/src/main/kotlin/com/saveourtool/save/authservice/config/WebSecurityConfig.kt
@@ -85,7 +85,6 @@ class WebSecurityConfig(
             // they are not proxied from gateway.
             "/actuator/**",
             "/internal/**",
-            "/sandbox/internal/**",
             // Agents should communicate with sandbox without authorization
             "/heartbeat",
             // `CollectionView` is a public page
@@ -103,7 +102,7 @@ class WebSecurityConfig(
             "/api/$v1/contests/*/public-test",
             "/api/$v1/contests/*/scores",
             "/api/$v1/contests/*/*/best",
-            "/demo/api/*/run",
+            "/api/demo/*/run",
             "/api/$v1/vulnerabilities/get-all-public",
             // `fossGraphView` is public page
             "/api/$v1/vulnerabilities/by-name-with-description",

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DemoManagerController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/DemoManagerController.kt
@@ -94,7 +94,7 @@ class DemoManagerController(
         }
         .flatMap {
             webClientDemo.post()
-                .uri("/demo/internal/manager/save-or-update")
+                .uri("/internal/demo/manager/save-or-update")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(demoCreationRequest.demoDto)
                 .retrieve()
@@ -113,7 +113,7 @@ class DemoManagerController(
         }
         .doOnSuccess {
             webClientDemo.post()
-                .uri("/demo/internal/files/${demoCreationRequest.demoDto.projectCoordinates}/upload?version=manual")
+                .uri("/internal/demo/files/${demoCreationRequest.demoDto.projectCoordinates}/upload?version=manual")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(demoCreationRequest.manuallyUploadedFileDtos)
                 .retrieve()
@@ -146,7 +146,7 @@ class DemoManagerController(
         authentication: Authentication,
     ): Mono<FileDto> = forwardRequestCheckingPermission(Permission.DELETE, organizationName, projectName, authentication) {
         webClientDemo.post()
-            .uri("/demo/internal/files/$organizationName/$projectName/upload?version=$version")
+            .uri("/internal/demo/files/$organizationName/$projectName/upload?version=$version")
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .body(BodyInserters.fromMultipartData("file", file))
             .retrieve()
@@ -182,7 +182,7 @@ class DemoManagerController(
         }
         .flatMap {
             webClientDemo.get()
-                .uri("/demo/internal/files/$organizationName/$projectName/list-file?version=$version")
+                .uri("/internal/demo/files/$organizationName/$projectName/list-file?version=$version")
                 .retrieve()
                 .defaultNotFoundProcessing(organizationName, projectName)
                 .bodyToMono<List<FileDto>>()
@@ -213,7 +213,7 @@ class DemoManagerController(
         authentication: Authentication,
     ): Mono<Boolean> = forwardRequestCheckingPermission(Permission.DELETE, organizationName, projectName, authentication) {
         webClientDemo.delete()
-            .uri("/demo/internal/files/$organizationName/$projectName/delete?version=$version&fileName=$fileName")
+            .uri("/internal/demo/files/$organizationName/$projectName/delete?version=$version&fileName=$fileName")
             .retrieve()
             .defaultNotFoundProcessing(organizationName, projectName)
             .bodyToMono()
@@ -239,7 +239,7 @@ class DemoManagerController(
         authentication: Authentication,
     ): Mono<StringResponse> = forwardRequestCheckingPermission(Permission.DELETE, organizationName, projectName, authentication) { project ->
         webClientDemo.post()
-            .uri("/demo/internal/manager/${project.toProjectCoordinates()}/delete")
+            .uri("/internal/demo/manager/${project.toProjectCoordinates()}/delete")
             .retrieve()
             .defaultNotFoundProcessing(organizationName, projectName)
             .toEntity()
@@ -265,7 +265,7 @@ class DemoManagerController(
         authentication: Authentication,
     ): Mono<StringResponse> = forwardRequestCheckingPermission(Permission.WRITE, organizationName, projectName, authentication) { project ->
         webClientDemo.post()
-            .uri("/demo/internal/manager/${project.toProjectCoordinates()}/start")
+            .uri("/internal/demo/manager/${project.toProjectCoordinates()}/start")
             .retrieve()
             .defaultNotFoundProcessing(organizationName, projectName)
             .toEntity()
@@ -291,7 +291,7 @@ class DemoManagerController(
         authentication: Authentication,
     ): Mono<StringResponse> = forwardRequestCheckingPermission(Permission.WRITE, organizationName, projectName, authentication) { project ->
         webClientDemo.post()
-            .uri("/demo/internal/manager/${project.toProjectCoordinates()}/stop")
+            .uri("/internal/demo/manager/${project.toProjectCoordinates()}/stop")
             .retrieve()
             .defaultNotFoundProcessing(organizationName, projectName)
             .toEntity()

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/BackendRoutes.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/BackendRoutes.kt
@@ -1,0 +1,43 @@
+/**
+ * Names that are used as endpoints in the frontend.
+ * If you create a new view with new URL - add it here.
+ */
+
+package com.saveourtool.save.validation
+
+import com.saveourtool.save.utils.URL_PATH_DELIMITER
+import kotlin.js.JsExport
+
+/**
+ * It is required to forbid creating organizations and users with such names
+ *
+ * @property path substring of url that defines given route
+ */
+@JsExport
+@Suppress("unused", "WRONG_DECLARATIONS_ORDER")
+enum class BackendRoutes(val path: String) {
+    API("api"),
+    INTERNAL("internal"),
+    ACTUATOR("actuator"),
+    GRAFANA("grafana"),
+    ERROR("error"),
+    LOGIN("login"),
+    LOGOUT("logout"),
+    SEC("sec"),
+    NEO4J("neo4j"),
+    ;
+
+    override fun toString(): String = path
+
+    companion object {
+        /**
+         * Get forbidden words from [BackendRoutes].
+         *
+         * @return list of forbidden words
+         */
+        fun getForbiddenWords() = BackendRoutes.values()
+            .map { it.path.split(URL_PATH_DELIMITER) }
+            .flatten()
+            .toTypedArray()
+    }
+}

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/ValidationUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/ValidationUtils.kt
@@ -51,6 +51,7 @@ fun String.isValidEmail() = ValidationRegularExpressions.EMAIL_VALIDATOR.value.m
 
 private fun String.hasOnlyAlphaNumOrAllowedSpecialSymbols() = all { it.isLetterOrDigit() || namingAllowedSpecialSymbols.contains(it) }
 
-private fun String.containsForbiddenWords() = FrontendRoutes.getForbiddenWords().any { this == it }
+private fun String.containsForbiddenWords() = (FrontendRoutes.getForbiddenWords() + BackendRoutes.getForbiddenWords())
+    .any { this == it }
 
 private fun String.isLengthOk(allowedLength: Int) = length < allowedLength

--- a/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/utils/SetupUtils.kt
+++ b/save-demo-agent/src/nativeMain/kotlin/com/saveourtool/save/demo/agent/utils/SetupUtils.kt
@@ -64,7 +64,7 @@ private fun executeSetupSh(setupShTimeoutMillis: Long, setupShName: String = "se
     }
 
 private suspend fun downloadDemoFiles(demoUrl: String, demoConfiguration: DemoConfiguration): Path {
-    val url = with(demoConfiguration) { "$demoUrl/demo/internal/files/$organizationName/$projectName/download-as-zip?version=$version" }
+    val url = with(demoConfiguration) { "$demoUrl/internal/demo/files/$organizationName/$projectName/download-as-zip?version=$version" }
     return downloadDemoFiles(url)
 }
 

--- a/save-demo-cpg/src/main/kotlin/com/saveourtool/save/demo/cpg/controller/CpgController.kt
+++ b/save-demo-cpg/src/main/kotlin/com/saveourtool/save/demo/cpg/controller/CpgController.kt
@@ -40,7 +40,7 @@ const val FILE_NAME_SEPARATOR = "==="
     Tag(name = "cpg-demo"),
 )
 @RestController
-@RequestMapping("/cpg/api")
+@RequestMapping("/api/cpg")
 @ExperimentalSerializationApi
 class CpgController(
     val configProperties: ConfigProperties,

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/DemoController.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/DemoController.kt
@@ -32,7 +32,7 @@ import reactor.kotlin.core.util.function.component2
     Tag(name = "demo"),
 )
 @RestController
-@RequestMapping("/demo/api")
+@RequestMapping("/api/demo")
 class DemoController(
     private val demoService: DemoService,
     private val demoRunnerFactory: RunnerFactory,

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/DependencyController.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/DependencyController.kt
@@ -26,7 +26,7 @@ import kotlinx.datetime.toKotlinLocalDateTime
  * Internal controller that allows to upload files to save-demo
  */
 @RestController
-@RequestMapping("/demo/internal/files")
+@RequestMapping("/internal/demo/files")
 class DependencyController(
     private val demoService: DemoService,
     private val downloadToolService: DownloadToolService,

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/ManagementApiController.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/ManagementApiController.kt
@@ -21,7 +21,7 @@ import reactor.kotlin.core.util.function.component2
     Tag(name = "management"),
 )
 @RestController
-@RequestMapping("/demo/api/manager")
+@RequestMapping("/api/demo/manager")
 class ManagementApiController(
     private val toolService: ToolService,
     private val demoService: DemoService,

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/ManagementController.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/controller/ManagementController.kt
@@ -17,7 +17,7 @@ import reactor.kotlin.core.util.function.component2
  * Internal controller that allows to create demos
  */
 @RestController
-@RequestMapping("/demo/internal/manager")
+@RequestMapping("/internal/demo/manager")
 class ManagementController(
     private val downloadToolService: DownloadToolService,
     private val demoService: DemoService,

--- a/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
+++ b/save-demo/src/main/kotlin/com/saveourtool/save/demo/utils/KubernetesUtils.kt
@@ -181,7 +181,7 @@ fun serviceNameForDemo(demo: Demo) = with(demo) {
 
 @Suppress("SameParameterValue")
 private fun getConfigureMeUrl(baseUrl: String, demo: Demo, version: String) = with(demo) {
-    "$baseUrl/demo/internal/manager/$organizationName/$projectName/configure-me?version=$version"
+    "$baseUrl/internal/demo/manager/$organizationName/$projectName/configure-me?version=$version"
 }
 
 @Suppress("TOO_LONG_FUNCTION")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
@@ -33,9 +33,8 @@ import kotlinx.serialization.json.Json
  * The list of all organizations, visible to super-users.
  */
 internal class OrganizationAdminView : AbstractView<Props, OrganizationAdminState>(Style.SAVE_LIGHT) {
-    private val comparator: Comparator<OrganizationDto> =
-            compareBy<OrganizationDto> { it.status.ordinal }
-                .thenBy { it.name }
+    private val comparator: Comparator<OrganizationDto> = compareBy<OrganizationDto> { it.status.ordinal }
+        .thenBy { it.name }
 
     @Suppress("TYPE_ALIAS")
     private val organizationTable: FC<TableProps<OrganizationDto>> = tableComponent(

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/SandboxView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/SandboxView.kt
@@ -33,7 +33,7 @@ import web.html.ButtonType
 
 import kotlinx.browser.window
 
-val sandboxApiUrl = "${window.location.origin}/sandbox/api"
+val sandboxApiUrl = "${window.location.origin}/api/sandbox"
 
 /**
  * A view for testing config files
@@ -47,9 +47,7 @@ val sandboxView = VFC {
     val resultReload = useDeferredRequest {
         val response = get(
             "$sandboxApiUrl/get-debug-info",
-            Headers().apply {
-                set("Accept", "application/octet-stream")
-            },
+            Headers().apply { set("Accept", "application/octet-stream") },
             loadingHandler = ::loadingHandler,
             responseHandler = ::noopResponseHandler,
         )

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/RequestUtils.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/utils/RequestUtils.kt
@@ -37,8 +37,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 
 val apiUrl = "${window.location.origin}/api/$v1"
-val demoApiUrl = "${window.location.origin}/demo/api"
-val cpgDemoApiUrl = "${window.location.origin}/cpg/api"
+val demoApiUrl = "${window.location.origin}/api/demo"
+val cpgDemoApiUrl = "${window.location.origin}/api/cpg"
 
 val jsonHeaders = Headers().apply {
     set("Accept", "application/json")
@@ -169,13 +169,12 @@ suspend fun ComponentWithScope<*, *>.get(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-): Response =
-        get<dynamic>(
-            url = url,
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = get<dynamic>(
+    url = url,
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Performs a `GET` request from a class component. See [request] for parameter
@@ -200,14 +199,13 @@ suspend fun <T : Any> ComponentWithScope<*, *>.get(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-): Response =
-        request(
-            url = url.withParams(params),
-            method = "GET",
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = request(
+    url = url.withParams(params),
+    method = "GET",
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Perform POST request from a class component. See [request] for parameter description.
@@ -221,14 +219,13 @@ suspend fun ComponentWithScope<*, *>.post(
     body: dynamic,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-): Response =
-        post<dynamic>(
-            url = url,
-            headers = headers,
-            body = body,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = post<dynamic>(
+    url = url,
+    headers = headers,
+    body = body,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Performs a `POST` request from a class component.
@@ -261,15 +258,14 @@ suspend fun <T : Any> ComponentWithScope<*, *>.post(
     body: dynamic,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-): Response =
-        request(
-            url = url.withParams(params),
-            method = "POST",
-            headers = headers,
-            body = body,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = request(
+    url = url.withParams(params),
+    method = "POST",
+    headers = headers,
+    body = body,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Perform DELETE request from a class component. See [request] for parameter description.
@@ -282,13 +278,12 @@ suspend fun ComponentWithScope<*, *>.delete(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-): Response =
-        delete<dynamic>(
-            url = url,
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = delete<dynamic>(
+    url = url,
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Performs a `DELETE` request from a class component.
@@ -318,14 +313,13 @@ suspend fun <T : Any> ComponentWithScope<*, *>.delete(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::classComponentResponseHandler,
-): Response =
-        request(
-            url = url.withParams(params),
-            method = "DELETE",
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = request(
+    url = url.withParams(params),
+    method = "DELETE",
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Perform GET request from a functional component
@@ -341,13 +335,12 @@ suspend fun WithRequestStatusContext.get(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::withModalResponseHandler,
-): Response =
-        get<dynamic>(
-            url = url,
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = get<dynamic>(
+    url = url,
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Performs a `GET` request from a functional component. See [request] for
@@ -373,14 +366,13 @@ suspend fun <T : Any> WithRequestStatusContext.get(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::withModalResponseHandler,
-): Response =
-        request(
-            url = url.withParams(params),
-            method = "GET",
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = request(
+    url = url.withParams(params),
+    method = "GET",
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Perform POST request from a functional component
@@ -397,14 +389,13 @@ suspend fun WithRequestStatusContext.post(
     body: dynamic,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::withModalResponseHandler,
-): Response =
-        post<dynamic>(
-            url = url,
-            headers = headers,
-            body = body,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = post<dynamic>(
+    url = url,
+    headers = headers,
+    body = body,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Performs a `POST` request from a functional component.
@@ -440,15 +431,14 @@ suspend fun <T : Any> WithRequestStatusContext.post(
     body: dynamic,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::withModalResponseHandler,
-): Response =
-        request(
-            url = url.withParams(params),
-            method = "POST",
-            headers = headers,
-            body = body,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = request(
+    url = url.withParams(params),
+    method = "POST",
+    headers = headers,
+    body = body,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Perform a `DELETE` request from a functional component.
@@ -479,13 +469,12 @@ suspend fun WithRequestStatusContext.delete(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::withModalResponseHandler,
-): Response =
-        delete<dynamic>(
-            url = url,
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = delete<dynamic>(
+    url = url,
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Performs a `DELETE` request from a functional component.
@@ -518,14 +507,13 @@ suspend fun <T : Any> WithRequestStatusContext.delete(
     headers: Headers,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = this::withModalResponseHandler,
-): Response =
-        request(
-            url = url.withParams(params),
-            method = "DELETE",
-            headers = headers,
-            loadingHandler = loadingHandler,
-            responseHandler = responseHandler,
-        )
+): Response = request(
+    url = url.withParams(params),
+    method = "DELETE",
+    headers = headers,
+    loadingHandler = loadingHandler,
+    responseHandler = responseHandler,
+)
 
 /**
  * Handler that allows to show loading modal
@@ -561,8 +549,7 @@ fun Response.isUnauthorized(): Boolean = this.status == 401.toShort()
  * @return the string  flow produced from the body of this HTTP response.
  * @see Response.inputStream
  */
-suspend fun Response.readLines(): Flow<String> =
-        inputStream().decodeToString()
+suspend fun Response.readLines(): Flow<String> = inputStream().decodeToString()
 
 /**
  * If this component has context, set [response] in this context. Otherwise, fallback to redirect.
@@ -741,13 +728,12 @@ private suspend fun Response.inputStream(): Flow<Byte> {
  * @return the converted instance.
  */
 @Suppress("UnsafeCastFromDynamic")
-private fun Uint8Array.asByteArray(): ByteArray =
-        Int8Array(
-            buffer = buffer.unsafeCast<ArrayBuffer>(),
-            byteOffset = byteOffset,
-            length = length,
-        )
-            .asDynamic()
+private fun Uint8Array.asByteArray(): ByteArray = Int8Array(
+    buffer = buffer.unsafeCast<ArrayBuffer>(),
+    byteOffset = byteOffset,
+    length = length,
+)
+    .asDynamic()
 
 /**
  * Appends the [parameters][params] to this URL.
@@ -798,21 +784,20 @@ private suspend fun request(
     credentials: RequestCredentials? = undefined,
     loadingHandler: suspend (suspend () -> Response) -> Response,
     responseHandler: (Response) -> Unit = ::noopResponseHandler,
-): Response =
-        loadingHandler {
-            window.fetch(
-                input = url,
-                RequestInit(
-                    method = method,
-                    headers = headers,
-                    body = body,
-                    credentials = credentials,
-                )
-            )
-                .await()
+): Response = loadingHandler {
+    window.fetch(
+        input = url,
+        RequestInit(
+            method = method,
+            headers = headers,
+            body = body,
+            credentials = credentials,
+        )
+    )
+        .await()
+}
+    .also { response ->
+        if (responseHandler != undefined) {
+            responseHandler(response)
         }
-            .also { response ->
-                if (responseHandler != undefined) {
-                    responseHandler(response)
-                }
-            }
+    }

--- a/save-frontend/webpack.config.d/dev-server.js
+++ b/save-frontend/webpack.config.d/dev-server.js
@@ -13,7 +13,7 @@ config.devServer = Object.assign(
           }
         },
         {
-          context: ["/sandbox/api/**"],
+          context: ["/api/sandbox/**"],
           target: 'http://localhost:5400',
           logLevel: 'debug',
           onProxyReq: function (proxyReq, req, res) {
@@ -22,12 +22,12 @@ config.devServer = Object.assign(
           }
         },
         {
-          context: ["/demo/api/**"],
+          context: ["/api/demo/**"],
           target: 'http://localhost:5421',
           logLevel: 'debug',
         },
         {
-          context: ["/cpg/api/**"],
+          context: ["/api/cpg/**"],
           target: 'http://localhost:5500',
           logLevel: 'debug',
         },

--- a/save-frontend/webpack.config.d/dev-server.js
+++ b/save-frontend/webpack.config.d/dev-server.js
@@ -4,15 +4,6 @@ config.devServer = Object.assign(
     {
       proxy: [
         {
-          context: ["/api/**"],
-          target: 'http://localhost:5800',
-          logLevel: 'debug',
-          onProxyReq: function (proxyReq, req, res) {
-            proxyReq.setHeader("Authorization", "Basic YWRtaW46");
-            proxyReq.setHeader("X-Authorization-Source", "basic");
-          }
-        },
-        {
           context: ["/api/sandbox/**"],
           target: 'http://localhost:5400',
           logLevel: 'debug',
@@ -30,6 +21,15 @@ config.devServer = Object.assign(
           context: ["/api/cpg/**"],
           target: 'http://localhost:5500',
           logLevel: 'debug',
+        },
+        {
+          context: ["/api/**"],
+          target: 'http://localhost:5800',
+          logLevel: 'debug',
+          onProxyReq: function (proxyReq, req, res) {
+            proxyReq.setHeader("Authorization", "Basic YWRtaW46");
+            proxyReq.setHeader("X-Authorization-Source", "basic");
+          }
         },
         {
           bypass: (req, res) => {

--- a/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/controller/SandboxController.kt
+++ b/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/controller/SandboxController.kt
@@ -59,7 +59,7 @@ import javax.transaction.Transactional
     Tag(name = "sandbox"),
 )
 @RestController
-@RequestMapping("/sandbox/api")
+@RequestMapping("/api/sandbox")
 @SuppressWarnings("LongParameterList")
 class SandboxController(
     val configProperties: ConfigProperties,

--- a/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/controller/SandboxInternalController.kt
+++ b/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/controller/SandboxInternalController.kt
@@ -30,7 +30,7 @@ typealias ByteBufferFluxResponse = ResponseEntity<Flux<ByteBuffer>>
  * Sandbox implementation of endpoints which are required for save-agent
  */
 @RestController
-@RequestMapping("/sandbox/internal")
+@RequestMapping("/internal/sandbox")
 class SandboxInternalController(
     private val storage: SandboxStorage,
     private val objectMapper: ObjectMapper,

--- a/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/service/SandboxOrchestratorAgentService.kt
+++ b/save-sandbox/src/main/kotlin/com/saveourtool/save/sandbox/service/SandboxOrchestratorAgentService.kt
@@ -44,7 +44,7 @@ class SandboxOrchestratorAgentService(
     private val internalFileStorage: SandboxInternalFileStorage,
     configProperties: ConfigProperties,
 ) : OrchestratorAgentService {
-    private val sandboxUrlForAgent = "${configProperties.agentSettings.sandboxUrl}/sandbox/internal"
+    private val sandboxUrlForAgent = "${configProperties.agentSettings.sandboxUrl}/internal/sandbox"
 
     override fun getInitConfig(containerId: String): Mono<AgentInitConfig> = getExecutionAsMonoByContainerId(containerId)
         .zipWhen { execution ->


### PR DESCRIPTION
### What's done:
 * Changed `/demo/api` -> `/api/demo`
 * Changed `/cpg/api` -> `/api/cpg`
 * Changed `/sandbox/api` -> `/api/sandbox`
 * Changed `/demo/internal` -> `/internal/demo`
 * Changed `/sandbox/internal` -> `/internal/sandbox`
 * Added BackendRoutes in order to forbid some high-level url path segments e.g. `api`, `sec`, `grafana` etc.
 * Reworked `App` to be `FC`