### PR TITLE
Hotfix for a DockerContainerManagerTest

### DIFF
--- a/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/docker/DockerContainerManagerTest.kt
+++ b/save-orchestrator-common/src/test/kotlin/com/saveourtool/save/orchestrator/docker/DockerContainerManagerTest.kt
@@ -89,10 +89,10 @@ class DockerContainerManagerTest {
         val inspectContainerResponse = dockerClient
             .inspectContainerCmd(testContainerId)
             .exec()
-
-        Assertions.assertEquals("bash", inspectContainerResponse.path)
+        Assertions.assertEquals("/entrypoint.sh", inspectContainerResponse.path)
+        inspectContainerResponse.args.forEach { println(it) }
         Assertions.assertArrayEquals(
-            arrayOf("-c", "env \$(cat /home/save-agent/.env | xargs) sh -c \"./script.sh\""),
+            arrayOf("bash", "-c", "env \$(cat /home/save-agent/.env | xargs) sh -c \"./script.sh\""),
             inspectContainerResponse.args
         )
         // leading extra slash: https://github.com/moby/moby/issues/6705


### PR DESCRIPTION
Without any reason this test started to fail. Looks like it happened due to some image update, so the inspectContainerResponse was changed on image side: 
1) run cmd became: 
```
bash
-c
env $(cat /home/save-agent/.env | xargs) sh -c "./script.sh"
```

from 

```
-c
env $(cat /home/save-agent/.env | xargs) sh -c "./script.sh"
```

2) `path = "bash"` -> `path = "/entrypoint.sh"`