### PR TITLE
Hotfix for vulnerability tags tooltip

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTagsComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTagsComponent.kt
@@ -90,7 +90,7 @@ val vulnerabilityTagsComponent: FC<VulnerabilityTagsComponentProps> = FC { props
                 placeholder = "Add a new tag..."
                 title = "Tag should not have commas, length should be more than 2 and less than 16."
                 asDynamic()["data-toggle"] = "tooltip"
-                asDynamic()["data-placement"] = "right"
+                asDynamic()["data-placement"] = "top"
                 onChange = { event -> setNewTag(event.target.value) }
             }
             div {


### PR DESCRIPTION
### What's done:
* Changed tooltip placement to `top`