### PR TITLE
Hotfix for registration redirect for first rendering

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/RegistrationView.kt
@@ -59,7 +59,7 @@ val registrationView: FC<RegistrationProps> = FC { props ->
     particles()
     val useNavigate = useNavigate()
 
-    if (props.userInfo?.status != UserStatus.NOT_APPROVED) {
+    if (props.userInfo?.status == UserStatus.ACTIVE) {
         useNavigate(to = "/")
     }
 


### PR DESCRIPTION
### What's done:
- When status is undefined on first rendering we make a loop of redirections