### PR TITLE
Fix broken navigation to an organization

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectSettingsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectSettingsMenu.kt
@@ -212,7 +212,7 @@ val projectSettingsMenu: FC<ProjectSettingsMenuProps> = FC { props ->
                             message = "Are you sure you want to delete the project $projectPath?"
                             clickMessage = "Also ban this project"
                             onActionSuccess = { _ ->
-                                navigate(to = "/organization/${props.project.organizationName}/${OrganizationMenuBar.TOOLS.name.lowercase()}")
+                                navigate(to = "/${props.project.organizationName}")
                             }
                             buttonStyleBuilder = { childrenBuilder ->
                                 with(childrenBuilder) {

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/OrganizationAdminView.kt
@@ -58,7 +58,7 @@ internal class OrganizationAdminView : AbstractView<Props, OrganizationAdminStat
                                 className = ClassName(stringClassName)
                                 when (organization.status) {
                                     OrganizationStatus.CREATED -> Link {
-                                        to = "/organization/$organizationName/tools"
+                                        to = "/$organizationName"
                                         +organizationName
                                     }
                                     else -> +organizationName


### PR DESCRIPTION
### What's done:

 - It's now possible to navigate to an organization from the "Manage Organizations" admin-only view.
 - It's now possible to delete a project from the settings of this very project (not from the project list).
 - Fixes #2730.