### PR TITLE
Make sure the "Edit" button has an i18n-ed label

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
@@ -88,3 +88,9 @@ const val DEFAULT_SETUP_SH_TIMEOUT_MILLIS: Long = 60_000L
  * directory with the default avatars package
  */
 const val AVATARS_PACKS_DIR: String = "/img/avatar_packs"
+
+/**
+ * `NO-BREAK SPACE` (U+00A0).
+ */
+@Suppress("NON_EXPORTABLE_TYPE")
+const val NO_BREAK_SPACE = '\u00a0'

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfoProps.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfoProps.kt
@@ -9,6 +9,7 @@ import com.saveourtool.save.frontend.externals.fontawesome.*
 import com.saveourtool.save.frontend.externals.i18next.useTranslation
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
+import com.saveourtool.save.utils.NO_BREAK_SPACE
 import com.saveourtool.save.utils.getRelatedLink
 import com.saveourtool.save.utils.toUnixCalendarFormat
 
@@ -71,7 +72,7 @@ val vulnerabilityGeneralInfoProps: FC<VulnerabilityGeneralInfoProps> = FC { prop
                                         style = jso {
                                             textDecoration = underline
                                         }
-                                        +"Edit ".t()
+                                        +("Edit".t() + NO_BREAK_SPACE)
                                         fontAwesomeIcon(icon = faEdit)
                                     }
                                 },


### PR DESCRIPTION
### What's done:

 - Now, the button's label changes according to the UI locale currently selected.
 - The trailing space is not a part of the translation.
 

![image](https://github.com/saveourtool/save-cloud/assets/73111822/71fcfc53-3866-4e60-8795-c10264082d26)

![image](https://github.com/saveourtool/save-cloud/assets/73111822/6ce86c27-21a9-4452-9751-748dcfa697b7)

