### PR TITLE
Fixed text displaying in tables on user and organization pages

### DIFF
--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationContestsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationContestsMenu.kt
@@ -40,6 +40,7 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
             column(id = "name", header = "Contest Name", { name }) { cellContext ->
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         Link {
                             to = "/contests/${cellContext.row.original.name}"
                             +cellContext.value
@@ -50,6 +51,7 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
             column(id = "description", header = "Description", { description }) { cellContext ->
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         +(cellContext.value ?: "Description is not provided")
                     }
                 }
@@ -57,6 +59,7 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
             column(id = "start_time", header = "Start Time", { startTime.toString() }) { cellContext ->
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         +cellContext.value.replace("T", " ")
                     }
                 }
@@ -64,6 +67,7 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
             column(id = "end_time", header = "End Time", { endTime.toString() }) { cellContext ->
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         +cellContext.value.replace("T", " ")
                     }
                 }
@@ -71,6 +75,7 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
             column("checkBox", "") { cellContext ->
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         input {
                             className = ClassName("mx-auto")
                             type = InputType.checkbox
@@ -89,8 +94,6 @@ private val contestsTable: FC<OrganizationContestsTableProps<ContestDto>> = tabl
             }
         }
     },
-    initialPageSize = 10,
-    useServerPaging = false
 ) {
     arrayOf(it.isContestCreated)
 }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationToolsMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/organizations/OrganizationToolsMenu.kt
@@ -99,6 +99,7 @@ private fun organizationToolsMenu() = FC<OrganizationToolsMenuProps> { props ->
                     Fragment.create {
                         val projectDto = cellContext.row.original
                         td {
+                            className = ClassName("align-middle text-center")
                             when (projectDto.status) {
                                 ProjectStatus.CREATED -> div {
                                     Link {
@@ -124,6 +125,7 @@ private fun organizationToolsMenu() = FC<OrganizationToolsMenuProps> { props ->
                 column(id = "description", header = "Description") {
                     Fragment.create {
                         td {
+                            className = ClassName("align-middle text-center")
                             +it.value.description
                         }
                     }
@@ -131,6 +133,7 @@ private fun organizationToolsMenu() = FC<OrganizationToolsMenuProps> { props ->
                 column(id = "rating", header = "Contest Rating") {
                     Fragment.create {
                         td {
+                            className = ClassName("align-middle text-center")
                             +"0"
                         }
                     }
@@ -143,6 +146,7 @@ private fun organizationToolsMenu() = FC<OrganizationToolsMenuProps> { props ->
                     column(id = DELETE_BUTTON_COLUMN_ID, header = EMPTY_COLUMN_HEADER) { cellProps ->
                         Fragment.create {
                             td {
+                                className = ClassName("align-middle text-center")
                                 val project = cellProps.row.original
                                 val projectName = project.name
 
@@ -260,7 +264,6 @@ private fun organizationToolsMenu() = FC<OrganizationToolsMenuProps> { props ->
                 }
             }
         },
-        useServerPaging = false
     ) { tableProps ->
         /*-
          * Necessary for the table to get re-rendered once a project gets

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectStatisticMenu.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/projects/ProjectStatisticMenu.kt
@@ -30,6 +30,7 @@ private val executionDetailsTable: FC<TableProps<TestSuiteExecutionStatisticDto>
             column(id = "name", header = "Test suite", { testSuiteName }) {
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         +it.value
                     }
                 }
@@ -37,6 +38,7 @@ private val executionDetailsTable: FC<TableProps<TestSuiteExecutionStatisticDto>
             column(id = "tests", header = "Number of tests", { countTest }) {
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         +"${it.value}"
                     }
                 }
@@ -44,14 +46,13 @@ private val executionDetailsTable: FC<TableProps<TestSuiteExecutionStatisticDto>
             column(id = "rate", header = "Passed tests", { countWithStatusTest }) {
                 Fragment.create {
                     td {
+                        className = ClassName("align-middle text-center")
                         +"${it.value}"
                     }
                 }
             }
         }
     },
-    initialPageSize = 10,
-    useServerPaging = false,
 )
 
 /**

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/table/filters/VulnerabilitiesFiltersRow.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/basic/table/filters/VulnerabilitiesFiltersRow.kt
@@ -88,8 +88,8 @@ val vulnerabilitiesFiltersRow: FC<VulnerabilitiesFiltersProps> = FC { props ->
                                         border = "none".unsafeCast<Border>()
                                         boxShadow = "none".unsafeCast<BoxShadow>()
                                     }
-                                    barLeftColor = "red"
-                                    barRightColor = "green"
+                                    barLeftColor = "green"
+                                    barRightColor = "red"
                                     barInnerColor = Colors.WHITE.value
                                     thumbLeftColor = Colors.VULN_PRIMARY.value
                                     thumbRightColor = Colors.VULN_PRIMARY.value

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileNewUsersTab.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileNewUsersTab.kt
@@ -29,7 +29,7 @@ val renderNewUsersTableForProfileView: FC<Props> = FC {
                     Fragment.create {
                         td {
                             className = ClassName("align-middle")
-                            renderUserAvatarWithName(cellContext.row.original, isHorizontal = true, classes = "mr-2") {
+                            renderUserAvatarWithName(cellContext.row.original) {
                                 height = 3.rem
                                 width = 3.rem
                             }
@@ -39,7 +39,7 @@ val renderNewUsersTableForProfileView: FC<Props> = FC {
                 column(id = "originalName", header = "Original login") { cellContext ->
                     Fragment.create {
                         td {
-                            className = ClassName("align-middle")
+                            className = ClassName("align-middle text-center")
                             +cellContext.value.originalLogins.firstNotNullOfOrNull { it.value }
                         }
                     }
@@ -47,15 +47,13 @@ val renderNewUsersTableForProfileView: FC<Props> = FC {
                 column(id = "source", header = "Source") { cellContext ->
                     Fragment.create {
                         td {
-                            className = ClassName("align-middle")
+                            className = ClassName("align-middle text-center")
                             +cellContext.value.originalLogins.firstNotNullOfOrNull { it.key }
                         }
                     }
                 }
             }
         },
-        initialPageSize = 10,
-        useServerPaging = false,
         isTransparentGrid = true,
     )
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileView.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/userprofile/UserProfileView.kt
@@ -94,17 +94,16 @@ val userProfileView: FC<UserProfileViewProps> = FC { props ->
         div {
             className = ClassName("col-7 mb-4 mt-2")
             props.currentUserInfo?.globalRole?.let { role ->
-                @Suppress("MISSING_KDOC_ON_FUNCTION")
-                fun UserProfileTab.toTabName() = if (this == UserProfileTab.USERS) "${this.name} ($countUsers)" else this.name
+                if (role.isSuperAdmin() && props.currentUserInfo?.name == user?.name && countUsers > 0) {
+                    @Suppress("MISSING_KDOC_ON_FUNCTION")
+                    fun UserProfileTab.toTabName() = if (this == UserProfileTab.USERS) "${this.name} ($countUsers)" else this.name
 
-                val tabList = if (role.isSuperAdmin() && props.currentUserInfo?.name == user?.name) {
-                    UserProfileTab.entries.map { it.toTabName() }
-                } else {
-                    UserProfileTab.entries.filter { it != UserProfileTab.USERS }.map { it.name }
-                }
-                tab(selectedMenu.toTabName(), tabList, "nav nav-tabs mt-3") { value ->
-                    val newValue = if (value.contains(UserProfileTab.USERS.name)) UserProfileTab.USERS.name else value
-                    setSelectedMenu { UserProfileTab.valueOf(newValue) }
+                    val tabList = UserProfileTab.entries.map { it.toTabName() }
+
+                    tab(selectedMenu.toTabName(), tabList, "nav nav-tabs mt-3") { value ->
+                        val newValue = if (value.contains(UserProfileTab.USERS.name)) UserProfileTab.USERS.name else value
+                        setSelectedMenu { UserProfileTab.valueOf(newValue) }
+                    }
                 }
             }
 

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTableComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTableComponent.kt
@@ -146,7 +146,7 @@ val vulnerabilityTableComponent: FC<VulnerabilityTableComponentProps> = FC { pro
                                     else -> ""
                                 }
                                 className = ClassName("align-middle $severityNumColor text-center")
-                                +"$severityNum"
+                                +(severityNum.toString())
                             }
                         }
                     }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTableComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTableComponent.kt
@@ -185,8 +185,15 @@ val vulnerabilityTableComponent: FC<VulnerabilityTableComponentProps> = FC { pro
                         column(id = "status", header = "Status".t(), { status }) { cellContext ->
                             Fragment.create {
                                 td {
-                                    className = ClassName("align-middle text-center text-nowrap")
-                                    +cellContext.row.original.status.value
+                                    val status = cellContext.row.original.status.value
+                                    val statusColor = when (status) {
+                                        "Approved" -> "text-success"
+                                        "Created", "Pending review" -> "text-warning"
+                                        "Rejected" -> "text-danger"
+                                        else -> ""
+                                    }
+                                    className = ClassName("align-middle $statusColor text-center text-nowrap")
+                                    +status
                                 }
                             }
                         }

--- a/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTableComponent.kt
+++ b/save-frontend/src/main/kotlin/com/saveourtool/save/frontend/components/views/vuln/VulnerabilityTableComponent.kt
@@ -138,8 +138,15 @@ val vulnerabilityTableComponent: FC<VulnerabilityTableComponentProps> = FC { pro
                     column(id = "severityNum", header = "Criticality".t(), { severityNum }) { cellContext ->
                         Fragment.create {
                             td {
-                                className = ClassName("align-middle text-center")
-                                +"${cellContext.row.original.severityNum}"
+                                val severityNum = cellContext.row.original.severityNum
+                                val severityNumColor = when (severityNum) {
+                                    in 0.0f..4.9f -> "text-success"
+                                    in 5.0f..7.5f -> "text-warning"
+                                    in 7.6f..10.0f -> "text-danger"
+                                    else -> ""
+                                }
+                                className = ClassName("align-middle $severityNumColor text-center")
+                                +"$severityNum"
                             }
                         }
                     }


### PR DESCRIPTION
### What's done:
- vulnerabilities and users tabs are now only displayed if there are new users to approve.
- added text centering in tables on user, organization and project pages.
- added colors for `Status` field depending on its value in the vulnerability table.
- added colors for `Criticality` field depending on its value in the vulnerability table.

![image](https://github.com/saveourtool/save-cloud/assets/29813548/3c9ba89a-e60b-4e3c-b031-68833aa8de6d)

Closes #2643