### PR TITLE
Let users add some info on registration

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
@@ -35,6 +35,7 @@ import react.dom.html.ReactHTML.input
 import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.main
 import react.dom.html.ReactHTML.span
+import react.dom.html.ReactHTML.textarea
 import react.router.dom.Link
 import web.cssom.*
 import web.file.File
@@ -230,6 +231,16 @@ val registrationView: FC<RegistrationProps> = FC { props ->
                                             setUserInfo { previousUserInfo -> previousUserInfo.copy(name = event.target.value) }
                                             setConflictErrorMessage(null)
                                         }
+                                    }
+                                }
+
+                                div {
+                                    className = ClassName("pt-3")
+                                    textarea {
+                                        className = ClassName("form-control")
+                                        value = userInfo.freeText
+                                        placeholder = "Please enter some information about yourself so that it would be easier for us to approve."
+                                        onChange = { event -> setUserInfo { previousUserInfo -> previousUserInfo.copy(freeText = event.target.value) } }
                                     }
                                 }
 


### PR DESCRIPTION
This PR is a part of #2451 

### What's done:
 * Added `textarea` on `registrationView` to fill personal info

### How it looks:
<img width="1424" alt="screenshots" src="https://github.com/saveourtool/save-cloud/assets/35039155/5fc204da-8ce4-4d39-8077-ece72d299b2c">
