### PR TITLE
Shorten the `VulnerabilityMetadata.summary` if it exceeds the maximum allowed length

### DIFF
--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/cosv/VulnerabilityMetadataDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/entities/cosv/VulnerabilityMetadataDto.kt
@@ -54,4 +54,13 @@ data class VulnerabilityMetadataDto(
         creationDateTime = submitted,
         lastUpdatedDateTime = modified,
     )
+
+    companion object {
+        /**
+         * The maximum length of [summary] (and of `VulnerabilityMetadata.summary`).
+         *
+         * Should be consistent with _Liquibase_ definitions (`varchar(250)`).
+         */
+        const val SUMMARY_LENGTH = 250
+    }
 }

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/Constants.kt
@@ -94,3 +94,9 @@ const val AVATARS_PACKS_DIR: String = "/img/avatar_packs"
  */
 @Suppress("NON_EXPORTABLE_TYPE")
 const val NO_BREAK_SPACE = '\u00a0'
+
+/**
+ * Horizontal Ellipsis (U+2026).
+ */
+@Suppress("NON_EXPORTABLE_TYPE")
+const val ELLIPSIS = '\u2026'

--- a/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/StringUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/com/saveourtool/save/utils/StringUtils.kt
@@ -1,6 +1,9 @@
+@file:JvmName("StringUtils")
 @file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
 
 package com.saveourtool.save.utils
+
+import kotlin.jvm.JvmName
 
 const val LOGIN_MAX_LENGTH = 14
 const val REAL_NAME_PART_MAX_LENGTH = 20
@@ -17,10 +20,28 @@ fun List<String>?.listToShortString(): String = this?.run {
 }.orEmpty()
 
 /**
- * @param maxLength
- * @return short [String] for text
+ * If necessary, shortens the receiver to have the maximum length of
+ * [maxLength], replacing the last character with [ELLIPSIS].
+ *
+ * @receiver the string to truncate.
+ * @param maxLength the maximum length the truncated string should have.
+ * @return the truncated string.
+ * @see ELLIPSIS
  */
-fun String.shorten(maxLength: Int): String = substring(0, maxLength - 1) + "..."
+fun String.shorten(maxLength: Int): String {
+    require(maxLength >= 1) {
+        "maxLength should be >= 1: $maxLength"
+    }
+
+    return when {
+        length <= maxLength -> this
+        else -> asSequence().joinToString(
+            separator = "",
+            limit = maxLength - 1,
+            truncated = ELLIPSIS.toString(),
+        )
+    }
+}
 
 /**
  * @return short [String] for login

--- a/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/cosv/VulnerabilityMetadata.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/com/saveourtool/save/entities/cosv/VulnerabilityMetadata.kt
@@ -2,6 +2,7 @@ package com.saveourtool.save.entities.cosv
 
 import com.saveourtool.save.entities.Organization
 import com.saveourtool.save.entities.User
+import com.saveourtool.save.entities.cosv.VulnerabilityMetadataDto.Companion.SUMMARY_LENGTH
 import com.saveourtool.save.entities.vulnerability.VulnerabilityLanguage
 import com.saveourtool.save.entities.vulnerability.VulnerabilityStatus
 import com.saveourtool.save.spring.entity.BaseEntityWithDto
@@ -28,6 +29,7 @@ import kotlinx.datetime.toKotlinLocalDateTime
 @Suppress("LongParameterList")
 class VulnerabilityMetadata(
     var identifier: String,
+    @Column(length = SUMMARY_LENGTH)
     var summary: String,
     var details: String,
     var severityNum: Float,

--- a/save-cosv/src/main/kotlin/com/saveourtool/save/cosv/service/VulnerabilityMetadataService.kt
+++ b/save-cosv/src/main/kotlin/com/saveourtool/save/cosv/service/VulnerabilityMetadataService.kt
@@ -9,11 +9,15 @@ import com.saveourtool.save.entities.Organization
 import com.saveourtool.save.entities.User
 import com.saveourtool.save.entities.cosv.CosvFile
 import com.saveourtool.save.entities.cosv.VulnerabilityMetadata
+import com.saveourtool.save.entities.cosv.VulnerabilityMetadataDto
+import com.saveourtool.save.entities.cosv.VulnerabilityMetadataDto.Companion.SUMMARY_LENGTH
 import com.saveourtool.save.entities.vulnerability.VulnerabilityLanguage
 import com.saveourtool.save.entities.vulnerability.VulnerabilityStatus
+import com.saveourtool.save.utils.ELLIPSIS
 import com.saveourtool.save.utils.getCurrentLocalDateTime
 import com.saveourtool.save.utils.getLanguage
 import com.saveourtool.save.utils.getLogger
+import com.saveourtool.save.utils.shorten
 import com.saveourtool.save.utils.warn
 
 import com.saveourtool.osv4k.Severity
@@ -72,6 +76,10 @@ class VulnerabilityMetadataService(
     companion object {
         @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
         private val logger = getLogger<VulnerabilityMetadataService>()
+
+        /**
+         * Should not exceed [VulnerabilityMetadataDto.SUMMARY_LENGTH].
+         */
         private const val SUMMARY_LENGTH_FROM_DETAILS = 35
 
         private fun CosvSchema<*, *, *, *>.toNewMetadata(
@@ -143,7 +151,7 @@ class VulnerabilityMetadataService(
             cosvFile: CosvFile,
             isAutoApprove: Boolean,
         ): VulnerabilityMetadata = apply {
-            summary = entry.summary ?: entry.details?.take(SUMMARY_LENGTH_FROM_DETAILS)?.let { "$it ..." } ?: "Summary not provided"
+            summary = entry.summary?.shorten(SUMMARY_LENGTH) ?: entry.details?.take(SUMMARY_LENGTH_FROM_DETAILS)?.let { "$it$ELLIPSIS" } ?: "Summary not provided"
             details = entry.details ?: "Details not provided"
             severityNum = entry.severity?.firstOrNull()?.let { getScore(it) } ?: 0f
             modified = entry.modified.toJavaLocalDateTime()

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/ExecutionView.kt
@@ -32,6 +32,7 @@ import com.saveourtool.save.frontend.http.getDebugInfoFor
 import com.saveourtool.save.frontend.http.getExecutionInfoFor
 import com.saveourtool.save.frontend.themes.Colors
 import com.saveourtool.save.frontend.utils.*
+import com.saveourtool.save.utils.ELLIPSIS
 
 import js.core.jso
 import org.w3c.fetch.Headers
@@ -54,11 +55,6 @@ import kotlinx.serialization.json.Json
  * The maximum length of a test name (in chars), before it gets shortened.
  */
 private const val MAX_TEST_NAME_LENGTH = 35
-
-/**
- * Horizontal Ellipsis (U+2026).
- */
-private const val ELLIPSIS = '\u2026'
 
 /**
  * The infix of the shortened text label.

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfoProps.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityGeneralInfoProps.kt
@@ -1,6 +1,7 @@
 package com.saveourtool.save.frontend.components.views.vuln
 
 import com.saveourtool.save.entities.cosv.VulnerabilityExt
+import com.saveourtool.save.entities.cosv.VulnerabilityMetadataDto.Companion.SUMMARY_LENGTH
 import com.saveourtool.save.entities.vulnerability.VulnerabilityStatus
 import com.saveourtool.save.frontend.components.basic.renderAvatar
 import com.saveourtool.save.frontend.components.basic.renderUserAvatarWithName
@@ -11,6 +12,7 @@ import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.utils.NO_BREAK_SPACE
 import com.saveourtool.save.utils.getRelatedLink
+import com.saveourtool.save.utils.shorten
 import com.saveourtool.save.utils.toUnixCalendarFormat
 
 import js.core.jso
@@ -93,7 +95,7 @@ val vulnerabilityGeneralInfoProps: FC<VulnerabilityGeneralInfoProps> = FC { prop
                     onChange = { event ->
                         props.setVulnerability { vulnerability ->
                             vulnerability?.copy(
-                                cosv = cosv.copy(summary = event.target.value)
+                                cosv = cosv.copy(summary = event.target.value.shorten(SUMMARY_LENGTH))
                             )
                         }
                     }


### PR DESCRIPTION
### What's done:

 - The check is implemented on both the front-end and the back-end side.
 - No more SQL exceptions when attempting to store a long summary.
 - If the text exceeds the length (currently, 250 chars), then the Unicode Ellipsis (U+2026) is appended to the truncated string.