### PR TITLE
Hotfix for agent setup.sh execution

### DIFF
--- a/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/SaveAgent.kt
+++ b/save-agent/src/commonMain/kotlin/com/saveourtool/save/agent/SaveAgent.kt
@@ -98,16 +98,15 @@ class SaveAgent(
         additionalFileNames
             .singleOrNull { it == "setup.sh" }
             ?.let { fileName ->
-                val targetFile = targetDirectory / fileName
-                logDebugCustom("Additionally setup of evaluated tool by $targetFile")
+                logDebugCustom("Additionally setup of evaluated tool by $fileName")
                 val setupResult = ProcessBuilder(true, fs)
                     .exec(
-                        "./$targetFile",
+                        "./$fileName",
                         // setup.sh should always be run from test-suites dir
-                        TEST_SUITES_DIR_NAME,
+                        TEST_SUITES_DIR_NAME,  // <- cd test-suites/
                         null,
                         setupShTimeoutMillis,
-                    )
+                    )  // < - cd test-suites && ./setup.sh
                 if (setupResult.code != 0) {
                     throw IllegalStateException("$fileName} is failed with error: ${setupResult.stderr}")
                 }


### PR DESCRIPTION
### What's done:
- Setup.sh will be executed only from `TEST_SUITES_DIR_NAME`