### PR TITLE
Remove `macosX64` target as it's causing problems with IDEA 2024.1+

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
 
     // setup native compilation
     linuxX64()
-    macosX64()
 
     sourceSets {
         sourceSets.all {
@@ -109,13 +108,11 @@ kotlin {
         }
 
         val linuxX64Main by getting
-        val macosX64Main by getting
 
         @Suppress("UNUSED_VARIABLE")
         val nativeMain by creating {
             dependsOn(commonMain)
             linuxX64Main.dependsOn(this)
-            macosX64Main.dependsOn(this)
 
             dependencies {
                 implementation(libs.ktoml.core)

--- a/save-demo-agent/build.gradle.kts
+++ b/save-demo-agent/build.gradle.kts
@@ -22,16 +22,13 @@ kotlin {
             }
         }
     }
-    macosX64(configureNative)
     linuxX64(configureNative)
 
     sourceSets {
-        val macosX64Main by getting
         val linuxX64Main by getting
 
         @Suppress("UNUSED_VARIABLE")
         val nativeMain by creating {
-            macosX64Main.dependsOn(this)
             linuxX64Main.dependsOn(this)
 
             dependencies {
@@ -51,12 +48,10 @@ kotlin {
             }
         }
 
-        val macosX64Test by getting
         val linuxX64Test by getting
 
         @Suppress("UNUSED_VARIABLE")
         val nativeTest by creating {
-            macosX64Test.dependsOn(this)
             linuxX64Test.dependsOn(this)
             dependencies {
                 implementation(libs.kotlin.test)


### PR DESCRIPTION
### What's done:

 - `macosX64` target removed (because `:common` depends on `cosv4k` which doesn't provide `macosX64`-specific publications);
 - no more project resolution problems in IDEA 2024.1+;
 - fixes #2972.