### PR TITLE
Hotfix for gateway user status check

### DIFF
--- a/api-gateway/src/main/kotlin/com/saveourtool/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/com/saveourtool/save/gateway/security/WebSecurityConfig.kt
@@ -4,7 +4,6 @@
 
 package com.saveourtool.save.gateway.security
 
-import com.saveourtool.save.authservice.utils.*
 import com.saveourtool.save.gateway.config.ConfigurationProperties
 import com.saveourtool.save.gateway.service.BackendService
 import com.saveourtool.save.gateway.utils.StoringServerAuthenticationSuccessHandler
@@ -43,6 +42,7 @@ import reactor.kotlin.core.publisher.cast
  */
 internal val allowedForInactiveEndpoints = listOf(
     "/api/$v1/users/*",
+    "/api/$v1/avatar/**"
 )
 
 @EnableWebFluxSecurity
@@ -82,10 +82,7 @@ class WebSecurityConfig(
                 // backend returns 401 for those endpoints that require authentication
                 .pathMatchers(*allowedForInactiveEndpoints.toTypedArray()).access(::defaultAuthorizationDecision)
                 .pathMatchers("/api/**").access { authorization, authorizationContext ->
-                    authorization.flatMap { backendService.findByName(it.name) }
-                        .filter { it.isEnabled }
-                        .flatMap { defaultAuthorizationDecision(authorization, authorizationContext) }
-                        .defaultIfEmpty(AuthorizationDecision(false))
+                    userStatusBasedAuthorizationDecision(backendService, authorization, authorizationContext)
                 }
                 // resources for frontend
                 .pathMatchers("/*.html", "/*.js*", "/*.css", "/img/**", "/*.ico", "/*.png", "/particles.json")
@@ -164,6 +161,17 @@ class WebSecurityConfig(
     )
 }
 
+private fun Mono<AuthorizationDecision>.mapForUnauthorized(authorizationContext: AuthorizationContext) = map {
+    if (!it.isGranted) {
+        // if request is not authorized by configured authorization manager, then we allow only requests w/o Authorization header
+        // then backend will return 401, if endpoint is protected for anonymous access
+        val hasAuthorizationHeader = authorizationContext.exchange.request.headers[HttpHeaders.AUTHORIZATION].isNullOrEmpty()
+        AuthorizationDecision(hasAuthorizationHeader)
+    } else {
+        it
+    }
+}
+
 /**
  * @return a bean with default [PasswordEncoder], that can be used throughout the application
  */
@@ -177,18 +185,25 @@ fun passwordEncoder(): PasswordEncoder = PasswordEncoderFactories.createDelegati
  * @param authorizationContext
  * @return [Mono] of [AuthorizationDecision]
  */
-private fun defaultAuthorizationDecision(
+private fun authorizationManagerAuthorizationDecision(
     authentication: Mono<Authentication>,
     authorizationContext: AuthorizationContext,
 ): Mono<AuthorizationDecision> = AuthenticatedReactiveAuthorizationManager.authenticated<AuthorizationContext>().check(
     authentication, authorizationContext
-).map {
-    if (!it.isGranted) {
-        // if request is not authorized by configured authorization manager, then we allow only requests w/o Authorization header
-        // then backend will return 401, if endpoint is protected for anonymous access
-        val hasAuthorizationHeader = authorizationContext.exchange.request.headers[HttpHeaders.AUTHORIZATION].isNullOrEmpty()
-        AuthorizationDecision(hasAuthorizationHeader)
-    } else {
-        it
-    }
-}
+)
+
+private fun defaultAuthorizationDecision(
+    authorization: Mono<Authentication>,
+    authorizationContext: AuthorizationContext,
+) = authorizationManagerAuthorizationDecision(authorization, authorizationContext)
+    .mapForUnauthorized(authorizationContext)
+
+private fun userStatusBasedAuthorizationDecision(
+    backendService: BackendService,
+    authorization: Mono<Authentication>,
+    authorizationContext: AuthorizationContext,
+) = authorization.flatMap { backendService.findByName(it.name) }
+    .filter { it.isEnabled }
+    .flatMap { authorizationManagerAuthorizationDecision(authorization, authorizationContext) }
+    .defaultIfEmpty(AuthorizationDecision(false))
+    .mapForUnauthorized(authorizationContext)


### PR DESCRIPTION
### What's done:
 * Added `/api/$v1/avatar/**` to `allowedForInactiveEndpoints`
 * Supported unauthorized users in gateway `WebSecurityConfig`