### PR TITLE
Lock `org.jetbrains.kotlin-wrappers:kotlin-wrappers-bom:1.0.0-pre.634`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,8 @@
         "^org\\.jetbrains\\.kotlinx?[.:]",
         "^org\\.neo4j\\:neo4j-ogm-bolt-driver",
         "^org\\.neo4j\\:neo4j-ogm-core",
-        "^org\\.neo4j\\.driver\\:neo4j-java-driver"
+        "^org\\.neo4j\\.driver\\:neo4j-java-driver",
+        "^org\\.jetbrains\\.kotlin-wrappers\\:kotlin-wrappers-bom"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -48,6 +49,17 @@
         "^org\\.neo4j\\.driver\\:neo4j-java-driver"
       ],
       "allowedVersions": "5.6.0",
+      "groupName": "all non-major dependencies (except core Kotlin)",
+      "groupSlug": "all-minor-patch"
+    },
+    {
+      "managers": [
+        "gradle"
+      ],
+      "matchPackagePatterns": [
+        "^org\\.jetbrains\\.kotlin-wrappers\\:kotlin-wrappers-bom"
+      ],
+      "allowedVersions": "<=1.0.0-pre.634",
       "groupName": "all non-major dependencies (except core Kotlin)",
       "groupSlug": "all-minor-patch"
     },


### PR DESCRIPTION
### What's done:
- locked version in renovate

It's part of #2221 and #2826