### PR TITLE
Editing view preparations: propagating of edit flag to children components

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -117,3 +117,8 @@ spring:
             scope:
               - user_info
 ---
+# logout timeout
+server:
+  servlet:
+    session:
+      timeout: 15m

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/vulnerability/VulnerabilityController.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/controllers/vulnerability/VulnerabilityController.kt
@@ -186,7 +186,6 @@ class VulnerabilityController(
     )
     @ApiResponse(responseCode = "200", description = "Successfully updated vulnerability")
     @RequiresAuthorizationSourceHeader
-    @PreAuthorize("hasRole('ROLE_SUPER_ADMIN')")
     fun update(
         @RequestBody vulnerabilityDto: VulnerabilityDto,
         authentication: Authentication,

--- a/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/vulnerability/VulnerabilityService.kt
+++ b/save-backend/src/main/kotlin/com/saveourtool/save/backend/service/vulnerability/VulnerabilityService.kt
@@ -296,16 +296,17 @@ class VulnerabilityService(
 
         val vulnerability = vulnerabilityRepository.findByIdentifier(vulnerabilityDto.identifier).orNotFound()
 
-        if (!authentication.hasRole(Role.SUPER_ADMIN) && (userId != vulnerability.userId || vulnerability.status == VulnerabilityStatus.APPROVED)) {
+        // only Super Users and owners of unapproved vuln. can edit it
+        if (authentication.hasRole(Role.SUPER_ADMIN) || (userId == vulnerability.userId && vulnerability.status != VulnerabilityStatus.APPROVED)) {
+            val vulnerabilityUpdate = vulnerability.apply {
+                progress = vulnerabilityDto.progress
+                description = vulnerabilityDto.description.orEmpty()
+                status = vulnerabilityDto.status
+            }
+            vulnerabilityRepository.save(vulnerabilityUpdate)
+        } else {
             throw ResponseStatusException(HttpStatus.FORBIDDEN)
         }
-
-        val vulnerabilityUpdate = vulnerability.apply {
-            progress = vulnerabilityDto.progress
-            description = vulnerabilityDto.description.orEmpty()
-            status = vulnerabilityDto.status
-        }
-        vulnerabilityRepository.save(vulnerabilityUpdate)
     }
 
     /**

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/vulnerability/VulnerabilityDateType.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/vulnerability/VulnerabilityDateType.kt
@@ -41,14 +41,14 @@ enum class VulnerabilityDateType(val value: String) {
     PUBLISHED("Published"),
 
     /**
+     * Date when the vuln was submitted to our archive, our platform specific
+     */
+    SUBMITTED("Submitted"),
+
+    /**
      * Date from [com.saveourtool.osv4k.OsvSchema.withdrawn] in COSV schema
      */
     WITHDRAWN("Withdrawn"),
-
-    /**
-     * Date when the vuln was submitted to our archive, our platform specific
-     */
-    SUBMITTED("Submitted")
     ;
 
     override fun toString(): String = value

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/vulnerability/VulnerabilityDateType.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/vulnerability/VulnerabilityDateType.kt
@@ -44,6 +44,11 @@ enum class VulnerabilityDateType(val value: String) {
      * Date from [com.saveourtool.osv4k.OsvSchema.withdrawn] in COSV schema
      */
     WITHDRAWN("Withdrawn"),
+
+    /**
+     * Date when the vuln was submitted to our archive, our platform specific
+     */
+    SUBMITTED("Submitted")
     ;
 
     override fun toString(): String = value

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/HasErrorModal.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/HasErrorModal.kt
@@ -10,6 +10,7 @@ import com.saveourtool.save.frontend.externals.animations.ringLoader
 import com.saveourtool.save.info.UserInfo
 
 import js.core.jso
+import kotlinx.browser.window
 import org.w3c.fetch.Response
 import react.*
 import react.dom.html.ReactHTML.button
@@ -102,7 +103,8 @@ val requestModalHandler: FC<RequestModalProps> = FC { props ->
                 onClick = {
                     if (response?.status == 401.toShort()) {
                         // if 401 - change current URL to the main page (with login screen)
-                        navigate("/")
+                        navigate(to = "/")
+                        window.location.reload()
                     }
                     setResponse(null)
                     setModalState(modalState.copy(isErrorModalOpen = false))

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/HasErrorModal.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/HasErrorModal.kt
@@ -10,7 +10,6 @@ import com.saveourtool.save.frontend.externals.animations.ringLoader
 import com.saveourtool.save.info.UserInfo
 
 import js.core.jso
-import kotlinx.browser.window
 import org.w3c.fetch.Response
 import react.*
 import react.dom.html.ReactHTML.button
@@ -20,6 +19,8 @@ import react.dom.html.ReactHTML.span
 import react.router.useNavigate
 import web.cssom.ClassName
 import web.html.ButtonType
+
+import kotlinx.browser.window
 
 /**
  * Loader animation

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TimelineComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/TimelineComponent.kt
@@ -14,78 +14,71 @@ import kotlinx.datetime.LocalDateTime
 const val HOVERABLE_CONST = "hoverable"
 
 val timelineComponent: FC<TimelineComponentProps> = FC { props ->
-    console.log(props.dates)
-    if (props.dates != undefined) {
-        val hoverable = props.onNodeClick?.let { HOVERABLE_CONST }.orEmpty()
+    val hoverable = props.onNodeClick?.let { HOVERABLE_CONST }.orEmpty()
+
+    div {
+        className = ClassName("mb-3")
+        props.title?.let { title ->
+            div {
+                className = ClassName("mt-3 mb-3 text-xs text-center font-weight-bold text-primary text-uppercase")
+                +title
+            }
+        }
+
+        props.onAddClick?.let { onClickCallback ->
+            buttonBuilder(
+                label = "Add date",
+                style = "secondary",
+                isOutline = true,
+                classes = "btn btn-sm btn-primary"
+            ) {
+                onClickCallback()
+            }
+        }
 
         div {
-            className = ClassName("mb-3")
-            props.title?.let { title ->
-                div {
-                    className = ClassName("mt-3 mb-3 text-xs text-center font-weight-bold text-primary text-uppercase")
-                    +title
-                }
-            }
-
-            props.onAddClick?.let { onClickCallback ->
-                buttonBuilder(
-                    label = "Add date",
-                    style = "secondary",
-                    isOutline = true,
-                    classes = "btn btn-sm btn-primary"
-                ) {
-                    onClickCallback()
-                }
-            }
-
+            className = ClassName("p-0 timeline-container")
             div {
-                className = ClassName("p-0 timeline-container")
+                className = ClassName("steps-container")
                 div {
-                    className = ClassName("steps-container")
-                    div {
-                        className = ClassName("line")
-                    }
-                    props.dates
-                        .plus(
-                            VulnerabilityDateType.SUBMITTED.value to
-                                    (props.vulnerability.creationDateTime ?: LocalDateTime(0, 1, 1, 0, 0, 0, 0))
-                        )
-                        .toList()
-                        .sortedBy { it.second }
-                        .forEach { (label, dateTime) ->
-                            div {
-                                className =
+                    className = ClassName("line")
+                }
+                props.dates
+                    .plus(
+                        VulnerabilityDateType.SUBMITTED.value to
+                                (props.vulnerability.creationDateTime ?: LocalDateTime(0, 1, 1, 0, 0, 0, 0))
+                    )
+                    .toList()
+                    .sortedBy { it.second }
+                    .forEach { (label, dateTime) ->
+                        div {
+                            className =
                                     ClassName(if (!label.isSubmittedType()) "step $hoverable" else "step-non-editable")
-                                if (!label.isSubmittedType()) {
-                                    props.onNodeClick?.let { onClickCallback ->
-                                        onClick = { onClickCallback(dateTime, label) }
-                                    }
-                                }
-                                div {
-                                    className = ClassName("text-label")
-                                    +label
-                                }
-                                div {
-                                    className = ClassName("date-label")
-                                    +dateTime.date.toString()
+                            if (!label.isSubmittedType()) {
+                                props.onNodeClick?.let { onClickCallback ->
+                                    onClick = { onClickCallback(dateTime, label) }
                                 }
                             }
                             div {
-                                className = ClassName("line")
+                                className = ClassName("text-label")
+                                +label
+                            }
+                            div {
+                                className = ClassName("date-label")
+                                +dateTime.date.toString()
                             }
                         }
-                    div {
-                        className = ClassName("line-end")
+                        div {
+                            className = ClassName("line")
+                        }
                     }
+                div {
+                    className = ClassName("line-end")
                 }
             }
         }
-    } else {
-
     }
 }
-
-private fun String.isSubmittedType() = this == VulnerabilityDateType.SUBMITTED.value
 
 /**
  * [Props] of [timelineComponent]
@@ -117,3 +110,5 @@ external interface TimelineComponentProps : Props {
      */
     var vulnerability: VulnerabilityDto
 }
+
+private fun String.isSubmittedType() = this == VulnerabilityDateType.SUBMITTED.value

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsView.kt
@@ -16,6 +16,7 @@ import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.validation.FrontendRoutes
 
 import js.core.jso
+import kotlinx.browser.window
 import react.*
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
@@ -54,6 +55,7 @@ val userSettingsView: FC<SettingsProps> = FC { props ->
                 type = ButtonType.button
                 onClick = {
                     useNavigate(to = "/")
+                    window.location.reload()
                 }
                 +"Proceed to login page"
             }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsView.kt
@@ -16,7 +16,6 @@ import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.validation.FrontendRoutes
 
 import js.core.jso
-import kotlinx.browser.window
 import react.*
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
@@ -28,6 +27,7 @@ import web.cssom.*
 import web.html.ButtonType
 import web.html.InputType
 
+import kotlinx.browser.window
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfo.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfo.kt
@@ -9,24 +9,23 @@ import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.utils.toUnixCalendarFormat
-import js.core.jso
 
+import js.core.jso
 import react.*
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h6
 import react.dom.html.ReactHTML.hr
 import react.dom.html.ReactHTML.label
+import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.textarea
 import react.router.dom.Link
 import web.cssom.ClassName
+import web.cssom.TextDecoration.Companion.underline
 import web.cssom.rem
 
 import kotlinx.datetime.TimeZone
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import react.dom.html.ReactHTML.p
-import web.cssom.Color
-import web.cssom.TextDecoration.Companion.underline
 
 /**
  * [FC] that is used to display some general vulnerability information
@@ -60,13 +59,13 @@ val vulnerabilityGeneralInfo: FC<VulnerabilityGeneralInfo> = FC { props ->
                     if (props.isEditDisabled) {
                         // only Super Users and owners of unapproved vuln. can edit it
                         if (props.userInfo?.isSuperAdmin() == true ||
-                            (props.userInfo?.name == userInfo.name && props.vulnerability.status != VulnerabilityStatus.APPROVED)) {
+                                (props.userInfo?.name == userInfo.name && props.vulnerability.status != VulnerabilityStatus.APPROVED)) {
                             buttonBuilder(
                                 labelBuilder = {
                                     p {
                                         className = ClassName("mb-0")
                                         style = jso {
-                                            textDecoration = underline;
+                                            textDecoration = underline
                                         }
                                         +"Edit "
                                         fontAwesomeIcon(icon = faEdit)
@@ -221,7 +220,7 @@ external interface VulnerabilityGeneralInfo : Props {
     var vulnerability: VulnerabilityDto
 
     /**
-     *
+     * Vulnerabilities setter
      */
     var setVulnerability: StateSetter<VulnerabilityDto>
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfo.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfo.kt
@@ -1,6 +1,7 @@
 package com.saveourtool.save.frontend.components.views.vuln
 
 import com.saveourtool.save.entities.vulnerability.VulnerabilityDto
+import com.saveourtool.save.entities.vulnerability.VulnerabilityStatus
 import com.saveourtool.save.frontend.components.basic.renderAvatar
 import com.saveourtool.save.frontend.components.basic.renderUserAvatarWithName
 import com.saveourtool.save.frontend.components.basic.userBoard
@@ -8,6 +9,7 @@ import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.utils.toUnixCalendarFormat
+import js.core.jso
 
 import react.*
 import react.dom.html.ReactHTML.div
@@ -22,20 +24,21 @@ import web.cssom.rem
 import kotlinx.datetime.TimeZone
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import react.dom.html.ReactHTML.p
+import web.cssom.Color
+import web.cssom.TextDecoration.Companion.underline
 
 /**
  * [FC] that is used to display some general vulnerability information
  */
 @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR", "MAGIC_NUMBER")
 val vulnerabilityGeneralInfo: FC<VulnerabilityGeneralInfo> = FC { props ->
-    val (vulnerability, setVulnerability) = useStateFromProps(props.vulnerability)
-
     val enrollRequest = useDeferredRequest {
         post(
             "$apiUrl/vulnerabilities/update",
             jsonHeaders,
-            Json.encodeToString(vulnerability),
-            loadingHandler = ::noopLoadingHandler,
+            Json.encodeToString(props.vulnerability),
+            loadingHandler = ::loadingHandler,
         )
     }
 
@@ -55,13 +58,21 @@ val vulnerabilityGeneralInfo: FC<VulnerabilityGeneralInfo> = FC { props ->
                         }
                     }
                     if (props.isEditDisabled) {
-                        if (props.userInfo?.isSuperAdmin() == true || props.userInfo?.name == userInfo.name) {
+                        // only Super Users and owners of unapproved vuln. can edit it
+                        if (props.userInfo?.isSuperAdmin() == true ||
+                            (props.userInfo?.name == userInfo.name && props.vulnerability.status != VulnerabilityStatus.APPROVED)) {
                             buttonBuilder(
                                 labelBuilder = {
-                                    +"Edit "
-                                    fontAwesomeIcon(icon = faEdit)
+                                    p {
+                                        className = ClassName("mb-0")
+                                        style = jso {
+                                            textDecoration = underline;
+                                        }
+                                        +"Edit "
+                                        fontAwesomeIcon(icon = faEdit)
+                                    }
                                 },
-                                "link", isOutline = true, classes = "text-xs text-muted text-left ml-auto"
+                                isOutline = true, classes = "text-xs text-left ml-auto"
                             ) {
                                 props.setIsEditDisabled(false)
                             }
@@ -72,33 +83,36 @@ val vulnerabilityGeneralInfo: FC<VulnerabilityGeneralInfo> = FC { props ->
                             props.setIsEditDisabled(true)
                         }
                         buttonBuilder(faTimesCircle, null, isOutline = true) {
-                            setVulnerability(props.vulnerability)
+                            props.setVulnerability(props.vulnerability)
                             props.setIsEditDisabled(true)
                         }
                     }
                 }
                 textarea {
-                    className = ClassName("auto_height form-control-plaintext pt-0 pb-0 text-gray-900")
+                    className = ClassName("auto_height form-control-plaintext px-2 pt-0 pb-0 text-gray-900")
                     value = shortDescription
+                    disabled = props.isEditDisabled
                     rows = 2
+                    if (!props.isEditDisabled) {
+                        style = borderEditStyle()
+                    }
+                    onChange = { event ->
+                        props.setVulnerability { vulnerability ->
+                            vulnerability.copy(
+                                shortDescription = event.target.value
+                            )
+                        }
+                    }
                 }
                 hr { }
                 div {
                     className = ClassName("d-flex justify-content-between align-items-center")
-                    label {
-                        className = ClassName("m-0")
-                        +"Creation time:"
-                    }
-                    label {
-                        className = ClassName("m-0")
-                        +creationDateTime?.toUnixCalendarFormat(TimeZone.currentSystemDefault())
-                    }
                 }
                 div {
                     className = ClassName("d-flex justify-content-between align-items-center")
                     label {
                         className = ClassName("m-0")
-                        +"Last updated time:"
+                        +"Last update time:"
                     }
                     label {
                         className = ClassName("m-0")
@@ -111,12 +125,15 @@ val vulnerabilityGeneralInfo: FC<VulnerabilityGeneralInfo> = FC { props ->
                     +"Description"
                 }
                 textarea {
-                    className = ClassName("auto_height form-control-plaintext pt-0 pb-0 text-gray-900")
+                    className = ClassName("auto_height form-control-plaintext px-2 pt-0 pb-0 text-gray-900")
                     value = description
                     disabled = props.isEditDisabled
                     rows = 8
+                    if (!props.isEditDisabled) {
+                        style = borderEditStyle()
+                    }
                     onChange = { event ->
-                        setVulnerability { vulnerability ->
+                        props.setVulnerability { vulnerability ->
                             vulnerability.copy(
                                 description = event.target.value
                             )
@@ -136,6 +153,7 @@ val vulnerabilityGeneralInfo: FC<VulnerabilityGeneralInfo> = FC { props ->
                             this.vulnerability = props.vulnerability
                             fetchVulnerability = props.fetchVulnerability
                             canEditVulnerability = props.canEditVulnerability
+                            isEditDisabled = props.isEditDisabled
                         }
                     }
                 }
@@ -201,6 +219,11 @@ external interface VulnerabilityGeneralInfo : Props {
      * [VulnerabilityDto] to display info about
      */
     var vulnerability: VulnerabilityDto
+
+    /**
+     *
+     */
+    var setVulnerability: StateSetter<VulnerabilityDto>
 
     /**
      * Callback to fetch updated vulnerability

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityHeader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityHeader.kt
@@ -30,12 +30,14 @@ import react.dom.html.ReactHTML.h6
 import react.dom.html.ReactHTML.textarea
 import react.router.useNavigate
 import react.useState
-import web.cssom.ClassName
-import web.cssom.Height
 
 import kotlinx.browser.window
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import react.dom.html.ReactHTML.h4
+import react.dom.html.ReactHTML.img
+import web.cssom.*
+import web.cssom.HtmlAttributes.Companion.src
 
 internal val headerMenu: FC<HeaderMenuProps> = FC { props ->
     val rejectVulnerabilityWindowOpenness = useWindowOpenness()
@@ -159,57 +161,87 @@ internal val headerMenu: FC<HeaderMenuProps> = FC { props ->
     div {
         className = ClassName("col-6")
         div {
-            className = ClassName("card shadow")
+            className = ClassName("row card shadow ribbon-parent")
             style = jso {
                 height = HEADER_HEIGHT.unsafeCast<Height>()
             }
-            tab(
-                props.selectedMenu.name,
-                VulnerabilityTab.values().map { it.name },
-                "nav nav-tabs mt-3"
-            ) { value -> props.setSelectedMenu { VulnerabilityTab.valueOf(value) } }
-
-            // separate it to button menu
-            div {
-                className = ClassName("row justify-content-center mt-3")
+            if (props.vulnerability.status == VulnerabilityStatus.APPROVED) {
                 div {
-                    className = ClassName("d-flex justify-content-end my-2")
-                    if (props.selectedMenu == VulnerabilityTab.INFO) {
-                        buttonBuilder(
-                            if (props.isTableView) faImage else faTable,
-                            "secondary",
-                            classes = "mr-2",
-                            isOutline = true,
-                            title = "Change to ${if (props.isTableView) "card" else "table"} mode"
-                        ) {
-                            props.setIsTableView { !it }
-                        }
+                    className = ClassName("ribbon-approved")
+                    +"Approved"
+                }
+            } else {
+                div {
+                    className = ClassName("ribbon-not-approved")
+                    +"Not Approved"
+                }
+            }
+            div {
+                className = ClassName("col-3")
+                div {
+                    className = ClassName("row")
+                    style = jso {
+                        height = "7rem".unsafeCast<Height>()
                     }
 
-                    if (props.permissions.isSuperAdmin ||
+                }
+            }
+
+            div {
+                className = ClassName("col-6")
+                tab(
+                    props.selectedMenu.name,
+                    VulnerabilityTab.values().map { it.name },
+                    "nav nav-tabs mt-3"
+                ) { value -> props.setSelectedMenu { VulnerabilityTab.valueOf(value) } }
+
+                // separate it to button menu
+                div {
+                    className = ClassName("row justify-content-center mt-3")
+                    div {
+                        className = ClassName("d-flex justify-content-end my-2")
+                        if (props.selectedMenu == VulnerabilityTab.INFO) {
+                            buttonBuilder(
+                                if (props.isTableView) faImage else faTable,
+                                "secondary",
+                                classes = "mr-2",
+                                isOutline = true,
+                                title = "Change to ${if (props.isTableView) "card" else "table"} mode"
+                            ) {
+                                props.setIsTableView { !it }
+                            }
+                        }
+
+                        if (props.permissions.isSuperAdmin ||
                             (props.permissions.isOwner && props.vulnerability.status != VulnerabilityStatus.APPROVED)
-                    ) {
-                        buttonBuilder(
-                            faTrash,
-                            "danger",
-                            isOutline = true,
-                            title = "Delete vulnerability",
-                            classes = "mr-2"
                         ) {
-                            deleteVulnerabilityWindowOpenness.openWindow()
+                            buttonBuilder(
+                                faTrash,
+                                "danger",
+                                isOutline = true,
+                                title = "Delete vulnerability",
+                                classes = "mr-2"
+                            ) {
+                                deleteVulnerabilityWindowOpenness.openWindow()
+                            }
                         }
-                    }
 
-                    if (props.permissions.isSuperAdmin && props.vulnerability.status != VulnerabilityStatus.APPROVED) {
-                        buttonBuilder(label = "Approve", classes = "mr-2 btn-sm", style = "success") {
-                            enrollUpdateRequest()
-                        }
-                        buttonBuilder(label = "Reject", classes = "mr-2 btn-sm", style = "warning") {
-                            rejectVulnerabilityWindowOpenness.openWindow()
+                        if (props.permissions.isSuperAdmin && props.vulnerability.status != VulnerabilityStatus.APPROVED) {
+                            buttonBuilder(label = "Approve", classes = "mr-2 btn-sm", style = "success") {
+                                enrollUpdateRequest()
+                            }
+                            buttonBuilder(label = "Reject", classes = "mr-2 btn-sm", style = "warning") {
+                                rejectVulnerabilityWindowOpenness.openWindow()
+                            }
                         }
                     }
                 }
             }
+
+            div {
+                className = ClassName("col-3")
+            }
+
         }
     }
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityHeader.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityHeader.kt
@@ -30,14 +30,11 @@ import react.dom.html.ReactHTML.h6
 import react.dom.html.ReactHTML.textarea
 import react.router.useNavigate
 import react.useState
+import web.cssom.*
 
 import kotlinx.browser.window
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import react.dom.html.ReactHTML.h4
-import react.dom.html.ReactHTML.img
-import web.cssom.*
-import web.cssom.HtmlAttributes.Companion.src
 
 internal val headerMenu: FC<HeaderMenuProps> = FC { props ->
     val rejectVulnerabilityWindowOpenness = useWindowOpenness()
@@ -183,7 +180,6 @@ internal val headerMenu: FC<HeaderMenuProps> = FC { props ->
                     style = jso {
                         height = "7rem".unsafeCast<Height>()
                     }
-
                 }
             }
 
@@ -213,7 +209,7 @@ internal val headerMenu: FC<HeaderMenuProps> = FC { props ->
                         }
 
                         if (props.permissions.isSuperAdmin ||
-                            (props.permissions.isOwner && props.vulnerability.status != VulnerabilityStatus.APPROVED)
+                                (props.permissions.isOwner && props.vulnerability.status != VulnerabilityStatus.APPROVED)
                         ) {
                             buttonBuilder(
                                 faTrash,
@@ -241,7 +237,6 @@ internal val headerMenu: FC<HeaderMenuProps> = FC { props ->
             div {
                 className = ClassName("col-3")
             }
-
         }
     }
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityInfoTab.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityInfoTab.kt
@@ -177,24 +177,23 @@ val vulnerabilityInfoTab: FC<VulnerabilityInfoTabProps> = FC { props ->
         }
     }
 
-    // if dates are empty - we will not show the timeline for non-owners
-    if (props.vulnerability.dates.isNotEmpty() || isAbleToEdit) {
-        timelineComponent {
-            dates = props.vulnerability.getDatesWithLabels()
-            onAddClick = { dateWindowOpenness.openWindow() }
-                .takeIf { isAbleToEdit }
-            onNodeClick = { date: LocalDateTime, type: String ->
-                props.vulnerability.dates
-                    .find { it.type.value == type && it.date == date }
-                    ?.let {
-                        if (window.confirm("Are you sure you want to delete a date?")) {
-                            setDateToDelete(it)
-                        }
+    // this timeline is always shown as we always have at least creation date
+    timelineComponent {
+        this.vulnerability = props.vulnerability
+        dates = props.vulnerability.getDatesWithLabels()
+        onAddClick = { dateWindowOpenness.openWindow() }
+            .takeIf { isAbleToEdit }
+        onNodeClick = { date: LocalDateTime, type: String ->
+            props.vulnerability.dates
+                .find { it.type.value == type && it.date == date }
+                ?.let {
+                    if (window.confirm("Are you sure you want to delete a date?")) {
+                        setDateToDelete(it)
                     }
-                    ?: Unit
-            }
-                .takeIf { isAbleToEdit }
+                }
+                ?: Unit
         }
+            .takeIf { isAbleToEdit }
     }
 
     renderProjects(
@@ -357,11 +356,7 @@ private fun ChildrenBuilder.renderPlaceholder(
         div {
             className = ClassName("d-flex justify-content-center vulnerability-placeholder")
             onClick = { onClickFun() }
-            style = jso {
-                cursor = "pointer".unsafeCast<Cursor>()
-                borderStyle = "dashed".unsafeCast<BorderStyle>()
-                borderWidth = "thin".unsafeCast<BorderWidth>()
-            }
+            style = borderEditStyle(pointerCursor = true)
             fontAwesomeIcon(faPlus, "m-5", "lg")
         }
     } else {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityInfoTab.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityInfoTab.kt
@@ -18,7 +18,6 @@ import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 
-import js.core.jso
 import react.*
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h4

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTagsComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTagsComponent.kt
@@ -87,9 +87,9 @@ val vulnerabilityTagsComponent: FC<VulnerabilityTagsComponentProps> = FC { props
         }
     }
 
-    if (props.canEditVulnerability) {
+    if (props.canEditVulnerability && !props.isEditDisabled) {
         div {
-            className = ClassName("input-group shadow")
+            className = ClassName("input-group shadow mb-1")
             input {
                 className = ClassName("form-control custom-input $validityClassName")
                 value = newTag
@@ -117,7 +117,7 @@ val vulnerabilityTagsComponent: FC<VulnerabilityTagsComponentProps> = FC { props
                 isOutline = true,
                 classes = "rounded-pill text-sm btn-sm mx-1 mt-2"
             ) {
-                if (tagEditable) {
+                if (tagEditable && !props.isEditDisabled) {
                     if (window.confirm("Do you want to remove tag '$tag' from this vulnerability?")) {
                         setTagToDelete(tag)
                     }
@@ -157,4 +157,9 @@ external interface VulnerabilityTagsComponentProps : Props {
      * Current logged-in user
      */
     var userInfo: UserInfo?
+
+    /**
+     * flag to change
+     */
+    var isEditDisabled: Boolean
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityView.kt
@@ -22,15 +22,6 @@ import web.cssom.*
 
 const val HEADER_HEIGHT = "9rem"
 
-fun borderEditStyle(pointerCursor: Boolean = false): CSSProperties = jso {
-    borderColor = "#5711d9".unsafeCast<BorderColor>()
-    borderStyle = "dashed".unsafeCast<BorderStyle>()
-    borderWidth = "thin".unsafeCast<BorderWidth>()
-    if (pointerCursor) {
-        cursor = "pointer".unsafeCast<Cursor>()
-    }
-}
-
 @Suppress(
     "MAGIC_NUMBER",
     "TOO_LONG_FUNCTION",
@@ -185,6 +176,19 @@ private fun ChildrenBuilder.languageSpan(language: VulnerabilityLanguage) {
             borderRadius = "2em".unsafeCast<BorderRadius>()
         }
         +language.value
+    }
+}
+
+/**
+ * @param pointerCursor
+ * @return returns the css for editable text form
+ */
+fun borderEditStyle(pointerCursor: Boolean = false): CSSProperties = jso {
+    borderColor = "#5711d9".unsafeCast<BorderColor>()
+    borderStyle = "dashed".unsafeCast<BorderStyle>()
+    borderWidth = "thin".unsafeCast<BorderWidth>()
+    if (pointerCursor) {
+        cursor = "pointer".unsafeCast<Cursor>()
     }
 }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityView.kt
@@ -22,6 +22,15 @@ import web.cssom.*
 
 const val HEADER_HEIGHT = "9rem"
 
+fun borderEditStyle(pointerCursor: Boolean = false): CSSProperties = jso {
+    borderColor = "#5711d9".unsafeCast<BorderColor>()
+    borderStyle = "dashed".unsafeCast<BorderStyle>()
+    borderWidth = "thin".unsafeCast<BorderWidth>()
+    if (pointerCursor) {
+        cursor = "pointer".unsafeCast<Cursor>()
+    }
+}
+
 @Suppress(
     "MAGIC_NUMBER",
     "TOO_LONG_FUNCTION",
@@ -90,6 +99,7 @@ val vulnerabilityView: FC<VulnerabilitiesViewProps> = FC { props ->
             className = ClassName("col-3 mr-3")
             vulnerabilityGeneralInfo {
                 this.vulnerability = vulnerability
+                this.setVulnerability = setVulnerability
                 this.fetchVulnerability = fetchVulnerability
                 this.canEditVulnerability = permissions.isOwner || permissions.isSuperAdmin || permissions.isParticipant
                 this.userInfo = props.currentUserInfo

--- a/save-frontend/src/main/resources/scss/_utilities.scss
+++ b/save-frontend/src/main/resources/scss/_utilities.scss
@@ -8,3 +8,4 @@
 @import "utilities/particles.scss";
 @import "utilities/_animated-card.scss";
 @import "utilities/_timeline.scss";
+@import "utilities/_ribbon.scss";

--- a/save-frontend/src/main/resources/scss/utilities/_ribbon.scss
+++ b/save-frontend/src/main/resources/scss/utilities/_ribbon.scss
@@ -1,0 +1,63 @@
+.ribbon-parent {
+  overflow: hidden;
+}
+
+.ribbon-approved {
+  margin: 0;
+  padding: 0;
+  background: green;
+  color:white;
+  padding:1em 0;
+  position: absolute;
+  top:0;
+  right:0;
+  transform: translateX(30%) translateY(0%) rotate(45deg);
+  transform-origin: top left;
+}
+.ribbon-approved:before,
+.ribbon-approved:after {
+  content: '';
+  position: absolute;
+  top:0;
+  margin: 0 -1px;
+  width: 100%;
+  height: 100%;
+  background: green;
+}
+.ribbon-approved:before {
+  right:100%;
+}
+
+.ribbon-approved:after {
+  left:100%;
+}
+
+.ribbon-not-approved {
+  margin: 0;
+  padding: 0;
+  background: #dc3545;
+  color:white;
+  padding:1em 0;
+  position: absolute;
+  top:0;
+  right:0;
+  transform: translateX(30%) translateY(0%) rotate(45deg);
+  transform-origin: top left;
+}
+.ribbon-not-approved:before,
+.ribbon-not-approved:after {
+  content: '';
+  position: absolute;
+  top:0;
+  margin: 0 -1px;
+  width: 100%;
+  height: 100%;
+  background: #dc3545;
+}
+.ribbon-not-approved:before {
+  right:100%;
+}
+
+.ribbon-not-approved:after {
+  left:100%;
+}

--- a/save-frontend/src/main/resources/scss/utilities/_timeline.scss
+++ b/save-frontend/src/main/resources/scss/utilities/_timeline.scss
@@ -23,6 +23,22 @@ $color-label-default: #0275d8;
     align-items: center;
     justify-content: center;
 
+
+    .step-non-editable {
+      transition: 0.4s;
+      z-index: 1;
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-grow: 0;
+      height: 1.5rem;
+      width: 1.5rem;
+      border: 0.2rem solid $color-line;
+      border-radius: 50%;
+      background: $color-line;
+    }
+
     .step {
       transition: 0.4s;
       z-index: 1;
@@ -31,8 +47,8 @@ $color-label-default: #0275d8;
       align-items: center;
       justify-content: center;
       flex-grow: 0;
-      height: 1.6rem;
-      width: 1.6rem;
+      height: 1.5rem;
+      width: 1.5rem;
       border: 0.2rem solid $color-step;
       border-radius: 50%;
       background: white;


### PR DESCRIPTION
### What's done:
- Minor Spring Security Timeout update (not tested)
- Propagating edit button actions to have a common editable page
- Adding creation date to timeline (so it's always shown)
- Adding ribbon for approved/not approved
- Fix for editing short and long description
- Minor fixes

https://github.com/saveourtool/save-cloud/assets/58667063/c2b7c74c-1c54-4490-a621-5113ddfca1fb


