### PR TITLE
ThanksForRegistrationView

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/FrontendRoutes.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/FrontendRoutes.kt
@@ -42,6 +42,7 @@ enum class FrontendRoutes(val path: String) {
     SETTINGS_PROFILE("$SETTINGS/profile"),
     SETTINGS_TOKEN("$SETTINGS/token"),
     TERMS_OF_USE("terms-of-use"),
+    THANKS_FOR_REGISTRATION("thanks-for-registration"),
     UPLOAD_VULNERABILITY("vuln/upload-vulnerability"),
     VULN("vuln"),
     VULNERABILITIES("$VULN/list"),
@@ -60,6 +61,7 @@ enum class FrontendRoutes(val path: String) {
             INDEX,
             ERROR_404,
             TERMS_OF_USE,
+            THANKS_FOR_REGISTRATION,
         )
 
         /**

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/App.kt
@@ -86,6 +86,11 @@ val App: VFC = FC {
                     to = "/${FrontendRoutes.BAN}"
                     replace = false
                 }
+            } else if (userInfo?.status == UserStatus.NOT_APPROVED) {
+                Navigate {
+                    to = "/${FrontendRoutes.THANKS_FOR_REGISTRATION}"
+                    replace = false
+                }
             }
 
             div {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/BanView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/BanView.kt
@@ -12,7 +12,7 @@ import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.info.UserStatus
 import js.core.jso
 import react.FC
-import react.PropsWithChildren
+import react.Props
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.p
@@ -66,7 +66,7 @@ val banView: FC<BanProps> = FC { props ->
 /**
  * `Props` retrieved from router
  */
-external interface BanProps : PropsWithChildren {
+external interface BanProps : Props {
     /**
      * Currently logged-in user or null
      */

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ThanksForRegistrationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ThanksForRegistrationView.kt
@@ -1,0 +1,84 @@
+/**
+ * View for users that are being reviewed until approve status gotten
+ */
+
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.saveourtool.save.frontend.components.views
+
+import com.saveourtool.save.frontend.externals.i18next.useTranslation
+import com.saveourtool.save.frontend.utils.Style
+import com.saveourtool.save.frontend.utils.useBackground
+import com.saveourtool.save.info.UserInfo
+import com.saveourtool.save.info.UserStatus
+import js.core.jso
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.a
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.h2
+import react.dom.html.ReactHTML.img
+import react.dom.html.ReactHTML.p
+import react.dom.html.ReactHTML.strong
+import react.router.useNavigate
+import web.cssom.ClassName
+import web.cssom.rem
+
+val thanksForRegistrationView: FC<BanProps> = FC { props ->
+    useBackground(Style.INDEX)
+
+    val navigate = useNavigate()
+    val (t) = useTranslation("thanks-for-registration")
+    if (props.userInfo?.status != UserStatus.NOT_APPROVED) {
+        navigate("/", jso { replace = true })
+    }
+
+    div {
+        className = ClassName("col text-center d-flex justify-content-center align-items-center")
+        style = jso {
+            height = 52.rem
+        }
+
+        div {
+            className = ClassName("col-5 bg-light mb-5 p-3 rounded")
+            img {
+                className = ClassName("avatar avatar-user border color-bg-default rounded-circle")
+                style = jso {
+                    width = 20.rem
+                }
+                src = "/img/avatar_packs/avatar1.png"
+            }
+
+            div {
+                className = ClassName("p-2")
+                h2 {
+                    className = ClassName("mx-auto")
+                    +"${"Thank you for registration".t()}!"
+                }
+
+                p {
+                    className = ClassName("lead text-gray-800 mb-0")
+                    +"Your request is pending review".t()
+                    a {
+                        className = ClassName("ml-1")
+                        href = "mailto:saveourtool@gmail.com"
+                        strong {
+                            className = ClassName("d-inline-block")
+                            +"  saveourtool@gmail.com."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * `Props` retrieved from router
+ */
+external interface ThanksForRegistrationViewProps : Props {
+    /**
+     * Currently logged-in user or null
+     */
+    var userInfo: UserInfo?
+}

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/i18next/InitI18n.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/i18next/InitI18n.kt
@@ -23,6 +23,7 @@ fun initI18n(isDebug: Boolean = false, interpolationEscapeValue: Boolean = false
                     "Notifications": "Notifications"
                 },
                 "vulnerability-collection": $VULN_COLLECTION_EN,
+                "thanks-for-registration": $THANKS_FOR_REGISTRATION_EN,
                 "vulnerability-upload": $VULN_UPLOAD_EN,
                 "table-headers": $TABLE_HEADERS_EN,
                 "topbar": $TOPBAR_EN,
@@ -38,6 +39,7 @@ fun initI18n(isDebug: Boolean = false, interpolationEscapeValue: Boolean = false
                     "Notifications": "Уведомления"
                 },
                 "vulnerability-collection": $VULN_COLLECTION_RU,
+                "thanks-for-registration": $THANKS_FOR_REGISTRATION_RU,
                 "vulnerability-upload": $VULN_UPLOAD_RU,
                 "table-headers": $TABLE_HEADERS_RU,
                 "topbar": $TOPBAR_RU,

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/i18next/locales/Translations.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/externals/i18next/locales/Translations.kt
@@ -120,3 +120,17 @@ const val COOKIES_RU = """
     "Read more": "Узнать больше"
 }
 """
+
+const val THANKS_FOR_REGISTRATION_EN = """
+{
+    "Thank you for registration": "Thank you for registration",
+    "Your request is pending review": "Right now the platform is still in development. Our admin team will soon review your request and approve it if everything is fine. Don't hesitate to contact us if you have any question:"
+}
+"""
+
+const val THANKS_FOR_REGISTRATION_RU = """
+{
+    "Thank you for registration": "Спасибо за регистрацию!",
+    "Your request is pending review": "SaveOurTool все еще находится на этапе разработки. Наша команда админов в скором времени рассмотрит Вашу заявку и одобрит ее в случае если все в порядке. Не стесняйтесь обращаться к нам по всем вопросам:"
+}
+"""

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/routing/BasicRouting.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/routing/BasicRouting.kt
@@ -217,6 +217,7 @@ val basicRouting: FC<AppProps> = FC { props ->
             topRatingView.create() to VULN_TOP_RATING,
             termsOfUsageView.create() to TERMS_OF_USE,
             cookieTermsOfUse.create() to COOKIE,
+            thanksForRegistrationView.create() to THANKS_FOR_REGISTRATION,
 
             userSettingsView.create {
                 this.userInfoSetter = props.userInfoSetter


### PR DESCRIPTION
This PR is a part of #2451 

### What's done:
 * Added `thanksForRegistrationView`
 * Added translations for `thanksForRegistrationView`

### How it looks:
![screenshot](https://github.com/saveourtool/save-cloud/assets/35039155/d4e43432-ad0f-482a-a52b-0069fd013dff)

