### PR TITLE
Hotfix for redirects after vulnerability reject/deletion

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityView.kt
@@ -94,7 +94,7 @@ val vulnerabilityView: FC<VulnerabilitiesViewProps> = FC { props ->
             loadingHandler = ::loadingHandler,
         )
         if (response.ok) {
-            navigate(to = "/${FrontendRoutes.VULN}")
+            navigate(to = "/${FrontendRoutes.VULNERABILITIES}")
         }
     }
 
@@ -105,7 +105,7 @@ val vulnerabilityView: FC<VulnerabilitiesViewProps> = FC { props ->
             loadingHandler = ::loadingHandler,
         )
         if (response.ok) {
-            navigate(to = "/${FrontendRoutes.VULN}")
+            navigate(to = "/${FrontendRoutes.VULNERABILITIES}")
         }
     }
 


### PR DESCRIPTION
### What's done:
* Changed redirect from `FrontendRoutes.VULN` to `FrontendRoutes.VULNERABILITIES`