### PR TITLE
Fixed long usernames don't fit into their placeholders.

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/StringUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/StringUtils.kt
@@ -17,11 +17,17 @@ fun List<String>?.listToShortString(): String = this?.run {
 }.orEmpty()
 
 /**
+ * @param maxLength
+ * @return short [String] for text
+ */
+fun String.shorten(maxLength: Int): String = substring(0, maxLength - 1) + "..."
+
+/**
  * @return short [String] for login
  */
-fun String?.shortenLogin(): String = this?.substring(0, LOGIN_MAX_LENGTH - 1) + "..."
+fun String.shortenLogin(): String = shorten(LOGIN_MAX_LENGTH)
 
 /**
  * @return short [String] for real name
  */
-fun String?.shortenRealName(): String = this?.substring(0, REAL_NAME_PART_MAX_LENGTH - 1) + "..."
+fun String.shortenRealName(): String = shorten(REAL_NAME_PART_MAX_LENGTH)

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/StringUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/StringUtils.kt
@@ -2,6 +2,9 @@
 
 package com.saveourtool.save.utils
 
+const val LOGIN_MAX_LENGTH = 14
+const val REAL_NAME_PART_MAX_LENGTH = 20
+
 /**
  * @return short [String] for list values
  */
@@ -12,3 +15,13 @@ fun List<String>?.listToShortString(): String = this?.run {
         "${first()} ... ${last()}"
     }
 }.orEmpty()
+
+/**
+ * @return short [String] for login
+ */
+fun String?.shortenLogin(): String = this?.substring(0, LOGIN_MAX_LENGTH - 1) + "..."
+
+/**
+ * @return short [String] for real name
+ */
+fun String?.shortenRealName(): String = this?.substring(0, REAL_NAME_PART_MAX_LENGTH - 1) + "..."

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/ValidationUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/validation/ValidationUtils.kt
@@ -94,4 +94,4 @@ private fun String.hasOnlyAlphaNumOrAllowedSpecialSymbols(
 private fun String.containsForbiddenWords() = (FrontendRoutes.getForbiddenWords() + BackendRoutes.getForbiddenWords())
     .any { this == it }
 
-private fun String.isLengthOk(allowedLength: Int) = length < allowedLength
+private fun String.isLengthOk(allowedLength: Int) = length <= allowedLength

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileView.kt
@@ -23,6 +23,7 @@ import com.saveourtool.save.validation.FrontendRoutes
 import js.core.jso
 import react.*
 import react.dom.aria.ariaDescribedBy
+import react.dom.html.HTMLAttributes
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h3
@@ -35,6 +36,7 @@ import react.dom.html.ReactHTML.textarea
 import react.router.dom.Link
 import react.router.useNavigate
 import web.cssom.*
+import web.html.HTMLHeadingElement
 import web.html.InputType
 
 val userProfileView: FC<UserProfileViewProps> = FC { props ->
@@ -267,12 +269,12 @@ fun ChildrenBuilder.renderLeftUserMenu(
 
     h3 {
         className = ClassName("mb-0 text-gray-900 text-center")
-        +(user?.name ?: "N/A")
+        validateName(user?.name, this)
     }
 
     h5 {
         className = ClassName("mb-0 text-gray-600 text-center")
-        +(user?.realName ?: "N/A")
+        validateRealName(user?.realName, this)
     }
 
     div {
@@ -369,6 +371,42 @@ fun ChildrenBuilder.renderLeftUserMenu(
             }
         }
     }
+}
+
+/**
+ * @param name
+ * @param header
+ */
+fun ChildrenBuilder.validateName(name: String?, header: HTMLAttributes<HTMLHeadingElement>) {
+    name?.let {
+        if (it.length > 14) {
+            asDynamic()["data-toggle"] = "tooltip"
+            asDynamic()["data-placement"] = "bottom"
+            header.title = it
+
+            +(it.substring(0, 13) + "...")
+        } else {
+            +it
+        }
+    } ?: "N/A"
+}
+
+/**
+ * @param realName
+ * @param header
+ */
+fun ChildrenBuilder.validateRealName(realName: String?, header: HTMLAttributes<HTMLHeadingElement>) {
+    realName?.let {
+        if (it.split(" ").any { namePart -> namePart.length > 20 }) {
+            asDynamic()["data-toggle"] = "tooltip"
+            asDynamic()["data-placement"] = "bottom"
+            header.title = it
+
+            +(it.substring(0, 19) + "...")
+        } else {
+            +it
+        }
+    } ?: "N/A"
 }
 
 /**

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileView.kt
@@ -18,6 +18,10 @@ import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.info.UserStatus
+import com.saveourtool.save.utils.LOGIN_MAX_LENGTH
+import com.saveourtool.save.utils.REAL_NAME_PART_MAX_LENGTH
+import com.saveourtool.save.utils.shortenLogin
+import com.saveourtool.save.utils.shortenRealName
 import com.saveourtool.save.validation.FrontendRoutes
 
 import js.core.jso
@@ -269,12 +273,12 @@ fun ChildrenBuilder.renderLeftUserMenu(
 
     h3 {
         className = ClassName("mb-0 text-gray-900 text-center")
-        validateName(user?.name, this)
+        shortenLoginWithTooltipIfNecessary(user?.name, this)
     }
 
     h5 {
         className = ClassName("mb-0 text-gray-600 text-center")
-        validateRealName(user?.realName, this)
+        shortenRealNameWithTooltipIfNecessary(user?.realName, this)
     }
 
     div {
@@ -374,39 +378,39 @@ fun ChildrenBuilder.renderLeftUserMenu(
 }
 
 /**
- * @param name
+ * @param login
  * @param header
  */
-fun ChildrenBuilder.validateName(name: String?, header: HTMLAttributes<HTMLHeadingElement>) {
-    name?.let {
-        if (it.length > 14) {
+fun ChildrenBuilder.shortenLoginWithTooltipIfNecessary(login: String?, header: HTMLAttributes<HTMLHeadingElement>) {
+    login?.let {
+        if (it.length > LOGIN_MAX_LENGTH) {
             asDynamic()["data-toggle"] = "tooltip"
-            asDynamic()["data-placement"] = "bottom"
+            asDynamic()["data-placement"] = "top"
             header.title = it
 
-            +(it.substring(0, 13) + "...")
+            +(it.shortenLogin())
         } else {
             +it
         }
-    } ?: "N/A"
+    } ?: +"N/A"
 }
 
 /**
  * @param realName
  * @param header
  */
-fun ChildrenBuilder.validateRealName(realName: String?, header: HTMLAttributes<HTMLHeadingElement>) {
-    realName?.let {
-        if (it.split(" ").any { namePart -> namePart.length > 20 }) {
+fun ChildrenBuilder.shortenRealNameWithTooltipIfNecessary(realName: String?, header: HTMLAttributes<HTMLHeadingElement>) {
+    realName?.let { name ->
+        if (name.split(" ").any { it.length > REAL_NAME_PART_MAX_LENGTH }) {
             asDynamic()["data-toggle"] = "tooltip"
             asDynamic()["data-placement"] = "bottom"
-            header.title = it
+            header.title = name
 
-            +(it.substring(0, 19) + "...")
+            +(name.shortenRealName())
         } else {
-            +it
+            +name
         }
-    } ?: "N/A"
+    } ?: +"N/A"
 }
 
 /**

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsViewLeftColumn.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsViewLeftColumn.kt
@@ -5,8 +5,8 @@
 package com.saveourtool.save.frontend.components.views.usersettings
 
 import com.saveourtool.save.frontend.components.basic.avatarRenderer
-import com.saveourtool.save.frontend.components.views.userprofile.validateName
-import com.saveourtool.save.frontend.components.views.userprofile.validateRealName
+import com.saveourtool.save.frontend.components.views.userprofile.shortenLoginWithTooltipIfNecessary
+import com.saveourtool.save.frontend.components.views.userprofile.shortenRealNameWithTooltipIfNecessary
 import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.validation.FrontendRoutes
@@ -66,14 +66,14 @@ val leftSettingsColumn: FC<SettingsProps> = FC { props ->
                                     className = ClassName("row justify-content-center")
                                     h4 {
                                         className = ClassName("mb-0 text-gray-800")
-                                        validateName(props.userInfo?.name, this)
+                                        shortenLoginWithTooltipIfNecessary(props.userInfo?.name, this)
                                     }
                                 }
                                 div {
                                     className = ClassName("row justify-content-center")
                                     h6 {
                                         className = ClassName("mb-0 text-gray-800")
-                                        validateRealName(props.userInfo?.realName, this)
+                                        shortenRealNameWithTooltipIfNecessary(props.userInfo?.realName, this)
                                     }
                                 }
                                 div {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsViewLeftColumn.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/usersettings/SettingsViewLeftColumn.kt
@@ -5,6 +5,8 @@
 package com.saveourtool.save.frontend.components.views.usersettings
 
 import com.saveourtool.save.frontend.components.basic.avatarRenderer
+import com.saveourtool.save.frontend.components.views.userprofile.validateName
+import com.saveourtool.save.frontend.components.views.userprofile.validateRealName
 import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.validation.FrontendRoutes
@@ -64,14 +66,14 @@ val leftSettingsColumn: FC<SettingsProps> = FC { props ->
                                     className = ClassName("row justify-content-center")
                                     h4 {
                                         className = ClassName("mb-0 text-gray-800")
-                                        +(props.userInfo?.name ?: "")
+                                        validateName(props.userInfo?.name, this)
                                     }
                                 }
                                 div {
                                     className = ClassName("row justify-content-center")
                                     h6 {
                                         className = ClassName("mb-0 text-gray-800")
-                                        +(props.userInfo?.realName.orEmpty())
+                                        validateRealName(props.userInfo?.realName, this)
                                     }
                                 }
                                 div {


### PR DESCRIPTION
### What's done:
- `isLengthOk` function has been changed so that in boundary cases number of characters matches maximum allowed length.
- added `shortenLoginWithTooltipIfNecessary` and `shortenRealNameWithTooltipIfNecessary` functions for names validation into their placeholders, which are in UserProfileView and SettingsView.
- added `shorten` function to shorten any string.
- added `shortenLogin` and `shortenRealName` functions to shorten strings of login and real name.

Closes #1195

![image](https://github.com/saveourtool/save-cloud/assets/29813548/bf0de6cd-9c15-41be-b6b2-cd9730e9708a)
![image](https://github.com/saveourtool/save-cloud/assets/29813548/bead975e-f83e-41a9-add3-090f8fc9057b)
![image](https://github.com/saveourtool/save-cloud/assets/29813548/659c68be-b99c-4e21-8757-c04a839f5a80)

