### PR TITLE
Hotfix for vulnerability tags duplicates

### DIFF
--- a/db/v-2/tables/tags.xml
+++ b/db/v-2/tables/tags.xml
@@ -16,4 +16,8 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="tag-2" author="sanyavertolet" context="dev or prod">
+        <addUniqueConstraint tableName="tag" columnNames="name" constraintName="uq_tag_name"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/TagController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/TagController.kt
@@ -45,6 +45,6 @@ class TagController(
         @RequestParam(required = false, defaultValue = "") prefix: String,
         @RequestParam(required = false, defaultValue = "3") pageSize: Int,
     ) = blockingToMono {
-        tagService.getVulnerabilityTagsByPrefix(prefix, Pageable.ofSize(pageSize)).map { it.name }
+        tagService.getVulnerabilityTagsByPrefix(prefix, Pageable.ofSize(pageSize)).map { it.name }.distinct()
     }
 }


### PR DESCRIPTION
### What's done:
* Now returning only distinct tags
* Added unique constraint to `tag` table for `name` column