### PR TITLE
Fixed broken logs in orchestrators

### DIFF
--- a/save-demo/build.gradle.kts
+++ b/save-demo/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(libs.ktor.client.logging)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
-
-    implementation(libs.fabric8.kubernetes.client)
+    implementation(libs.fabric8.kubernetes.client) {
+        exclude("org.slf4j", "slf4j-api")
+    }
 }

--- a/save-orchestrator-common/build.gradle.kts
+++ b/save-orchestrator-common/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
     implementation(libs.commons.compress)
     implementation(libs.kotlinx.datetime)
     implementation(libs.zip4j)
-    implementation(libs.fabric8.kubernetes.client)
+    implementation(libs.fabric8.kubernetes.client) {
+        exclude("org.slf4j", "slf4j-api")
+    }
     implementation(libs.spring.kafka)
     testImplementation(projects.testUtils)
     testImplementation(libs.fabric8.kubernetes.server.mock)

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -24,7 +24,9 @@ dependencies {
     implementation(libs.kotlinx.datetime)
     implementation(libs.zip4j)
     implementation(libs.spring.cloud.starter.kubernetes.client.config)
-    implementation(libs.fabric8.kubernetes.client)
+    implementation(libs.fabric8.kubernetes.client) {
+        exclude("org.slf4j", "slf4j-api")
+    }
     implementation(libs.spring.kafka)
     testImplementation(projects.testUtils)
     testImplementation(libs.fabric8.kubernetes.server.mock)


### PR DESCRIPTION
### What's done:
- added exclusion for `org.slf4j` in `io.fabric8:kubernetes-client`