### PR TITLE
Set first 35 letters of details as summary

### DIFF
--- a/db/v-2/tables/vulnerability-metadata.xml
+++ b/db/v-2/tables/vulnerability-metadata.xml
@@ -19,4 +19,11 @@
         <modifyDataType tableName="vulnerability_metadata" columnName="severity_num" newDataType="DECIMAL(2,1)"/>
     </changeSet>
 
+    <changeSet id="vulnerability-metadata-4" author="nulls">
+        <update tableName="vulnerability_metadata">
+            <column name="summary" valueComputed="left(details, 35)"/>
+            <where>summary = 'Summary not provided' and details &lt;&gt; 'Details not provided'</where>
+        </update>
+    </changeSet>
+
 </databaseChangeLog>

--- a/save-cosv/src/main/kotlin/com/saveourtool/save/cosv/service/VulnerabilityMetadataService.kt
+++ b/save-cosv/src/main/kotlin/com/saveourtool/save/cosv/service/VulnerabilityMetadataService.kt
@@ -96,6 +96,8 @@ class VulnerabilityMetadataService(
         private val logger = getLogger<VulnerabilityMetadataService>()
         private const val VULNERABILITY_ORGANIZATION_RATING = 10
         private const val VULNERABILITY_OWNER_RATING = 10
+        private const val SUMMARY_LENGTH_FROM_DETAILS = 35
+
         private fun CosvSchema<*, *, *, *>.toNewMetadata(
             user: User,
             organization: Organization?,
@@ -103,7 +105,7 @@ class VulnerabilityMetadataService(
             isAutoApprove: Boolean,
         ) = VulnerabilityMetadata(
             identifier = id,
-            summary = summary ?: "Summary not provided",
+            summary = summary ?: details?.take(SUMMARY_LENGTH_FROM_DETAILS) ?: "Summary not provided",
             details = details ?: "Details not provided",
             severityNum = severity?.firstOrNull()?.let { getScore(it) } ?: 0f,
             modified = modified.toJavaLocalDateTime(),
@@ -165,7 +167,7 @@ class VulnerabilityMetadataService(
             cosvFile: CosvFile,
             isAutoApprove: Boolean,
         ): VulnerabilityMetadata = apply {
-            summary = entry.summary ?: "Summary not provided"
+            summary = entry.summary ?: entry.details?.take(SUMMARY_LENGTH_FROM_DETAILS) ?: "Summary not provided"
             details = entry.details ?: "Details not provided"
             severityNum = entry.severity?.firstOrNull()
                 ?.scoreNum

--- a/save-cosv/src/main/kotlin/com/saveourtool/save/cosv/service/VulnerabilityMetadataService.kt
+++ b/save-cosv/src/main/kotlin/com/saveourtool/save/cosv/service/VulnerabilityMetadataService.kt
@@ -94,9 +94,9 @@ class VulnerabilityMetadataService(
     companion object {
         @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
         private val logger = getLogger<VulnerabilityMetadataService>()
+        private const val SUMMARY_LENGTH_FROM_DETAILS = 35
         private const val VULNERABILITY_ORGANIZATION_RATING = 10
         private const val VULNERABILITY_OWNER_RATING = 10
-        private const val SUMMARY_LENGTH_FROM_DETAILS = 35
 
         private fun CosvSchema<*, *, *, *>.toNewMetadata(
             user: User,


### PR DESCRIPTION
### What's done:
- Set first 35 letters of details as summary on creating or updating metadata
- Update database

It closes #2645