### PR TITLE
Terms of Use view should be available for unregistered users

### DIFF
--- a/save-frontend/README.md
+++ b/save-frontend/README.md
@@ -142,7 +142,7 @@ Thus, we add `Authorization` and `X-Authorization-Source` headers that correspon
       {
         proxy: [
           {
-            context: ["/api/**", "/sec/**", "/oauth2/**", "/logout/**", "/login/oauth2/**", "**.ico", "**.png"],
+            context: ["/api/**", "/sec/**", "/oauth2/**", "/logout/**", "/login/oauth2/**"],
             target: 'http://localhost:5300',
             logLevel: 'debug',
           }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
@@ -37,7 +37,6 @@ import kotlinx.serialization.json.Json
 @Suppress("VARIABLE_NAME_INCORRECT_FORMAT", "NULLABLE_PROPERTY_TYPE")
 val App: VFC = FC {
     val (userInfo, setUserInfo) = useState<UserInfo?>(null)
-
     useRequest {
         val userName: String? = get(
             "${window.location.origin}/sec/user",
@@ -69,13 +68,12 @@ val App: VFC = FC {
 
         userInfoNew?.let { setUserInfo(userInfoNew) }
     }
-
     BrowserRouter {
         basename = "/"
         requestModalHandler {
             this.userInfo = userInfo
 
-            if (userInfo?.status == UserStatus.CREATED) {
+            if (userInfo?.status == UserStatus.CREATED && kotlinx.browser.window.location.pathname != "/${FrontendRoutes.TERMS_OF_USE}") {
                 Navigate {
                     to = "/${FrontendRoutes.REGISTRATION}"
                     replace = false

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
@@ -15,6 +15,7 @@ import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.info.UserStatus
 import com.saveourtool.save.utils.AvatarType
 import com.saveourtool.save.v1
+import com.saveourtool.save.validation.FrontendRoutes
 import com.saveourtool.save.validation.isValidLengthName
 import com.saveourtool.save.validation.isValidName
 
@@ -89,7 +90,7 @@ val registrationView: FC<RegistrationProps> = FC { props ->
             loadingHandler = ::loadingHandler,
         )
         if (replyToLogout.ok) {
-            window.location.href = "${window.location.origin}/#"
+            window.location.href = window.location.origin
             window.location.reload()
         }
     }
@@ -153,7 +154,7 @@ val registrationView: FC<RegistrationProps> = FC { props ->
                                 }
 
                                 div {
-                                    className = ClassName("mt-2 form-check")
+                                    className = ClassName("mt-2 form-check row")
                                     input {
                                         className = ClassName("form-check-input")
                                         type = "checkbox".unsafeCast<InputType>()
@@ -163,10 +164,9 @@ val registrationView: FC<RegistrationProps> = FC { props ->
                                     }
                                     label {
                                         className = ClassName("form-check-label")
-                                        htmlFor = "terms-of-use"
                                         +" I agree with "
                                         Link {
-                                            to = "/terms-of-use"
+                                            to = "/${FrontendRoutes.TERMS_OF_USE}"
                                             target = "_blank".unsafeCast<WindowTarget>()
                                             +"terms of use"
                                         }


### PR DESCRIPTION
### What's done:
* Removed redirect to `/registration` if user is created and is on `/terms-of-use` view
* Removed `**.ico`, `**.png` from `README.md#Using OAuth with a local deployment` (I'm done with `431` error)
* Made `I agree with terms of use` label be not clickable - you must now click the checkbox