### PR TITLE
Fix rendering of static avatars on the Organization Settings page

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/AvatarRenderers.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/AvatarRenderers.kt
@@ -26,9 +26,38 @@ import web.cssom.rem
 const val AVATAR_ORGANIZATION_PLACEHOLDER = "/img/company.png"
 
 /**
- * links to avatars: "/img" for static resources, "/api" for uploaded
+ * The base URL for uploaded avatars.
  */
-fun String.avatarRenderer() = if (this.startsWith("/img")) this else "/api/$v1/avatar/$this"
+const val AVATAR_BASE_URL = "/api/$v1/avatar"
+
+/**
+ * links to avatars: `/img` for static resources, `/api` for uploaded.
+ *
+ * @receiver the local avatar URL (w/o the host name), either absolute or relative.
+ * @return the absolute avatar URL (still local to the web server).
+ */
+fun String.avatarRenderer(): String =
+        when {
+            /*
+             * Static resource, such as `/img/avatar_packs/avatar1.png`
+             */
+            startsWith("/img") -> this
+
+            /*
+             * Uploaded resource (absolute), the URL is already processed/canonicalized.
+             */
+            startsWith(AVATAR_BASE_URL) -> this
+
+            /*
+             * Uploaded resource (absolute), such as `/users/admin?1`.
+             */
+            startsWith('/') -> AVATAR_BASE_URL + this
+
+            /*
+             * Uploaded resource (relative).
+             */
+            else -> "$AVATAR_BASE_URL/$this"
+        }
 
 /**
  * Render organization avatar or placeholder

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/ManageUserRoleCard.kt
@@ -15,7 +15,6 @@ import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.info.UserInfo
 import com.saveourtool.save.permission.SetRoleRequest
 import com.saveourtool.save.utils.getHighestRole
-import com.saveourtool.save.v1
 
 import js.core.jso
 import react.*
@@ -140,7 +139,7 @@ val manageUserRoleCardComponent: FC<ManageUserRoleCardProps> = FC { props ->
                             className = ClassName("col-2 align-items-center")
                             img {
                                 className = ClassName("avatar avatar-user border color-bg-default rounded-circle pl-0")
-                                src = user.avatar?.let { "/api/$v1/avatar$it" }
+                                src = user.avatar?.let(String::avatarRenderer)
                                     ?: "/img/undraw_profile.svg"
                                 style = jso {
                                     width = "2rem".unsafeCast<Width>()

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/welcome/FeaturedDemos.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/demo/welcome/FeaturedDemos.kt
@@ -5,10 +5,10 @@
 package com.saveourtool.save.frontend.components.basic.demo.welcome
 
 import com.saveourtool.save.demo.DemoDto
+import com.saveourtool.save.frontend.components.basic.AVATAR_BASE_URL
 import com.saveourtool.save.frontend.components.basic.carousel
 import com.saveourtool.save.frontend.utils.*
 import com.saveourtool.save.frontend.utils.noopResponseHandler
-import com.saveourtool.save.v1
 
 import react.VFC
 import react.dom.html.ReactHTML.div
@@ -43,7 +43,7 @@ internal val featuredDemos = VFC {
         setAvatars {
             featuredDemos.associate { demoDto ->
                 with(demoDto.projectCoordinates) {
-                    organizationName to "/api/$v1/avatar/organizations/$organizationName"
+                    organizationName to "$AVATAR_BASE_URL/organizations/$organizationName"
                 }
             }
         }


### PR DESCRIPTION
### What's done:

 - The page corrected to use a different (non-API) URL for static avatars.
 - Fixes #2718.