### PR TITLE
Rename "Author" -> "COSV Submitter" in the UI

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/table/filters/VulnerabilitiesFiltersRow.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/table/filters/VulnerabilitiesFiltersRow.kt
@@ -85,7 +85,7 @@ val vulnerabilitiesFiltersRow: FC<VulnerabilitiesFiltersProps> = FC { props ->
                         getUrlForOptionsFetch = { prefix ->
                             "$apiUrl/users/by-prefix?prefix=$prefix&pageSize=$DROPDOWN_OPTIONS_AMOUNT"
                         }
-                        placeholder = "${"Author".t()}..."
+                        placeholder = "${"COSV Submitter".t()}..."
                         renderOption = ::renderUserWithAvatar
                         onOptionClick = { newUser ->
                             setUser(newUser)

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityCollectionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityCollectionView.kt
@@ -118,7 +118,7 @@ val vulnerabilityCollectionView: FC<VulnerabilityCollectionViewProps> = FC { pro
                             }
                         }
                     }
-                    column(id = "user", header = "Author".t(), { user.name }) { cellContext ->
+                    column(id = "user", header = "COSV Submitter".t(), { user.name }) { cellContext ->
                         Fragment.create {
                             td {
                                 className = ClassName("align-middle")

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfoProps.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfoProps.kt
@@ -187,7 +187,7 @@ val vulnerabilityGeneralInfoProps: FC<VulnerabilityGeneralInfoProps> = FC { prop
                     hr { }
                     h6 {
                         className = ClassName("font-weight-bold text-primary-blue mb-3")
-                        +"Author".t()
+                        +"COSV Submitter".t()
                     }
                     renderUserAvatarWithName(this@run, isHorizontal = true, classes = "mr-2") {
                         height = 4.rem

--- a/save-frontend/src/main/resources/locales/cn/table-headers.json
+++ b/save-frontend/src/main/resources/locales/cn/table-headers.json
@@ -3,7 +3,7 @@
   "Identifier": "编号",
   "Organization": "组织",
   "Description": "描述",
-  "Author": "作者",
+  "COSV Submitter": "作者",
   "Criticality": "危险程度",
   "Language": "语言",
   "Status": "状态",

--- a/save-frontend/src/main/resources/locales/cn/vulnerability.json
+++ b/save-frontend/src/main/resources/locales/cn/vulnerability.json
@@ -17,7 +17,7 @@
   "Details": "描述",
   "Tags": "标签",
   "References": "相关链接",
-  "Author": "作者",
+  "COSV Submitter": "作者",
   "Organization": "组织",
   "Credits": "合作者",
   "Add a new tag...": "添加一个新标签",

--- a/save-frontend/src/main/resources/locales/en/table-headers.json
+++ b/save-frontend/src/main/resources/locales/en/table-headers.json
@@ -3,7 +3,7 @@
   "Identifier": "Identifier",
   "Organization": "Organization",
   "Description": "Description",
-  "Author": "Author",
+  "COSV Submitter": "COSV Submitter",
   "Criticality": "Criticality",
   "Language": "Language",
   "Status": "Status",

--- a/save-frontend/src/main/resources/locales/en/vulnerability.json
+++ b/save-frontend/src/main/resources/locales/en/vulnerability.json
@@ -17,7 +17,7 @@
   "Description": "Description",
   "Tags": "Tags",
   "Related link": "Related link",
-  "Author": "Author",
+  "COSV Submitter": "COSV Submitter",
   "Organization": "Organization",
   "Collaborators": "Collaborators",
   "Add a new tag...": "Add a new tag...",

--- a/save-frontend/src/main/resources/locales/ru/table-headers.json
+++ b/save-frontend/src/main/resources/locales/ru/table-headers.json
@@ -3,7 +3,7 @@
   "Identifier": "Идентификатор",
   "Organization": "Организация",
   "Description": "Описание",
-  "Author": "Автор",
+  "COSV Submitter": "Автор отчёта в COSV",
   "Criticality": "Критичность",
   "Language": "Язык",
   "Status": "Статус",

--- a/save-frontend/src/main/resources/locales/ru/vulnerability.json
+++ b/save-frontend/src/main/resources/locales/ru/vulnerability.json
@@ -17,7 +17,7 @@
   "Details": "Описание",
   "Tags": "Теги",
   "References": "Связанная ссылка",
-  "Author": "Автор",
+  "COSV Submitter": "Автор отчёта в COSV",
   "Organization": "Организация",
   "Credits": "Соавторы",
   "Add a new tag...": "Добавить тег...",


### PR DESCRIPTION
### What's done:

 - "Author" renamed, both as the key and as the translated string.
 - Chinese (CN) translation left intact.
 
#### Change 1 

![image](https://github.com/saveourtool/save-cloud/assets/73111822/327638b9-9985-412e-b7b8-cbaffbb72f2f)

#### Change 2

![image](https://github.com/saveourtool/save-cloud/assets/73111822/52873066-5d3b-4ce2-8a0a-279b9434132d)

